### PR TITLE
feat: define deterministic RPG scenario contracts

### DIFF
--- a/docs/rpg_scenario_contract.md
+++ b/docs/rpg_scenario_contract.md
@@ -1,0 +1,75 @@
+# RPG Scenario Contract v1
+
+The RPG contract is a local, deterministic data format. It defines state and
+rule inputs only; persistence, UI, narrative generation, and rule execution are
+outside this contract.
+
+## Package shape
+
+An `RpgScenario` contains:
+
+- `schemaVersion`: contract schema version. Version 1 is currently supported.
+- `metadata`: stable scenario ID, display name, package version, author, and
+  tags.
+- `initialSeed`: the seed from which deterministic execution starts.
+- `compatibility`: minimum/maximum engine versions and required capabilities.
+- `protectedFields`: state paths that narrative-derived patches cannot change.
+- definitions for attributes, items, actors, locations, quests, and actions.
+- `initialState`: all deterministic inputs needed to start or resume execution.
+
+IDs start with a letter and contain only letters, digits, `_`, or `-`. IDs are
+stable addresses and must not be reused for a different definition in a later
+package version.
+
+## Runtime state
+
+`RpgRuntimeState` persists the scenario ID/version, turn, random generator
+state, consumed roll count, attributes, variables, inventory, relationships,
+clock, location, quests, cooldowns, and event history. Re-serializing a state
+does not regenerate its seed or any other deterministic input.
+
+Snapshot metadata records the branch, optional parent snapshot, turn, random
+state, consumed roll count, creation time, and an optional state hash. This is
+the minimum ownership information needed by future rollback and branch storage.
+
+## Declarative rules
+
+Conditions use an `operator`, a state `path`, and a JSON value, or combine
+nested conditions with `all`, `any`, and `not`. Effects use a closed
+`RpgEffectType` enum. There are no callbacks, expressions, source code, or
+script hooks in either contract.
+
+Dice use canonical `NdM`, `NdM+K`, or `NdM-K` notation. Examples are `1d20`,
+`2d6+3`, and `4d8-1`.
+
+Recognized state paths include:
+
+- `attributes.<attributeId>` and `variables.<variableId>`
+- `inventory.<itemId>.quantity`
+- `relationships.<actorId>.score`
+- `quests.<questId>.status` and `quests.<questId>.stageId`
+- `cooldowns.<actionId>`
+- `turn`, `locationId`, `clock.*`, and `random.*`
+
+References in conditions, effects, runtime state, and cooldowns must resolve to
+definitions in the same scenario package.
+
+## Protected mutations
+
+The default protected fields include random generator inputs, turn, inventory,
+quests, cooldowns, and event history. Every proposed `RpgStatePatch` declares
+whether it comes from the rule engine or narrative. Validate narrative patches
+with `RpgScenarioValidator.validatePatch`; an effect whose state path overlaps a
+protected field is rejected. Applications must not apply an unvalidated patch
+from LLM output.
+
+## Validation
+
+Run `RpgScenarioValidator.validate` after decoding a package and before making
+it available to the engine. Each issue contains a machine-readable `code`, a
+JSON-like `path`, and an actionable `message`. `throwIfInvalid` is available for
+callers that prefer exception-based control flow.
+
+The contract intentionally models JSON only. A future YAML importer must parse
+YAML into the same JSON-shaped values and run this validator; it must not add
+language-specific tags or executable objects.

--- a/lib/data/models/rpg/rpg.dart
+++ b/lib/data/models/rpg/rpg.dart
@@ -1,0 +1,4 @@
+export 'rpg_rules.dart';
+export 'rpg_scenario.dart';
+export 'rpg_state.dart';
+export 'rpg_validation.dart';

--- a/lib/data/models/rpg/rpg_rules.dart
+++ b/lib/data/models/rpg/rpg_rules.dart
@@ -1,0 +1,244 @@
+enum RpgConditionOperator {
+  equals,
+  notEquals,
+  greaterThan,
+  greaterThanOrEqual,
+  lessThan,
+  lessThanOrEqual,
+  contains,
+  notContains,
+  exists,
+  all,
+  any,
+  not;
+
+  static RpgConditionOperator fromJson(String value) =>
+      RpgConditionOperator.values
+          .firstWhere((operator) => operator.name == value);
+}
+
+/// A declarative condition tree. It deliberately has no callback or source
+/// field, so imported packages cannot embed executable predicates.
+class RpgCondition {
+  final RpgConditionOperator operator;
+  final String? path;
+  final Object? value;
+  final List<RpgCondition> conditions;
+
+  const RpgCondition({
+    required this.operator,
+    this.path,
+    this.value,
+    this.conditions = const [],
+  });
+
+  Map<String, dynamic> toJson() => {
+        'operator': operator.name,
+        if (path != null) 'path': path,
+        if (value != null) 'value': value,
+        if (conditions.isNotEmpty)
+          'conditions':
+              conditions.map((condition) => condition.toJson()).toList(),
+      };
+
+  factory RpgCondition.fromJson(Map<String, dynamic> json) => RpgCondition(
+        operator: RpgConditionOperator.fromJson(json['operator'] as String),
+        path: json['path'] as String?,
+        value: json['value'],
+        conditions: _ruleMapList(
+          json['conditions'],
+        ).map(RpgCondition.fromJson).toList(),
+      );
+}
+
+enum RpgEffectType {
+  setValue,
+  incrementValue,
+  decrementValue,
+  addItem,
+  removeItem,
+  adjustRelationship,
+  moveTo,
+  setQuestStatus,
+  setCooldown,
+  appendEvent;
+
+  static RpgEffectType fromJson(String value) =>
+      RpgEffectType.values.firstWhere((type) => type.name == value);
+}
+
+/// A typed state transition description interpreted by the future rule engine.
+class RpgEffect {
+  final RpgEffectType type;
+  final String target;
+  final Object? value;
+  final num? amount;
+
+  const RpgEffect({
+    required this.type,
+    required this.target,
+    this.value,
+    this.amount,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'type': type.name,
+        'target': target,
+        if (value != null) 'value': value,
+        if (amount != null) 'amount': amount,
+      };
+
+  factory RpgEffect.fromJson(Map<String, dynamic> json) => RpgEffect(
+        type: RpgEffectType.fromJson(json['type'] as String),
+        target: json['target'] as String,
+        value: json['value'],
+        amount: json['amount'] as num?,
+      );
+}
+
+class RpgActionCost {
+  final String path;
+  final num amount;
+
+  const RpgActionCost({required this.path, required this.amount});
+
+  Map<String, dynamic> toJson() => {'path': path, 'amount': amount};
+
+  factory RpgActionCost.fromJson(Map<String, dynamic> json) => RpgActionCost(
+        path: json['path'] as String,
+        amount: json['amount'] as num,
+      );
+}
+
+/// Canonical dice notation such as `1d20`, `2d6+3`, or `4d8-1`.
+class RpgDiceSpec {
+  final String expression;
+
+  const RpgDiceSpec(this.expression);
+
+  Map<String, dynamic> toJson() => {'expression': expression};
+
+  factory RpgDiceSpec.fromJson(Map<String, dynamic> json) =>
+      RpgDiceSpec(json['expression'] as String);
+}
+
+class RpgSkillCheck {
+  final String attributeId;
+  final RpgDiceSpec dice;
+  final num difficulty;
+  final List<RpgEffect> successEffects;
+  final List<RpgEffect> failureEffects;
+
+  const RpgSkillCheck({
+    required this.attributeId,
+    required this.dice,
+    required this.difficulty,
+    this.successEffects = const [],
+    this.failureEffects = const [],
+  });
+
+  Map<String, dynamic> toJson() => {
+        'attributeId': attributeId,
+        'dice': dice.toJson(),
+        'difficulty': difficulty,
+        if (successEffects.isNotEmpty)
+          'successEffects':
+              successEffects.map((effect) => effect.toJson()).toList(),
+        if (failureEffects.isNotEmpty)
+          'failureEffects':
+              failureEffects.map((effect) => effect.toJson()).toList(),
+      };
+
+  factory RpgSkillCheck.fromJson(Map<String, dynamic> json) => RpgSkillCheck(
+        attributeId: json['attributeId'] as String,
+        dice: RpgDiceSpec.fromJson(json['dice'] as Map<String, dynamic>),
+        difficulty: json['difficulty'] as num,
+        successEffects: _ruleMapList(
+          json['successEffects'],
+        ).map(RpgEffect.fromJson).toList(),
+        failureEffects: _ruleMapList(
+          json['failureEffects'],
+        ).map(RpgEffect.fromJson).toList(),
+      );
+}
+
+class RpgActionDefinition {
+  final String id;
+  final String label;
+  final String description;
+  final List<RpgCondition> availability;
+  final List<RpgActionCost> costs;
+  final RpgSkillCheck? check;
+  final List<RpgEffect> effects;
+
+  const RpgActionDefinition({
+    required this.id,
+    required this.label,
+    this.description = '',
+    this.availability = const [],
+    this.costs = const [],
+    this.check,
+    this.effects = const [],
+  });
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'label': label,
+        if (description.isNotEmpty) 'description': description,
+        if (availability.isNotEmpty)
+          'availability':
+              availability.map((condition) => condition.toJson()).toList(),
+        if (costs.isNotEmpty)
+          'costs': costs.map((cost) => cost.toJson()).toList(),
+        if (check != null) 'check': check!.toJson(),
+        if (effects.isNotEmpty)
+          'effects': effects.map((effect) => effect.toJson()).toList(),
+      };
+
+  factory RpgActionDefinition.fromJson(Map<String, dynamic> json) =>
+      RpgActionDefinition(
+        id: json['id'] as String,
+        label: json['label'] as String,
+        description: json['description'] as String? ?? '',
+        availability: _ruleMapList(
+          json['availability'],
+        ).map(RpgCondition.fromJson).toList(),
+        costs: _ruleMapList(json['costs']).map(RpgActionCost.fromJson).toList(),
+        check: json['check'] == null
+            ? null
+            : RpgSkillCheck.fromJson(json['check'] as Map<String, dynamic>),
+        effects: _ruleMapList(json['effects']).map(RpgEffect.fromJson).toList(),
+      );
+}
+
+enum RpgMutationSource {
+  ruleEngine,
+  narrative;
+
+  static RpgMutationSource fromJson(String value) =>
+      RpgMutationSource.values.firstWhere((source) => source.name == value);
+}
+
+/// Proposed changes are tagged by origin so protected state can reject changes
+/// derived directly from narrative/LLM output.
+class RpgStatePatch {
+  final RpgMutationSource source;
+  final List<RpgEffect> effects;
+
+  const RpgStatePatch({required this.source, required this.effects});
+
+  Map<String, dynamic> toJson() => {
+        'source': source.name,
+        'effects': effects.map((effect) => effect.toJson()).toList(),
+      };
+
+  factory RpgStatePatch.fromJson(Map<String, dynamic> json) => RpgStatePatch(
+        source: RpgMutationSource.fromJson(json['source'] as String),
+        effects: _ruleMapList(json['effects']).map(RpgEffect.fromJson).toList(),
+      );
+}
+
+List<Map<String, dynamic>> _ruleMapList(Object? value) =>
+    (value as List<dynamic>? ?? const <dynamic>[])
+        .map((item) => item as Map<String, dynamic>)
+        .toList();

--- a/lib/data/models/rpg/rpg_scenario.dart
+++ b/lib/data/models/rpg/rpg_scenario.dart
@@ -1,0 +1,327 @@
+import 'rpg_rules.dart';
+import 'rpg_state.dart';
+
+class RpgScenarioMetadata {
+  final String id;
+  final String name;
+  final String version;
+  final String description;
+  final String author;
+  final List<String> tags;
+
+  const RpgScenarioMetadata({
+    required this.id,
+    required this.name,
+    required this.version,
+    this.description = '',
+    this.author = '',
+    this.tags = const [],
+  });
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'name': name,
+        'version': version,
+        if (description.isNotEmpty) 'description': description,
+        if (author.isNotEmpty) 'author': author,
+        if (tags.isNotEmpty) 'tags': tags,
+      };
+
+  factory RpgScenarioMetadata.fromJson(Map<String, dynamic> json) =>
+      RpgScenarioMetadata(
+        id: json['id'] as String,
+        name: json['name'] as String,
+        version: json['version'] as String,
+        description: json['description'] as String? ?? '',
+        author: json['author'] as String? ?? '',
+        tags: _scenarioStringList(json['tags']),
+      );
+}
+
+class RpgCompatibility {
+  static const defaultEngineVersion = '1.0.0';
+
+  final String minimumEngineVersion;
+  final String? maximumEngineVersion;
+  final List<String> requiredCapabilities;
+
+  const RpgCompatibility({
+    this.minimumEngineVersion = defaultEngineVersion,
+    this.maximumEngineVersion,
+    this.requiredCapabilities = const [],
+  });
+
+  Map<String, dynamic> toJson() => {
+        'minimumEngineVersion': minimumEngineVersion,
+        if (maximumEngineVersion != null)
+          'maximumEngineVersion': maximumEngineVersion,
+        'requiredCapabilities': requiredCapabilities,
+      };
+
+  factory RpgCompatibility.fromJson(Map<String, dynamic> json) =>
+      RpgCompatibility(
+        minimumEngineVersion:
+            json['minimumEngineVersion'] as String? ?? defaultEngineVersion,
+        maximumEngineVersion: json['maximumEngineVersion'] as String?,
+        requiredCapabilities: _scenarioStringList(json['requiredCapabilities']),
+      );
+}
+
+class RpgAttributeDefinition {
+  final String id;
+  final String label;
+  final num initialValue;
+  final num? minimum;
+  final num? maximum;
+
+  const RpgAttributeDefinition({
+    required this.id,
+    required this.label,
+    this.initialValue = 0,
+    this.minimum,
+    this.maximum,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'label': label,
+        'initialValue': initialValue,
+        if (minimum != null) 'minimum': minimum,
+        if (maximum != null) 'maximum': maximum,
+      };
+
+  factory RpgAttributeDefinition.fromJson(Map<String, dynamic> json) =>
+      RpgAttributeDefinition(
+        id: json['id'] as String,
+        label: json['label'] as String,
+        initialValue: json['initialValue'] as num? ?? 0,
+        minimum: json['minimum'] as num?,
+        maximum: json['maximum'] as num?,
+      );
+}
+
+class RpgItemDefinition {
+  final String id;
+  final String label;
+  final String description;
+  final bool stackable;
+
+  const RpgItemDefinition({
+    required this.id,
+    required this.label,
+    this.description = '',
+    this.stackable = true,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'label': label,
+        if (description.isNotEmpty) 'description': description,
+        'stackable': stackable,
+      };
+
+  factory RpgItemDefinition.fromJson(Map<String, dynamic> json) =>
+      RpgItemDefinition(
+        id: json['id'] as String,
+        label: json['label'] as String,
+        description: json['description'] as String? ?? '',
+        stackable: json['stackable'] as bool? ?? true,
+      );
+}
+
+class RpgActorDefinition {
+  final String id;
+  final String label;
+
+  const RpgActorDefinition({required this.id, required this.label});
+
+  Map<String, dynamic> toJson() => {'id': id, 'label': label};
+
+  factory RpgActorDefinition.fromJson(Map<String, dynamic> json) =>
+      RpgActorDefinition(
+        id: json['id'] as String,
+        label: json['label'] as String,
+      );
+}
+
+class RpgLocationDefinition {
+  final String id;
+  final String label;
+  final String description;
+
+  const RpgLocationDefinition({
+    required this.id,
+    required this.label,
+    this.description = '',
+  });
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'label': label,
+        if (description.isNotEmpty) 'description': description,
+      };
+
+  factory RpgLocationDefinition.fromJson(Map<String, dynamic> json) =>
+      RpgLocationDefinition(
+        id: json['id'] as String,
+        label: json['label'] as String,
+        description: json['description'] as String? ?? '',
+      );
+}
+
+class RpgQuestStageDefinition {
+  final String id;
+  final String label;
+  final List<String> objectiveIds;
+
+  const RpgQuestStageDefinition({
+    required this.id,
+    required this.label,
+    this.objectiveIds = const [],
+  });
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'label': label,
+        if (objectiveIds.isNotEmpty) 'objectiveIds': objectiveIds,
+      };
+
+  factory RpgQuestStageDefinition.fromJson(Map<String, dynamic> json) =>
+      RpgQuestStageDefinition(
+        id: json['id'] as String,
+        label: json['label'] as String,
+        objectiveIds: _scenarioStringList(json['objectiveIds']),
+      );
+}
+
+class RpgQuestDefinition {
+  final String id;
+  final String label;
+  final List<RpgQuestStageDefinition> stages;
+
+  const RpgQuestDefinition({
+    required this.id,
+    required this.label,
+    this.stages = const [],
+  });
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'label': label,
+        'stages': stages.map((stage) => stage.toJson()).toList(),
+      };
+
+  factory RpgQuestDefinition.fromJson(Map<String, dynamic> json) =>
+      RpgQuestDefinition(
+        id: json['id'] as String,
+        label: json['label'] as String,
+        stages: _scenarioMapList(
+          json['stages'],
+        ).map(RpgQuestStageDefinition.fromJson).toList(),
+      );
+}
+
+/// Version 1 contract for a script-free, deterministic scenario package.
+class RpgScenario {
+  static const currentSchemaVersion = 1;
+
+  static const defaultProtectedFields = <String>[
+    'random.initialSeed',
+    'random.state',
+    'random.rollsConsumed',
+    'turn',
+    'inventory',
+    'quests',
+    'cooldowns',
+    'eventHistory',
+  ];
+
+  final int schemaVersion;
+  final RpgScenarioMetadata metadata;
+  final int initialSeed;
+  final RpgCompatibility compatibility;
+  final List<String> protectedFields;
+  final List<RpgAttributeDefinition> attributes;
+  final List<RpgItemDefinition> items;
+  final List<RpgActorDefinition> actors;
+  final List<RpgLocationDefinition> locations;
+  final List<RpgQuestDefinition> quests;
+  final List<RpgActionDefinition> actions;
+  final RpgRuntimeState initialState;
+
+  const RpgScenario({
+    this.schemaVersion = currentSchemaVersion,
+    required this.metadata,
+    required this.initialSeed,
+    this.compatibility = const RpgCompatibility(),
+    this.protectedFields = defaultProtectedFields,
+    this.attributes = const [],
+    this.items = const [],
+    this.actors = const [],
+    this.locations = const [],
+    this.quests = const [],
+    this.actions = const [],
+    required this.initialState,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'schemaVersion': schemaVersion,
+        'metadata': metadata.toJson(),
+        'initialSeed': initialSeed,
+        'compatibility': compatibility.toJson(),
+        'protectedFields': protectedFields,
+        'attributes':
+            attributes.map((attribute) => attribute.toJson()).toList(),
+        'items': items.map((item) => item.toJson()).toList(),
+        'actors': actors.map((actor) => actor.toJson()).toList(),
+        'locations': locations.map((location) => location.toJson()).toList(),
+        'quests': quests.map((quest) => quest.toJson()).toList(),
+        'actions': actions.map((action) => action.toJson()).toList(),
+        'initialState': initialState.toJson(),
+      };
+
+  factory RpgScenario.fromJson(Map<String, dynamic> json) => RpgScenario(
+        schemaVersion: (json['schemaVersion'] as num).toInt(),
+        metadata: RpgScenarioMetadata.fromJson(
+          json['metadata'] as Map<String, dynamic>,
+        ),
+        initialSeed: (json['initialSeed'] as num).toInt(),
+        compatibility: json['compatibility'] == null
+            ? const RpgCompatibility()
+            : RpgCompatibility.fromJson(
+                json['compatibility'] as Map<String, dynamic>,
+              ),
+        protectedFields: json['protectedFields'] == null
+            ? defaultProtectedFields
+            : _scenarioStringList(json['protectedFields']),
+        attributes: _scenarioMapList(
+          json['attributes'],
+        ).map(RpgAttributeDefinition.fromJson).toList(),
+        items: _scenarioMapList(
+          json['items'],
+        ).map(RpgItemDefinition.fromJson).toList(),
+        actors: _scenarioMapList(
+          json['actors'],
+        ).map(RpgActorDefinition.fromJson).toList(),
+        locations: _scenarioMapList(
+          json['locations'],
+        ).map(RpgLocationDefinition.fromJson).toList(),
+        quests: _scenarioMapList(
+          json['quests'],
+        ).map(RpgQuestDefinition.fromJson).toList(),
+        actions: _scenarioMapList(
+          json['actions'],
+        ).map(RpgActionDefinition.fromJson).toList(),
+        initialState: RpgRuntimeState.fromJson(
+          json['initialState'] as Map<String, dynamic>,
+        ),
+      );
+}
+
+List<Map<String, dynamic>> _scenarioMapList(Object? value) =>
+    (value as List<dynamic>? ?? const <dynamic>[])
+        .map((item) => item as Map<String, dynamic>)
+        .toList();
+
+List<String> _scenarioStringList(Object? value) =>
+    (value as List<dynamic>? ?? const <dynamic>[]).cast<String>();

--- a/lib/data/models/rpg/rpg_state.dart
+++ b/lib/data/models/rpg/rpg_state.dart
@@ -1,0 +1,347 @@
+/// Deterministic random-generator inputs persisted with every runtime state.
+class RpgRandomState {
+  final int initialSeed;
+  final int state;
+  final int rollsConsumed;
+
+  const RpgRandomState({
+    required this.initialSeed,
+    required this.state,
+    this.rollsConsumed = 0,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'initialSeed': initialSeed,
+        'state': state,
+        'rollsConsumed': rollsConsumed,
+      };
+
+  factory RpgRandomState.fromJson(Map<String, dynamic> json) => RpgRandomState(
+        initialSeed: (json['initialSeed'] as num).toInt(),
+        state: (json['state'] as num).toInt(),
+        rollsConsumed: (json['rollsConsumed'] as num?)?.toInt() ?? 0,
+      );
+}
+
+class RpgInventoryEntry {
+  final String itemId;
+  final int quantity;
+  final Map<String, Object?> metadata;
+
+  const RpgInventoryEntry({
+    required this.itemId,
+    required this.quantity,
+    this.metadata = const {},
+  });
+
+  Map<String, dynamic> toJson() => {
+        'itemId': itemId,
+        'quantity': quantity,
+        if (metadata.isNotEmpty) 'metadata': metadata,
+      };
+
+  factory RpgInventoryEntry.fromJson(Map<String, dynamic> json) =>
+      RpgInventoryEntry(
+        itemId: json['itemId'] as String,
+        quantity: (json['quantity'] as num).toInt(),
+        metadata: _objectMap(json['metadata']),
+      );
+}
+
+class RpgRelationshipState {
+  final String actorId;
+  final num score;
+  final List<String> tags;
+
+  const RpgRelationshipState({
+    required this.actorId,
+    this.score = 0,
+    this.tags = const [],
+  });
+
+  Map<String, dynamic> toJson() => {
+        'actorId': actorId,
+        'score': score,
+        if (tags.isNotEmpty) 'tags': tags,
+      };
+
+  factory RpgRelationshipState.fromJson(Map<String, dynamic> json) =>
+      RpgRelationshipState(
+        actorId: json['actorId'] as String,
+        score: json['score'] as num? ?? 0,
+        tags: _stringList(json['tags']),
+      );
+}
+
+/// Scenario time represented without wall-clock or locale dependencies.
+class RpgClockState {
+  final int elapsedMinutes;
+  final int day;
+  final int minuteOfDay;
+
+  const RpgClockState({
+    this.elapsedMinutes = 0,
+    this.day = 1,
+    this.minuteOfDay = 0,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'elapsedMinutes': elapsedMinutes,
+        'day': day,
+        'minuteOfDay': minuteOfDay,
+      };
+
+  factory RpgClockState.fromJson(Map<String, dynamic> json) => RpgClockState(
+        elapsedMinutes: (json['elapsedMinutes'] as num?)?.toInt() ?? 0,
+        day: (json['day'] as num?)?.toInt() ?? 1,
+        minuteOfDay: (json['minuteOfDay'] as num?)?.toInt() ?? 0,
+      );
+}
+
+enum RpgQuestStatus {
+  inactive,
+  active,
+  completed,
+  failed;
+
+  static RpgQuestStatus fromJson(String value) =>
+      RpgQuestStatus.values.firstWhere((status) => status.name == value);
+}
+
+class RpgQuestState {
+  final String questId;
+  final RpgQuestStatus status;
+  final String? stageId;
+  final Map<String, int> objectiveProgress;
+
+  const RpgQuestState({
+    required this.questId,
+    this.status = RpgQuestStatus.inactive,
+    this.stageId,
+    this.objectiveProgress = const {},
+  });
+
+  Map<String, dynamic> toJson() => {
+        'questId': questId,
+        'status': status.name,
+        if (stageId != null) 'stageId': stageId,
+        if (objectiveProgress.isNotEmpty)
+          'objectiveProgress': objectiveProgress,
+      };
+
+  factory RpgQuestState.fromJson(Map<String, dynamic> json) => RpgQuestState(
+        questId: json['questId'] as String,
+        status: RpgQuestStatus.fromJson(
+          json['status'] as String? ?? RpgQuestStatus.inactive.name,
+        ),
+        stageId: json['stageId'] as String?,
+        objectiveProgress: _intMap(json['objectiveProgress']),
+      );
+}
+
+class RpgEventRecord {
+  final String id;
+  final int turn;
+  final String type;
+  final String? actionId;
+  final String summary;
+  final Map<String, Object?> data;
+
+  const RpgEventRecord({
+    required this.id,
+    required this.turn,
+    required this.type,
+    this.actionId,
+    this.summary = '',
+    this.data = const {},
+  });
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'turn': turn,
+        'type': type,
+        if (actionId != null) 'actionId': actionId,
+        if (summary.isNotEmpty) 'summary': summary,
+        if (data.isNotEmpty) 'data': data,
+      };
+
+  factory RpgEventRecord.fromJson(Map<String, dynamic> json) => RpgEventRecord(
+        id: json['id'] as String,
+        turn: (json['turn'] as num).toInt(),
+        type: json['type'] as String,
+        actionId: json['actionId'] as String?,
+        summary: json['summary'] as String? ?? '',
+        data: _objectMap(json['data']),
+      );
+}
+
+/// All inputs needed to resume deterministic rule execution.
+class RpgRuntimeState {
+  final String scenarioId;
+  final String scenarioVersion;
+  final int turn;
+  final RpgRandomState random;
+  final Map<String, num> attributes;
+  final Map<String, Object?> variables;
+  final List<RpgInventoryEntry> inventory;
+  final List<RpgRelationshipState> relationships;
+  final RpgClockState clock;
+  final String locationId;
+  final List<RpgQuestState> quests;
+  final Map<String, int> cooldowns;
+  final List<RpgEventRecord> eventHistory;
+
+  const RpgRuntimeState({
+    required this.scenarioId,
+    required this.scenarioVersion,
+    this.turn = 0,
+    required this.random,
+    this.attributes = const {},
+    this.variables = const {},
+    this.inventory = const [],
+    this.relationships = const [],
+    this.clock = const RpgClockState(),
+    this.locationId = '',
+    this.quests = const [],
+    this.cooldowns = const {},
+    this.eventHistory = const [],
+  });
+
+  Map<String, dynamic> toJson() => {
+        'scenarioId': scenarioId,
+        'scenarioVersion': scenarioVersion,
+        'turn': turn,
+        'random': random.toJson(),
+        'attributes': attributes,
+        'variables': variables,
+        'inventory': inventory.map((entry) => entry.toJson()).toList(),
+        'relationships':
+            relationships.map((relationship) => relationship.toJson()).toList(),
+        'clock': clock.toJson(),
+        'locationId': locationId,
+        'quests': quests.map((quest) => quest.toJson()).toList(),
+        'cooldowns': cooldowns,
+        'eventHistory': eventHistory.map((event) => event.toJson()).toList(),
+      };
+
+  factory RpgRuntimeState.fromJson(Map<String, dynamic> json) =>
+      RpgRuntimeState(
+        scenarioId: json['scenarioId'] as String,
+        scenarioVersion: json['scenarioVersion'] as String,
+        turn: (json['turn'] as num?)?.toInt() ?? 0,
+        random: RpgRandomState.fromJson(json['random'] as Map<String, dynamic>),
+        attributes: _numMap(json['attributes']),
+        variables: _objectMap(json['variables']),
+        inventory: _mapList(
+          json['inventory'],
+        ).map(RpgInventoryEntry.fromJson).toList(),
+        relationships: _mapList(
+          json['relationships'],
+        ).map(RpgRelationshipState.fromJson).toList(),
+        clock: json['clock'] == null
+            ? const RpgClockState()
+            : RpgClockState.fromJson(json['clock'] as Map<String, dynamic>),
+        locationId: json['locationId'] as String? ?? '',
+        quests: _mapList(json['quests']).map(RpgQuestState.fromJson).toList(),
+        cooldowns: _intMap(json['cooldowns']),
+        eventHistory: _mapList(
+          json['eventHistory'],
+        ).map(RpgEventRecord.fromJson).toList(),
+      );
+}
+
+/// Metadata needed to attach a snapshot to a rollback/branch graph.
+class RpgSnapshotMetadata {
+  final String id;
+  final String scenarioId;
+  final String scenarioVersion;
+  final String branchId;
+  final String? parentSnapshotId;
+  final int turn;
+  final int randomState;
+  final int rollsConsumed;
+  final DateTime createdAt;
+  final String? stateHash;
+
+  const RpgSnapshotMetadata({
+    required this.id,
+    required this.scenarioId,
+    required this.scenarioVersion,
+    required this.branchId,
+    this.parentSnapshotId,
+    required this.turn,
+    required this.randomState,
+    required this.rollsConsumed,
+    required this.createdAt,
+    this.stateHash,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'scenarioId': scenarioId,
+        'scenarioVersion': scenarioVersion,
+        'branchId': branchId,
+        if (parentSnapshotId != null) 'parentSnapshotId': parentSnapshotId,
+        'turn': turn,
+        'randomState': randomState,
+        'rollsConsumed': rollsConsumed,
+        'createdAt': createdAt.toUtc().toIso8601String(),
+        if (stateHash != null) 'stateHash': stateHash,
+      };
+
+  factory RpgSnapshotMetadata.fromJson(Map<String, dynamic> json) =>
+      RpgSnapshotMetadata(
+        id: json['id'] as String,
+        scenarioId: json['scenarioId'] as String,
+        scenarioVersion: json['scenarioVersion'] as String,
+        branchId: json['branchId'] as String,
+        parentSnapshotId: json['parentSnapshotId'] as String?,
+        turn: (json['turn'] as num).toInt(),
+        randomState: (json['randomState'] as num).toInt(),
+        rollsConsumed: (json['rollsConsumed'] as num).toInt(),
+        createdAt: DateTime.parse(json['createdAt'] as String),
+        stateHash: json['stateHash'] as String?,
+      );
+}
+
+class RpgStateSnapshot {
+  final RpgSnapshotMetadata metadata;
+  final RpgRuntimeState state;
+
+  const RpgStateSnapshot({required this.metadata, required this.state});
+
+  Map<String, dynamic> toJson() => {
+        'metadata': metadata.toJson(),
+        'state': state.toJson(),
+      };
+
+  factory RpgStateSnapshot.fromJson(Map<String, dynamic> json) =>
+      RpgStateSnapshot(
+        metadata: RpgSnapshotMetadata.fromJson(
+          json['metadata'] as Map<String, dynamic>,
+        ),
+        state: RpgRuntimeState.fromJson(json['state'] as Map<String, dynamic>),
+      );
+}
+
+List<Map<String, dynamic>> _mapList(Object? value) =>
+    (value as List<dynamic>? ?? const <dynamic>[])
+        .map((item) => item as Map<String, dynamic>)
+        .toList();
+
+List<String> _stringList(Object? value) =>
+    (value as List<dynamic>? ?? const <dynamic>[]).cast<String>();
+
+Map<String, Object?> _objectMap(Object? value) => Map<String, Object?>.from(
+      value as Map<String, dynamic>? ?? const <String, dynamic>{},
+    );
+
+Map<String, int> _intMap(Object? value) =>
+    (value as Map<String, dynamic>? ?? const <String, dynamic>{}).map(
+      (key, item) => MapEntry(key, (item as num).toInt()),
+    );
+
+Map<String, num> _numMap(Object? value) =>
+    (value as Map<String, dynamic>? ?? const <String, dynamic>{}).map(
+      (key, item) => MapEntry(key, item as num),
+    );

--- a/lib/data/models/rpg/rpg_validation.dart
+++ b/lib/data/models/rpg/rpg_validation.dart
@@ -1,0 +1,1157 @@
+import 'rpg_rules.dart';
+import 'rpg_scenario.dart';
+import 'rpg_state.dart';
+
+class RpgValidationIssue {
+  final String path;
+  final String code;
+  final String message;
+
+  const RpgValidationIssue({
+    required this.path,
+    required this.code,
+    required this.message,
+  });
+
+  @override
+  String toString() => '$path [$code]: $message';
+}
+
+class RpgValidationResult {
+  final List<RpgValidationIssue> issues;
+
+  const RpgValidationResult(this.issues);
+
+  bool get isValid => issues.isEmpty;
+
+  void throwIfInvalid() {
+    if (!isValid) throw RpgContractValidationException(issues);
+  }
+}
+
+class RpgContractValidationException implements Exception {
+  final List<RpgValidationIssue> issues;
+
+  const RpgContractValidationException(this.issues);
+
+  @override
+  String toString() => 'Invalid RPG contract:\n${issues.join('\n')}';
+}
+
+class RpgScenarioValidator {
+  static final RegExp _stableId = RegExp(r'^[A-Za-z][A-Za-z0-9_-]*$');
+  static final RegExp _semanticVersion = RegExp(
+    r'^[0-9]+\.[0-9]+\.[0-9]+(?:[-+][A-Za-z0-9.-]+)?$',
+  );
+  static final RegExp _diceExpression = RegExp(
+    r'^([1-9][0-9]*)d([1-9][0-9]*)(?:[+-][0-9]+)?$',
+  );
+
+  const RpgScenarioValidator();
+
+  RpgValidationResult validate(RpgScenario scenario) {
+    final collector = _ValidationCollector();
+
+    if (scenario.schemaVersion <= 0) {
+      collector.add(
+        'schemaVersion',
+        'invalid_schema_version',
+        'Schema version must be a positive integer.',
+      );
+    } else if (scenario.schemaVersion > RpgScenario.currentSchemaVersion) {
+      collector.add(
+        'schemaVersion',
+        'unsupported_schema_version',
+        'Schema version ${scenario.schemaVersion} is newer than supported '
+            'version ${RpgScenario.currentSchemaVersion}.',
+      );
+    }
+
+    _requireId(collector, 'metadata.id', scenario.metadata.id);
+    _requireText(collector, 'metadata.name', scenario.metadata.name);
+    _requireText(collector, 'metadata.version', scenario.metadata.version);
+    _validateCompatibility(collector, scenario.compatibility);
+
+    final attributeIds = _validateDefinitionIds(
+      collector,
+      'attributes',
+      scenario.attributes.map((attribute) => attribute.id).toList(),
+    );
+    final itemIds = _validateDefinitionIds(
+      collector,
+      'items',
+      scenario.items.map((item) => item.id).toList(),
+    );
+    final actorIds = _validateDefinitionIds(
+      collector,
+      'actors',
+      scenario.actors.map((actor) => actor.id).toList(),
+    );
+    final locationIds = _validateDefinitionIds(
+      collector,
+      'locations',
+      scenario.locations.map((location) => location.id).toList(),
+    );
+    final questIds = _validateDefinitionIds(
+      collector,
+      'quests',
+      scenario.quests.map((quest) => quest.id).toList(),
+    );
+    final actionIds = _validateDefinitionIds(
+      collector,
+      'actions',
+      scenario.actions.map((action) => action.id).toList(),
+    );
+
+    for (var index = 0; index < scenario.attributes.length; index++) {
+      final attribute = scenario.attributes[index];
+      final path = 'attributes[$index]';
+      _requireText(collector, '$path.label', attribute.label);
+      _requireFinite(collector, '$path.initialValue', attribute.initialValue);
+      if (attribute.minimum case final minimum?) {
+        _requireFinite(collector, '$path.minimum', minimum);
+      }
+      if (attribute.maximum case final maximum?) {
+        _requireFinite(collector, '$path.maximum', maximum);
+      }
+      if (attribute.minimum != null &&
+          attribute.maximum != null &&
+          attribute.minimum! > attribute.maximum!) {
+        collector.add(
+          path,
+          'invalid_range',
+          'Minimum must not be greater than maximum.',
+        );
+      }
+      if (attribute.minimum != null &&
+          attribute.initialValue < attribute.minimum!) {
+        collector.add(
+          '$path.initialValue',
+          'out_of_range',
+          'Initial value is below ${attribute.minimum}.',
+        );
+      }
+      if (attribute.maximum != null &&
+          attribute.initialValue > attribute.maximum!) {
+        collector.add(
+          '$path.initialValue',
+          'out_of_range',
+          'Initial value is above ${attribute.maximum}.',
+        );
+      }
+    }
+
+    for (var index = 0; index < scenario.items.length; index++) {
+      _requireText(
+        collector,
+        'items[$index].label',
+        scenario.items[index].label,
+      );
+    }
+    for (var index = 0; index < scenario.actors.length; index++) {
+      _requireText(
+        collector,
+        'actors[$index].label',
+        scenario.actors[index].label,
+      );
+    }
+    for (var index = 0; index < scenario.locations.length; index++) {
+      _requireText(
+        collector,
+        'locations[$index].label',
+        scenario.locations[index].label,
+      );
+    }
+
+    final questStages = <String, Set<String>>{};
+    final questObjectives = <String, Set<String>>{};
+    for (var questIndex = 0;
+        questIndex < scenario.quests.length;
+        questIndex++) {
+      final quest = scenario.quests[questIndex];
+      final questPath = 'quests[$questIndex]';
+      _requireText(collector, '$questPath.label', quest.label);
+      final stageIds = _validateDefinitionIds(
+        collector,
+        '$questPath.stages',
+        quest.stages.map((stage) => stage.id).toList(),
+      );
+      final objectiveIds = <String>{};
+      for (var stageIndex = 0; stageIndex < quest.stages.length; stageIndex++) {
+        final stage = quest.stages[stageIndex];
+        final stagePath = '$questPath.stages[$stageIndex]';
+        _requireText(collector, '$stagePath.label', stage.label);
+        for (var objectiveIndex = 0;
+            objectiveIndex < stage.objectiveIds.length;
+            objectiveIndex++) {
+          final objectiveId = stage.objectiveIds[objectiveIndex];
+          final objectivePath = '$stagePath.objectiveIds[$objectiveIndex]';
+          _requireId(collector, objectivePath, objectiveId);
+          if (!objectiveIds.add(objectiveId)) {
+            collector.add(
+              objectivePath,
+              'duplicate_id',
+              'Objective ID `$objectiveId` is duplicated in quest `${quest.id}`.',
+            );
+          }
+        }
+      }
+      questStages[quest.id] = stageIds;
+      questObjectives[quest.id] = objectiveIds;
+    }
+
+    for (var index = 0; index < scenario.protectedFields.length; index++) {
+      final field = scenario.protectedFields[index];
+      if (!_isKnownStatePath(
+        field,
+        attributeIds: attributeIds,
+        itemIds: itemIds,
+        actorIds: actorIds,
+        questIds: questIds,
+        actionIds: actionIds,
+        allowCollectionRoot: true,
+      )) {
+        collector.add(
+          'protectedFields[$index]',
+          'unknown_protected_field',
+          'Protected field `$field` is not a recognized state path.',
+        );
+      }
+    }
+
+    for (var index = 0; index < scenario.actions.length; index++) {
+      _validateAction(
+        collector,
+        scenario.actions[index],
+        'actions[$index]',
+        attributeIds: attributeIds,
+        itemIds: itemIds,
+        actorIds: actorIds,
+        locationIds: locationIds,
+        questIds: questIds,
+        actionIds: actionIds,
+      );
+    }
+
+    _validateRuntimeState(
+      collector,
+      scenario.initialState,
+      'initialState',
+      scenario: scenario,
+      attributeIds: attributeIds,
+      itemIds: itemIds,
+      actorIds: actorIds,
+      locationIds: locationIds,
+      questIds: questIds,
+      actionIds: actionIds,
+      questStages: questStages,
+      questObjectives: questObjectives,
+    );
+
+    return RpgValidationResult(List.unmodifiable(collector.issues));
+  }
+
+  RpgValidationResult validatePatch(RpgScenario scenario, RpgStatePatch patch) {
+    final collector = _ValidationCollector();
+    final attributeIds = scenario.attributes.map((item) => item.id).toSet();
+    final itemIds = scenario.items.map((item) => item.id).toSet();
+    final actorIds = scenario.actors.map((item) => item.id).toSet();
+    final locationIds = scenario.locations.map((item) => item.id).toSet();
+    final questIds = scenario.quests.map((item) => item.id).toSet();
+    final actionIds = scenario.actions.map((item) => item.id).toSet();
+
+    for (var index = 0; index < patch.effects.length; index++) {
+      final effect = patch.effects[index];
+      final path = 'effects[$index]';
+      _validateEffect(
+        collector,
+        effect,
+        path,
+        attributeIds: attributeIds,
+        itemIds: itemIds,
+        actorIds: actorIds,
+        locationIds: locationIds,
+        questIds: questIds,
+        actionIds: actionIds,
+      );
+      final statePath = _effectStatePath(effect);
+      if (patch.source == RpgMutationSource.narrative &&
+          scenario.protectedFields.any(
+            (protected) => _pathsIntersect(protected, statePath),
+          )) {
+        collector.add(
+          path,
+          'protected_state_mutation',
+          'Narrative patches cannot mutate protected state `$statePath`.',
+        );
+      }
+    }
+    return RpgValidationResult(List.unmodifiable(collector.issues));
+  }
+
+  RpgValidationResult validateSnapshot(
+    RpgScenario scenario,
+    RpgStateSnapshot snapshot,
+  ) {
+    final collector = _ValidationCollector();
+    final metadata = snapshot.metadata;
+    _requireId(collector, 'metadata.id', metadata.id);
+    _requireId(collector, 'metadata.branchId', metadata.branchId);
+    if (metadata.parentSnapshotId == metadata.id) {
+      collector.add(
+        'metadata.parentSnapshotId',
+        'self_reference',
+        'A snapshot cannot be its own parent.',
+      );
+    }
+    if (metadata.scenarioId != scenario.metadata.id ||
+        metadata.scenarioVersion != scenario.metadata.version) {
+      collector.add(
+        'metadata',
+        'scenario_mismatch',
+        'Snapshot metadata must target `${scenario.metadata.id}` version '
+            '`${scenario.metadata.version}`.',
+      );
+    }
+    if (metadata.turn != snapshot.state.turn ||
+        metadata.randomState != snapshot.state.random.state ||
+        metadata.rollsConsumed != snapshot.state.random.rollsConsumed) {
+      collector.add(
+        'metadata',
+        'determinism_mismatch',
+        'Snapshot metadata must match the persisted turn and random state.',
+      );
+    }
+    return RpgValidationResult(List.unmodifiable(collector.issues));
+  }
+
+  void _validateCompatibility(
+    _ValidationCollector collector,
+    RpgCompatibility compatibility,
+  ) {
+    if (!_semanticVersion.hasMatch(compatibility.minimumEngineVersion)) {
+      collector.add(
+        'compatibility.minimumEngineVersion',
+        'invalid_version',
+        'Minimum engine version must use semantic versioning (for example 1.0.0).',
+      );
+    }
+    final maximum = compatibility.maximumEngineVersion;
+    if (maximum != null && !_semanticVersion.hasMatch(maximum)) {
+      collector.add(
+        'compatibility.maximumEngineVersion',
+        'invalid_version',
+        'Maximum engine version must use semantic versioning.',
+      );
+    }
+    _validateDefinitionIds(
+      collector,
+      'compatibility.requiredCapabilities',
+      compatibility.requiredCapabilities,
+    );
+  }
+
+  void _validateAction(
+    _ValidationCollector collector,
+    RpgActionDefinition action,
+    String path, {
+    required Set<String> attributeIds,
+    required Set<String> itemIds,
+    required Set<String> actorIds,
+    required Set<String> locationIds,
+    required Set<String> questIds,
+    required Set<String> actionIds,
+  }) {
+    _requireText(collector, '$path.label', action.label);
+    for (var index = 0; index < action.availability.length; index++) {
+      _validateCondition(
+        collector,
+        action.availability[index],
+        '$path.availability[$index]',
+        attributeIds: attributeIds,
+        itemIds: itemIds,
+        actorIds: actorIds,
+        questIds: questIds,
+        actionIds: actionIds,
+      );
+    }
+    for (var index = 0; index < action.costs.length; index++) {
+      final cost = action.costs[index];
+      final costPath = '$path.costs[$index]';
+      if (!_isNumericPath(
+        cost.path,
+        attributeIds: attributeIds,
+        actorIds: actorIds,
+      )) {
+        collector.add(
+          '$costPath.path',
+          'invalid_cost_path',
+          'Cost path `${cost.path}` is not a known numeric state field.',
+        );
+      }
+      if (!cost.amount.isFinite || cost.amount <= 0) {
+        collector.add(
+          '$costPath.amount',
+          'invalid_cost',
+          'Action cost must be a positive finite number.',
+        );
+      }
+    }
+    final check = action.check;
+    if (check != null) {
+      final checkPath = '$path.check';
+      if (!attributeIds.contains(check.attributeId)) {
+        collector.add(
+          '$checkPath.attributeId',
+          'invalid_reference',
+          'Unknown attribute `${check.attributeId}`.',
+        );
+      }
+      if (!_diceExpression.hasMatch(check.dice.expression)) {
+        collector.add(
+          '$checkPath.dice.expression',
+          'invalid_dice_expression',
+          'Use canonical NdM notation with an optional modifier, such as 2d6+3.',
+        );
+      }
+      _requireFinite(collector, '$checkPath.difficulty', check.difficulty);
+      _validateEffects(
+        collector,
+        check.successEffects,
+        '$checkPath.successEffects',
+        attributeIds: attributeIds,
+        itemIds: itemIds,
+        actorIds: actorIds,
+        locationIds: locationIds,
+        questIds: questIds,
+        actionIds: actionIds,
+      );
+      _validateEffects(
+        collector,
+        check.failureEffects,
+        '$checkPath.failureEffects',
+        attributeIds: attributeIds,
+        itemIds: itemIds,
+        actorIds: actorIds,
+        locationIds: locationIds,
+        questIds: questIds,
+        actionIds: actionIds,
+      );
+    }
+    _validateEffects(
+      collector,
+      action.effects,
+      '$path.effects',
+      attributeIds: attributeIds,
+      itemIds: itemIds,
+      actorIds: actorIds,
+      locationIds: locationIds,
+      questIds: questIds,
+      actionIds: actionIds,
+    );
+  }
+
+  void _validateCondition(
+    _ValidationCollector collector,
+    RpgCondition condition,
+    String path, {
+    required Set<String> attributeIds,
+    required Set<String> itemIds,
+    required Set<String> actorIds,
+    required Set<String> questIds,
+    required Set<String> actionIds,
+  }) {
+    final isGroup = condition.operator == RpgConditionOperator.all ||
+        condition.operator == RpgConditionOperator.any ||
+        condition.operator == RpgConditionOperator.not;
+    if (isGroup) {
+      final expectedCount =
+          condition.operator == RpgConditionOperator.not ? 1 : 0;
+      if (condition.conditions.isEmpty ||
+          (expectedCount == 1 && condition.conditions.length != 1)) {
+        collector.add(
+          '$path.conditions',
+          'invalid_condition_group',
+          condition.operator == RpgConditionOperator.not
+              ? '`not` requires exactly one nested condition.'
+              : '`${condition.operator.name}` requires nested conditions.',
+        );
+      }
+      if (condition.path != null || condition.value != null) {
+        collector.add(
+          path,
+          'invalid_condition_shape',
+          'Grouped conditions cannot declare path or value.',
+        );
+      }
+      for (var index = 0; index < condition.conditions.length; index++) {
+        _validateCondition(
+          collector,
+          condition.conditions[index],
+          '$path.conditions[$index]',
+          attributeIds: attributeIds,
+          itemIds: itemIds,
+          actorIds: actorIds,
+          questIds: questIds,
+          actionIds: actionIds,
+        );
+      }
+      return;
+    }
+
+    if (condition.conditions.isNotEmpty) {
+      collector.add(
+        '$path.conditions',
+        'invalid_condition_shape',
+        'Leaf conditions cannot have nested conditions.',
+      );
+    }
+    final statePath = condition.path;
+    if (statePath == null ||
+        !_isKnownStatePath(
+          statePath,
+          attributeIds: attributeIds,
+          itemIds: itemIds,
+          actorIds: actorIds,
+          questIds: questIds,
+          actionIds: actionIds,
+        )) {
+      collector.add(
+        '$path.path',
+        'invalid_state_path',
+        'Condition path `${statePath ?? ''}` is not recognized.',
+      );
+    }
+    if (condition.operator != RpgConditionOperator.exists &&
+        condition.value == null) {
+      collector.add(
+        '$path.value',
+        'missing_condition_value',
+        '`${condition.operator.name}` requires a comparison value.',
+      );
+    } else if (!_isJsonValue(condition.value)) {
+      collector.add(
+        '$path.value',
+        'non_json_value',
+        'Condition value must be JSON-compatible data.',
+      );
+    }
+  }
+
+  void _validateEffects(
+    _ValidationCollector collector,
+    List<RpgEffect> effects,
+    String path, {
+    required Set<String> attributeIds,
+    required Set<String> itemIds,
+    required Set<String> actorIds,
+    required Set<String> locationIds,
+    required Set<String> questIds,
+    required Set<String> actionIds,
+  }) {
+    for (var index = 0; index < effects.length; index++) {
+      _validateEffect(
+        collector,
+        effects[index],
+        '$path[$index]',
+        attributeIds: attributeIds,
+        itemIds: itemIds,
+        actorIds: actorIds,
+        locationIds: locationIds,
+        questIds: questIds,
+        actionIds: actionIds,
+      );
+    }
+  }
+
+  void _validateEffect(
+    _ValidationCollector collector,
+    RpgEffect effect,
+    String path, {
+    required Set<String> attributeIds,
+    required Set<String> itemIds,
+    required Set<String> actorIds,
+    required Set<String> locationIds,
+    required Set<String> questIds,
+    required Set<String> actionIds,
+  }) {
+    switch (effect.type) {
+      case RpgEffectType.setValue:
+        if (!_isWritableValuePath(effect.target, attributeIds)) {
+          _invalidTarget(collector, path, effect);
+        }
+        if (effect.value == null || !_isJsonValue(effect.value)) {
+          collector.add(
+            '$path.value',
+            'invalid_effect_value',
+            '`setValue` requires a JSON-compatible value.',
+          );
+        }
+      case RpgEffectType.incrementValue:
+      case RpgEffectType.decrementValue:
+        if (!_isNumericPath(
+          effect.target,
+          attributeIds: attributeIds,
+          actorIds: actorIds,
+        )) {
+          _invalidTarget(collector, path, effect);
+        }
+        _requirePositiveAmount(collector, path, effect);
+      case RpgEffectType.addItem:
+      case RpgEffectType.removeItem:
+        if (!itemIds.contains(effect.target)) {
+          _invalidReference(collector, path, 'item', effect.target);
+        }
+        _requirePositiveIntegerAmount(collector, path, effect);
+      case RpgEffectType.adjustRelationship:
+        if (!actorIds.contains(effect.target)) {
+          _invalidReference(collector, path, 'actor', effect.target);
+        }
+        _requireFiniteAmount(collector, path, effect);
+      case RpgEffectType.moveTo:
+        if (!locationIds.contains(effect.target)) {
+          _invalidReference(collector, path, 'location', effect.target);
+        }
+      case RpgEffectType.setQuestStatus:
+        if (!questIds.contains(effect.target)) {
+          _invalidReference(collector, path, 'quest', effect.target);
+        }
+        final status = effect.value;
+        if (status is! String ||
+            !RpgQuestStatus.values.any((item) => item.name == status)) {
+          collector.add(
+            '$path.value',
+            'invalid_quest_status',
+            'Quest status must be one of: '
+                '${RpgQuestStatus.values.map((item) => item.name).join(', ')}.',
+          );
+        }
+      case RpgEffectType.setCooldown:
+        if (!actionIds.contains(effect.target)) {
+          _invalidReference(collector, path, 'action', effect.target);
+        }
+        final amount = effect.amount;
+        if (amount == null || amount != amount.toInt() || amount < 0) {
+          collector.add(
+            '$path.amount',
+            'invalid_cooldown',
+            'Cooldown must be a non-negative integer.',
+          );
+        }
+      case RpgEffectType.appendEvent:
+        if (effect.target.trim().isEmpty) {
+          collector.add(
+            '$path.target',
+            'missing_event_type',
+            'Appended events require a non-empty event type.',
+          );
+        }
+        if (!_isJsonValue(effect.value)) {
+          collector.add(
+            '$path.value',
+            'non_json_value',
+            'Event data must be JSON-compatible.',
+          );
+        }
+    }
+  }
+
+  void _validateRuntimeState(
+    _ValidationCollector collector,
+    RpgRuntimeState state,
+    String path, {
+    required RpgScenario scenario,
+    required Set<String> attributeIds,
+    required Set<String> itemIds,
+    required Set<String> actorIds,
+    required Set<String> locationIds,
+    required Set<String> questIds,
+    required Set<String> actionIds,
+    required Map<String, Set<String>> questStages,
+    required Map<String, Set<String>> questObjectives,
+  }) {
+    if (state.scenarioId != scenario.metadata.id) {
+      collector.add(
+        '$path.scenarioId',
+        'scenario_mismatch',
+        'Expected scenario ID `${scenario.metadata.id}`.',
+      );
+    }
+    if (state.scenarioVersion != scenario.metadata.version) {
+      collector.add(
+        '$path.scenarioVersion',
+        'scenario_version_mismatch',
+        'Expected scenario version `${scenario.metadata.version}`.',
+      );
+    }
+    if (state.turn < 0) {
+      collector.add('$path.turn', 'negative_value', 'Turn cannot be negative.');
+    }
+    if (state.random.initialSeed != scenario.initialSeed) {
+      collector.add(
+        '$path.random.initialSeed',
+        'seed_mismatch',
+        'Runtime seed must match scenario initialSeed ${scenario.initialSeed}.',
+      );
+    }
+    if (state.random.rollsConsumed < 0) {
+      collector.add(
+        '$path.random.rollsConsumed',
+        'negative_value',
+        'Consumed roll count cannot be negative.',
+      );
+    }
+
+    final definitions = {for (final item in scenario.attributes) item.id: item};
+    for (final entry in state.attributes.entries) {
+      final valuePath = '$path.attributes.${entry.key}';
+      final definition = definitions[entry.key];
+      if (definition == null) {
+        _invalidReference(collector, valuePath, 'attribute', entry.key);
+        continue;
+      }
+      _requireFinite(collector, valuePath, entry.value);
+      if (definition.minimum != null && entry.value < definition.minimum!) {
+        collector.add(
+          valuePath,
+          'out_of_range',
+          'Value is below ${definition.minimum}.',
+        );
+      }
+      if (definition.maximum != null && entry.value > definition.maximum!) {
+        collector.add(
+          valuePath,
+          'out_of_range',
+          'Value is above ${definition.maximum}.',
+        );
+      }
+    }
+    for (final entry in state.variables.entries) {
+      if (!_stableId.hasMatch(entry.key)) {
+        collector.add(
+          '$path.variables.${entry.key}',
+          'invalid_id',
+          'Variable keys must use stable ID syntax.',
+        );
+      }
+      if (!_isJsonValue(entry.value)) {
+        collector.add(
+          '$path.variables.${entry.key}',
+          'non_json_value',
+          'Variable value must be JSON-compatible.',
+        );
+      }
+    }
+
+    final inventoryIds = <String>{};
+    final itemDefinitions = {for (final item in scenario.items) item.id: item};
+    for (var index = 0; index < state.inventory.length; index++) {
+      final entry = state.inventory[index];
+      final entryPath = '$path.inventory[$index]';
+      final definition = itemDefinitions[entry.itemId];
+      if (definition == null) {
+        _invalidReference(collector, '$entryPath.itemId', 'item', entry.itemId);
+      }
+      if (!inventoryIds.add(entry.itemId)) {
+        collector.add(
+          '$entryPath.itemId',
+          'duplicate_id',
+          'Inventory item `${entry.itemId}` appears more than once.',
+        );
+      }
+      if (entry.quantity < 0) {
+        collector.add(
+          '$entryPath.quantity',
+          'negative_quantity',
+          'Inventory quantity cannot be negative.',
+        );
+      }
+      if (definition != null && !definition.stackable && entry.quantity > 1) {
+        collector.add(
+          '$entryPath.quantity',
+          'non_stackable_quantity',
+          'Non-stackable item `${entry.itemId}` cannot have quantity above 1.',
+        );
+      }
+      if (!_isJsonValue(entry.metadata)) {
+        collector.add(
+          '$entryPath.metadata',
+          'non_json_value',
+          'Item metadata must be JSON-compatible.',
+        );
+      }
+    }
+
+    final relationshipIds = <String>{};
+    for (var index = 0; index < state.relationships.length; index++) {
+      final relationship = state.relationships[index];
+      final relationshipPath = '$path.relationships[$index]';
+      if (!actorIds.contains(relationship.actorId)) {
+        _invalidReference(
+          collector,
+          '$relationshipPath.actorId',
+          'actor',
+          relationship.actorId,
+        );
+      }
+      if (!relationshipIds.add(relationship.actorId)) {
+        collector.add(
+          '$relationshipPath.actorId',
+          'duplicate_id',
+          'Relationship actor `${relationship.actorId}` appears more than once.',
+        );
+      }
+      _requireFinite(collector, '$relationshipPath.score', relationship.score);
+    }
+
+    if (state.clock.elapsedMinutes < 0 ||
+        state.clock.day < 1 ||
+        state.clock.minuteOfDay < 0 ||
+        state.clock.minuteOfDay >= 1440) {
+      collector.add(
+        '$path.clock',
+        'invalid_clock',
+        'Clock requires non-negative elapsed minutes, day >= 1, and '
+            'minuteOfDay from 0 through 1439.',
+      );
+    }
+    if (state.locationId.isNotEmpty &&
+        !locationIds.contains(state.locationId)) {
+      _invalidReference(
+        collector,
+        '$path.locationId',
+        'location',
+        state.locationId,
+      );
+    }
+
+    final runtimeQuestIds = <String>{};
+    for (var index = 0; index < state.quests.length; index++) {
+      final quest = state.quests[index];
+      final questPath = '$path.quests[$index]';
+      if (!questIds.contains(quest.questId)) {
+        _invalidReference(
+          collector,
+          '$questPath.questId',
+          'quest',
+          quest.questId,
+        );
+      }
+      if (!runtimeQuestIds.add(quest.questId)) {
+        collector.add(
+          '$questPath.questId',
+          'duplicate_id',
+          'Quest state `${quest.questId}` appears more than once.',
+        );
+      }
+      if (quest.stageId != null &&
+          !(questStages[quest.questId]?.contains(quest.stageId) ?? false)) {
+        _invalidReference(
+          collector,
+          '$questPath.stageId',
+          'quest stage',
+          quest.stageId!,
+        );
+      }
+      for (final objective in quest.objectiveProgress.entries) {
+        final objectivePath = '$questPath.objectiveProgress.${objective.key}';
+        if (!(questObjectives[quest.questId]?.contains(objective.key) ??
+            false)) {
+          _invalidReference(
+            collector,
+            objectivePath,
+            'quest objective',
+            objective.key,
+          );
+        }
+        if (objective.value < 0) {
+          collector.add(
+            objectivePath,
+            'negative_quantity',
+            'Objective progress cannot be negative.',
+          );
+        }
+      }
+    }
+
+    for (final cooldown in state.cooldowns.entries) {
+      final cooldownPath = '$path.cooldowns.${cooldown.key}';
+      if (!actionIds.contains(cooldown.key)) {
+        _invalidReference(collector, cooldownPath, 'action', cooldown.key);
+      }
+      if (cooldown.value < 0) {
+        collector.add(
+          cooldownPath,
+          'negative_quantity',
+          'Cooldown turns cannot be negative.',
+        );
+      }
+    }
+
+    final eventIds = <String>{};
+    for (var index = 0; index < state.eventHistory.length; index++) {
+      final event = state.eventHistory[index];
+      final eventPath = '$path.eventHistory[$index]';
+      _requireId(collector, '$eventPath.id', event.id);
+      if (!eventIds.add(event.id)) {
+        collector.add(
+          '$eventPath.id',
+          'duplicate_id',
+          'Event ID `${event.id}` appears more than once.',
+        );
+      }
+      if (event.turn < 0 || event.turn > state.turn) {
+        collector.add(
+          '$eventPath.turn',
+          'invalid_event_turn',
+          'Event turn must be between 0 and the current turn ${state.turn}.',
+        );
+      }
+      if (event.actionId != null && !actionIds.contains(event.actionId)) {
+        _invalidReference(
+          collector,
+          '$eventPath.actionId',
+          'action',
+          event.actionId!,
+        );
+      }
+      _requireText(collector, '$eventPath.type', event.type);
+      if (!_isJsonValue(event.data)) {
+        collector.add(
+          '$eventPath.data',
+          'non_json_value',
+          'Event data must be JSON-compatible.',
+        );
+      }
+    }
+  }
+
+  Set<String> _validateDefinitionIds(
+    _ValidationCollector collector,
+    String path,
+    List<String> ids,
+  ) {
+    final seen = <String>{};
+    for (var index = 0; index < ids.length; index++) {
+      final id = ids[index];
+      _requireId(collector, '$path[$index].id', id);
+      if (!seen.add(id)) {
+        collector.add(
+          '$path[$index].id',
+          'duplicate_id',
+          'Stable ID `$id` is duplicated in `$path`.',
+        );
+      }
+    }
+    return seen;
+  }
+
+  bool _isKnownStatePath(
+    String path, {
+    required Set<String> attributeIds,
+    required Set<String> itemIds,
+    required Set<String> actorIds,
+    required Set<String> questIds,
+    required Set<String> actionIds,
+    bool allowCollectionRoot = false,
+  }) {
+    const scalarPaths = <String>{
+      'turn',
+      'random.initialSeed',
+      'random.state',
+      'random.rollsConsumed',
+      'clock.elapsedMinutes',
+      'clock.day',
+      'clock.minuteOfDay',
+      'locationId',
+    };
+    if (scalarPaths.contains(path)) return true;
+    if (allowCollectionRoot &&
+        const <String>{
+          'attributes',
+          'variables',
+          'inventory',
+          'relationships',
+          'clock',
+          'quests',
+          'cooldowns',
+          'eventHistory',
+        }.contains(path)) {
+      return true;
+    }
+    final segments = path.split('.');
+    if (segments.length == 2) {
+      return switch (segments.first) {
+        'attributes' => attributeIds.contains(segments.last),
+        'variables' => _stableId.hasMatch(segments.last),
+        'cooldowns' => actionIds.contains(segments.last),
+        _ => false,
+      };
+    }
+    if (segments.length == 3) {
+      return switch (segments.first) {
+        'inventory' =>
+          itemIds.contains(segments[1]) && segments.last == 'quantity',
+        'relationships' =>
+          actorIds.contains(segments[1]) && segments.last == 'score',
+        'quests' => questIds.contains(segments[1]) &&
+            const <String>{'status', 'stageId'}.contains(segments.last),
+        _ => false,
+      };
+    }
+    return false;
+  }
+
+  bool _isNumericPath(
+    String path, {
+    required Set<String> attributeIds,
+    required Set<String> actorIds,
+  }) {
+    final segments = path.split('.');
+    if (segments.length == 2) {
+      return (segments.first == 'attributes' &&
+              attributeIds.contains(segments.last)) ||
+          (segments.first == 'variables' && _stableId.hasMatch(segments.last));
+    }
+    return segments.length == 3 &&
+        segments.first == 'relationships' &&
+        actorIds.contains(segments[1]) &&
+        segments.last == 'score';
+  }
+
+  bool _isWritableValuePath(String path, Set<String> attributeIds) {
+    final segments = path.split('.');
+    return segments.length == 2 &&
+        ((segments.first == 'attributes' &&
+                attributeIds.contains(segments.last)) ||
+            (segments.first == 'variables' &&
+                _stableId.hasMatch(segments.last)));
+  }
+
+  String _effectStatePath(RpgEffect effect) => switch (effect.type) {
+        RpgEffectType.setValue ||
+        RpgEffectType.incrementValue ||
+        RpgEffectType.decrementValue =>
+          effect.target,
+        RpgEffectType.addItem ||
+        RpgEffectType.removeItem =>
+          'inventory.${effect.target}.quantity',
+        RpgEffectType.adjustRelationship =>
+          'relationships.${effect.target}.score',
+        RpgEffectType.moveTo => 'locationId',
+        RpgEffectType.setQuestStatus => 'quests.${effect.target}.status',
+        RpgEffectType.setCooldown => 'cooldowns.${effect.target}',
+        RpgEffectType.appendEvent => 'eventHistory',
+      };
+
+  bool _pathsIntersect(String protected, String target) =>
+      protected == target ||
+      target.startsWith('$protected.') ||
+      protected.startsWith('$target.');
+
+  bool _isJsonValue(Object? value) {
+    if (value == null || value is String || value is bool) return true;
+    if (value is num) return value.isFinite;
+    if (value is List<Object?>) return value.every(_isJsonValue);
+    if (value is Map<String, Object?>) {
+      return value.values.every(_isJsonValue);
+    }
+    return false;
+  }
+
+  void _requireId(_ValidationCollector collector, String path, String id) {
+    if (!_stableId.hasMatch(id)) {
+      collector.add(
+        path,
+        'invalid_id',
+        'Stable IDs must start with a letter and contain only letters, '
+            'digits, `_`, or `-`.',
+      );
+    }
+  }
+
+  void _requireText(_ValidationCollector collector, String path, String value) {
+    if (value.trim().isEmpty) {
+      collector.add(path, 'required', 'A non-empty value is required.');
+    }
+  }
+
+  void _requireFinite(_ValidationCollector collector, String path, num value) {
+    if (!value.isFinite) {
+      collector.add(path, 'not_finite', 'Value must be a finite number.');
+    }
+  }
+
+  void _requirePositiveAmount(
+    _ValidationCollector collector,
+    String path,
+    RpgEffect effect,
+  ) {
+    final amount = effect.amount;
+    if (amount == null || !amount.isFinite || amount <= 0) {
+      collector.add(
+        '$path.amount',
+        'invalid_amount',
+        'Effect amount must be a positive finite number.',
+      );
+    }
+  }
+
+  void _requireFiniteAmount(
+    _ValidationCollector collector,
+    String path,
+    RpgEffect effect,
+  ) {
+    if (effect.amount == null || !effect.amount!.isFinite) {
+      collector.add(
+        '$path.amount',
+        'invalid_amount',
+        'Effect amount must be a finite number.',
+      );
+    }
+  }
+
+  void _requirePositiveIntegerAmount(
+    _ValidationCollector collector,
+    String path,
+    RpgEffect effect,
+  ) {
+    final amount = effect.amount;
+    if (amount == null || amount != amount.toInt() || amount <= 0) {
+      collector.add(
+        '$path.amount',
+        'invalid_quantity',
+        'Item quantity must be a positive integer.',
+      );
+    }
+  }
+
+  void _invalidTarget(
+    _ValidationCollector collector,
+    String path,
+    RpgEffect effect,
+  ) {
+    collector.add(
+      '$path.target',
+      'invalid_effect_target',
+      '`${effect.target}` is not valid for `${effect.type.name}`.',
+    );
+  }
+
+  void _invalidReference(
+    _ValidationCollector collector,
+    String path,
+    String kind,
+    String id,
+  ) {
+    collector.add(path, 'invalid_reference', 'Unknown $kind ID `$id`.');
+  }
+}
+
+class _ValidationCollector {
+  final List<RpgValidationIssue> issues = [];
+
+  void add(String path, String code, String message) {
+    issues.add(RpgValidationIssue(path: path, code: code, message: message));
+  }
+}

--- a/test/rpg_scenario_contract_test.dart
+++ b/test/rpg_scenario_contract_test.dart
@@ -1,0 +1,408 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:native_tavern/data/models/rpg/rpg.dart';
+
+void main() {
+  const validator = RpgScenarioValidator();
+
+  group('RPG scenario JSON contract', () {
+    test('minimal scenario round-trips with compatibility defaults', () {
+      final original = _minimalScenario();
+      final decoded = RpgScenario.fromJson(
+        jsonDecode(jsonEncode(original.toJson())) as Map<String, dynamic>,
+      );
+
+      expect(decoded.toJson(), original.toJson());
+      expect(decoded.schemaVersion, RpgScenario.currentSchemaVersion);
+      expect(
+        decoded.compatibility.minimumEngineVersion,
+        RpgCompatibility.defaultEngineVersion,
+      );
+      expect(decoded.compatibility.requiredCapabilities, isEmpty);
+      expect(validator.validate(decoded).isValid, isTrue);
+    });
+
+    test('representative full scenario preserves every deterministic input',
+        () {
+      final original = _fullScenario();
+      final decoded = RpgScenario.fromJson(
+        jsonDecode(jsonEncode(original.toJson())) as Map<String, dynamic>,
+      );
+      final result = validator.validate(decoded);
+
+      expect(result.issues, isEmpty);
+      expect(decoded.toJson(), original.toJson());
+      expect(decoded.initialState.random.initialSeed, 424242);
+      expect(decoded.initialState.random.state, 918273645);
+      expect(decoded.initialState.random.rollsConsumed, 7);
+      expect(decoded.initialState.turn, 12);
+      expect(decoded.initialState.inventory.single.quantity, 2);
+      expect(decoded.initialState.relationships.single.score, 15);
+      expect(decoded.initialState.quests.single.status, RpgQuestStatus.active);
+      expect(decoded.initialState.cooldowns['explore'], 2);
+    });
+
+    test('actions serialize only typed declarative conditions and effects', () {
+      final action = _fullScenario().actions.single;
+      final encoded = action.toJson();
+      final condition = (encoded['availability'] as List<dynamic>).single
+          as Map<String, dynamic>;
+      final effect =
+          (encoded['effects'] as List<dynamic>).single as Map<String, dynamic>;
+
+      expect(condition.keys, unorderedEquals(['operator', 'path', 'value']));
+      expect(effect.keys, unorderedEquals(['type', 'target', 'amount']));
+      expect(jsonEncode(encoded), isNot(contains('script')));
+      expect(jsonEncode(encoded), isNot(contains('source')));
+    });
+  });
+
+  group('RPG scenario validation', () {
+    test('reports duplicate IDs, invalid references, quantities, and dice', () {
+      const invalid = RpgScenario(
+        metadata: RpgScenarioMetadata(
+          id: 'invalid_scenario',
+          name: 'Invalid scenario',
+          version: '1.0.0',
+        ),
+        initialSeed: 7,
+        protectedFields: ['random.state', 'madeUpField'],
+        attributes: [
+          RpgAttributeDefinition(id: 'power', label: 'Power'),
+          RpgAttributeDefinition(id: 'power', label: 'Power again'),
+        ],
+        items: [RpgItemDefinition(id: 'potion', label: 'Potion')],
+        actions: [
+          RpgActionDefinition(
+            id: 'roll',
+            label: 'Roll',
+            check: RpgSkillCheck(
+              attributeId: 'missing_attribute',
+              dice: RpgDiceSpec('twenty-sided-die'),
+              difficulty: 10,
+            ),
+            effects: [
+              RpgEffect(
+                type: RpgEffectType.addItem,
+                target: 'missing_item',
+                amount: 1,
+              ),
+            ],
+          ),
+        ],
+        initialState: RpgRuntimeState(
+          scenarioId: 'invalid_scenario',
+          scenarioVersion: '1.0.0',
+          random: RpgRandomState(initialSeed: 7, state: 7),
+          inventory: [
+            RpgInventoryEntry(itemId: 'missing_item', quantity: -1),
+          ],
+          relationships: [RpgRelationshipState(actorId: 'missing_actor')],
+          locationId: 'missing_location',
+          quests: [RpgQuestState(questId: 'missing_quest')],
+          cooldowns: {'missing_action': -3},
+        ),
+      );
+
+      final result = validator.validate(invalid);
+      final codes = result.issues.map((issue) => issue.code).toSet();
+
+      expect(result.isValid, isFalse);
+      expect(codes, contains('duplicate_id'));
+      expect(codes, contains('invalid_reference'));
+      expect(codes, contains('negative_quantity'));
+      expect(codes, contains('invalid_dice_expression'));
+      expect(codes, contains('unknown_protected_field'));
+      expect(
+        result.issues.any(
+          (issue) =>
+              issue.path == 'actions[0].check.dice.expression' &&
+              issue.message.contains('2d6+3'),
+        ),
+        isTrue,
+      );
+    });
+
+    test('requires stable scenario and definition IDs', () {
+      const invalid = RpgScenario(
+        metadata: RpgScenarioMetadata(
+          id: '',
+          name: 'No IDs',
+          version: '1.0.0',
+        ),
+        initialSeed: 1,
+        attributes: [
+          RpgAttributeDefinition(id: 'not valid', label: 'Broken'),
+        ],
+        initialState: RpgRuntimeState(
+          scenarioId: '',
+          scenarioVersion: '1.0.0',
+          random: RpgRandomState(initialSeed: 1, state: 1),
+        ),
+      );
+
+      final issues = validator.validate(invalid).issues;
+
+      expect(
+        issues.where((issue) => issue.code == 'invalid_id'),
+        hasLength(greaterThanOrEqualTo(2)),
+      );
+    });
+
+    test('rejects narrative changes to protected state', () {
+      final scenario = _fullScenario();
+      const patch = RpgStatePatch(
+        source: RpgMutationSource.narrative,
+        effects: [
+          RpgEffect(
+            type: RpgEffectType.removeItem,
+            target: 'potion',
+            amount: 1,
+          ),
+        ],
+      );
+
+      final result = validator.validatePatch(scenario, patch);
+
+      expect(result.isValid, isFalse);
+      expect(result.issues.single.code, 'protected_state_mutation');
+      expect(
+          result.issues.single.message, contains('inventory.potion.quantity'));
+    });
+
+    test('allows the rule engine to apply a valid protected-state effect', () {
+      final scenario = _fullScenario();
+      const patch = RpgStatePatch(
+        source: RpgMutationSource.ruleEngine,
+        effects: [
+          RpgEffect(
+            type: RpgEffectType.removeItem,
+            target: 'potion',
+            amount: 1,
+          ),
+        ],
+      );
+
+      expect(validator.validatePatch(scenario, patch).issues, isEmpty);
+    });
+  });
+
+  group('RPG snapshots', () {
+    test('round-trip keeps rollback and branch inheritance metadata', () {
+      final scenario = _fullScenario();
+      final snapshot = RpgStateSnapshot(
+        metadata: RpgSnapshotMetadata(
+          id: 'snapshot_12',
+          scenarioId: scenario.metadata.id,
+          scenarioVersion: scenario.metadata.version,
+          branchId: 'main_branch',
+          parentSnapshotId: 'snapshot_08',
+          turn: scenario.initialState.turn,
+          randomState: scenario.initialState.random.state,
+          rollsConsumed: scenario.initialState.random.rollsConsumed,
+          createdAt: DateTime.utc(2026, 8, 7, 10, 30),
+          stateHash: 'sha256:example',
+        ),
+        state: scenario.initialState,
+      );
+      final decoded = RpgStateSnapshot.fromJson(
+        jsonDecode(jsonEncode(snapshot.toJson())) as Map<String, dynamic>,
+      );
+
+      expect(decoded.toJson(), snapshot.toJson());
+      expect(decoded.metadata.parentSnapshotId, 'snapshot_08');
+      expect(validator.validateSnapshot(scenario, decoded).isValid, isTrue);
+    });
+
+    test('detects snapshot metadata that diverges from runtime state', () {
+      final scenario = _fullScenario();
+      final snapshot = RpgStateSnapshot(
+        metadata: RpgSnapshotMetadata(
+          id: 'snapshot_12',
+          scenarioId: scenario.metadata.id,
+          scenarioVersion: scenario.metadata.version,
+          branchId: 'main_branch',
+          turn: 99,
+          randomState: 0,
+          rollsConsumed: 0,
+          createdAt: DateTime.utc(2026, 8, 7),
+        ),
+        state: scenario.initialState,
+      );
+
+      expect(
+        validator.validateSnapshot(scenario, snapshot).issues.single.code,
+        'determinism_mismatch',
+      );
+    });
+  });
+}
+
+RpgScenario _minimalScenario() => const RpgScenario(
+      metadata: RpgScenarioMetadata(
+        id: 'minimal_scenario',
+        name: 'Minimal scenario',
+        version: '1.0.0',
+      ),
+      initialSeed: 11,
+      initialState: RpgRuntimeState(
+        scenarioId: 'minimal_scenario',
+        scenarioVersion: '1.0.0',
+        random: RpgRandomState(initialSeed: 11, state: 11),
+      ),
+    );
+
+RpgScenario _fullScenario() => const RpgScenario(
+      metadata: RpgScenarioMetadata(
+        id: 'lost_relic',
+        name: 'The Lost Relic',
+        version: '1.2.0',
+        description: 'Recover the relic from the old ruins.',
+        author: 'NativeTavern',
+        tags: ['adventure'],
+      ),
+      initialSeed: 424242,
+      compatibility: RpgCompatibility(
+        minimumEngineVersion: '1.0.0',
+        maximumEngineVersion: '2.0.0',
+        requiredCapabilities: ['core_rules'],
+      ),
+      protectedFields: [
+        'random.state',
+        'random.rollsConsumed',
+        'turn',
+        'inventory',
+        'quests',
+        'cooldowns',
+        'eventHistory',
+      ],
+      attributes: [
+        RpgAttributeDefinition(
+          id: 'strength',
+          label: 'Strength',
+          initialValue: 4,
+          minimum: 0,
+          maximum: 10,
+        ),
+        RpgAttributeDefinition(
+          id: 'stamina',
+          label: 'Stamina',
+          initialValue: 8,
+          minimum: 0,
+          maximum: 10,
+        ),
+      ],
+      items: [
+        RpgItemDefinition(id: 'potion', label: 'Potion'),
+      ],
+      actors: [RpgActorDefinition(id: 'guide', label: 'Village Guide')],
+      locations: [
+        RpgLocationDefinition(id: 'village', label: 'Village'),
+        RpgLocationDefinition(id: 'ruins', label: 'Old Ruins'),
+      ],
+      quests: [
+        RpgQuestDefinition(
+          id: 'find_relic',
+          label: 'Find the relic',
+          stages: [
+            RpgQuestStageDefinition(
+              id: 'search_ruins',
+              label: 'Search the ruins',
+              objectiveIds: ['inspect_altar'],
+            ),
+          ],
+        ),
+      ],
+      actions: [
+        RpgActionDefinition(
+          id: 'explore',
+          label: 'Explore the ruins',
+          availability: [
+            RpgCondition(
+              operator: RpgConditionOperator.greaterThanOrEqual,
+              path: 'attributes.stamina',
+              value: 2,
+            ),
+          ],
+          costs: [RpgActionCost(path: 'attributes.stamina', amount: 2)],
+          check: RpgSkillCheck(
+            attributeId: 'strength',
+            dice: RpgDiceSpec('1d20+2'),
+            difficulty: 12,
+            successEffects: [
+              RpgEffect(
+                type: RpgEffectType.setQuestStatus,
+                target: 'find_relic',
+                value: 'completed',
+              ),
+            ],
+            failureEffects: [
+              RpgEffect(
+                type: RpgEffectType.setCooldown,
+                target: 'explore',
+                amount: 1,
+              ),
+            ],
+          ),
+          effects: [
+            RpgEffect(
+              type: RpgEffectType.decrementValue,
+              target: 'attributes.stamina',
+              amount: 2,
+            ),
+          ],
+        ),
+      ],
+      initialState: RpgRuntimeState(
+        scenarioId: 'lost_relic',
+        scenarioVersion: '1.2.0',
+        turn: 12,
+        random: RpgRandomState(
+          initialSeed: 424242,
+          state: 918273645,
+          rollsConsumed: 7,
+        ),
+        attributes: {'strength': 4, 'stamina': 8},
+        variables: {
+          'weather': 'rain',
+          'tutorialSeen': true,
+          'clues': ['map', 'rune'],
+        },
+        inventory: [
+          RpgInventoryEntry(
+            itemId: 'potion',
+            quantity: 2,
+            metadata: {'quality': 'common'},
+          ),
+        ],
+        relationships: [
+          RpgRelationshipState(actorId: 'guide', score: 15, tags: ['trusted']),
+        ],
+        clock: RpgClockState(
+          elapsedMinutes: 780,
+          day: 2,
+          minuteOfDay: 540,
+        ),
+        locationId: 'ruins',
+        quests: [
+          RpgQuestState(
+            questId: 'find_relic',
+            status: RpgQuestStatus.active,
+            stageId: 'search_ruins',
+            objectiveProgress: {'inspect_altar': 1},
+          ),
+        ],
+        cooldowns: {'explore': 2},
+        eventHistory: [
+          RpgEventRecord(
+            id: 'event_12',
+            turn: 12,
+            type: 'actionResolved',
+            actionId: 'explore',
+            summary: 'The party entered the ruins.',
+            data: {'roll': 14},
+          ),
+        ],
+      ),
+    );

--- a/test/rpg_scenario_end_to_end_test.dart
+++ b/test/rpg_scenario_end_to_end_test.dart
@@ -1,0 +1,160 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:native_tavern/data/models/rpg/rpg.dart';
+
+void main() {
+  test('scenario package flows from JSON through policy and snapshot checks',
+      () {
+    final packageJson = <String, dynamic>{
+      'schemaVersion': 1,
+      'metadata': {
+        'id': 'vault_run',
+        'name': 'Vault Run',
+        'version': '1.0.0',
+      },
+      'initialSeed': 99,
+      'attributes': [
+        {
+          'id': 'luck',
+          'label': 'Luck',
+          'initialValue': 3,
+          'minimum': 0,
+          'maximum': 10,
+        },
+      ],
+      'items': [
+        {'id': 'vault_key', 'label': 'Vault Key', 'stackable': false},
+      ],
+      'actors': [
+        {'id': 'guardian', 'label': 'Guardian'},
+      ],
+      'locations': [
+        {'id': 'gate', 'label': 'Gate'},
+        {'id': 'vault', 'label': 'Vault'},
+      ],
+      'quests': [
+        {
+          'id': 'open_vault',
+          'label': 'Open the vault',
+          'stages': [
+            {
+              'id': 'unlock',
+              'label': 'Unlock the gate',
+              'objectiveIds': ['find_key'],
+            },
+          ],
+        },
+      ],
+      'actions': [
+        {
+          'id': 'enter_vault',
+          'label': 'Enter the vault',
+          'availability': [
+            {
+              'operator': 'greaterThanOrEqual',
+              'path': 'inventory.vault_key.quantity',
+              'value': 1,
+            },
+          ],
+          'check': {
+            'attributeId': 'luck',
+            'dice': {'expression': '1d20'},
+            'difficulty': 10,
+            'successEffects': [
+              {'type': 'moveTo', 'target': 'vault'},
+            ],
+          },
+          'effects': [
+            {'type': 'setCooldown', 'target': 'enter_vault', 'amount': 2},
+          ],
+        },
+      ],
+      'initialState': {
+        'scenarioId': 'vault_run',
+        'scenarioVersion': '1.0.0',
+        'turn': 3,
+        'random': {'initialSeed': 99, 'state': 123456, 'rollsConsumed': 1},
+        'attributes': {'luck': 3},
+        'variables': {'gateOpen': false},
+        'inventory': [
+          {'itemId': 'vault_key', 'quantity': 1},
+        ],
+        'relationships': [
+          {'actorId': 'guardian', 'score': -2},
+        ],
+        'clock': {'elapsedMinutes': 30, 'day': 1, 'minuteOfDay': 510},
+        'locationId': 'gate',
+        'quests': [
+          {
+            'questId': 'open_vault',
+            'status': 'active',
+            'stageId': 'unlock',
+            'objectiveProgress': {'find_key': 1},
+          },
+        ],
+        'cooldowns': {'enter_vault': 0},
+        'eventHistory': [
+          {
+            'id': 'found_key',
+            'turn': 2,
+            'type': 'itemFound',
+            'actionId': 'enter_vault',
+          },
+        ],
+      },
+    };
+
+    final transported =
+        jsonDecode(jsonEncode(packageJson)) as Map<String, dynamic>;
+    final scenario = RpgScenario.fromJson(transported);
+    const validator = RpgScenarioValidator();
+
+    expect(validator.validate(scenario).issues, isEmpty);
+    expect(scenario.toJson()['initialState'], packageJson['initialState']);
+
+    final narrativePatch = RpgStatePatch.fromJson({
+      'source': 'narrative',
+      'effects': [
+        {'type': 'removeItem', 'target': 'vault_key', 'amount': 1},
+      ],
+    });
+    expect(
+      validator.validatePatch(scenario, narrativePatch).issues.single.code,
+      'protected_state_mutation',
+    );
+
+    final enginePatch = RpgStatePatch.fromJson({
+      'source': 'ruleEngine',
+      'effects': [
+        {
+          'type': 'setQuestStatus',
+          'target': 'open_vault',
+          'value': 'completed',
+        },
+      ],
+    });
+    expect(validator.validatePatch(scenario, enginePatch).issues, isEmpty);
+
+    final snapshot = RpgStateSnapshot(
+      metadata: RpgSnapshotMetadata(
+        id: 'after_key',
+        scenarioId: scenario.metadata.id,
+        scenarioVersion: scenario.metadata.version,
+        branchId: 'main_branch',
+        turn: scenario.initialState.turn,
+        randomState: scenario.initialState.random.state,
+        rollsConsumed: scenario.initialState.random.rollsConsumed,
+        createdAt: DateTime.utc(2026, 8, 7, 12),
+      ),
+      state: scenario.initialState,
+    );
+    final restoredSnapshot = RpgStateSnapshot.fromJson(
+      jsonDecode(jsonEncode(snapshot.toJson())) as Map<String, dynamic>,
+    );
+
+    expect(
+        validator.validateSnapshot(scenario, restoredSnapshot).issues, isEmpty);
+    expect(restoredSnapshot.toJson(), snapshot.toJson());
+  });
+}


### PR DESCRIPTION
## Summary
- add versioned RPG scenario and deterministic runtime-state contracts
- add typed conditions, effects, dice checks, snapshots, and protected mutation validation
- document the JSON contract and validation boundaries
- add focused contract coverage and an end-to-end JSON/policy/snapshot flow test

## Verification
- `flutter analyze --no-pub lib/data/models/rpg test/rpg_scenario_contract_test.dart test/rpg_scenario_end_to_end_test.dart`
- `flutter test --no-pub` (100 tests)

Closes #7