### PR TITLE
feat: stabilize Live2D gestures and model lifecycle

### DIFF
--- a/lib/data/models/character.dart
+++ b/lib/data/models/character.dart
@@ -259,12 +259,13 @@ class CharacterAssets {
     String? avatarUrl,
     Map<String, String>? expressionPack,
     Live2DConfig? live2d,
+    bool clearLive2D = false,
   }) {
     return CharacterAssets(
       avatarPath: avatarPath ?? this.avatarPath,
       avatarUrl: avatarUrl ?? this.avatarUrl,
       expressionPack: expressionPack ?? this.expressionPack,
-      live2d: live2d ?? this.live2d,
+      live2d: clearLive2D ? null : (live2d ?? this.live2d),
     );
   }
 

--- a/lib/domain/services/live2d_import_service.dart
+++ b/lib/domain/services/live2d_import_service.dart
@@ -18,13 +18,35 @@ class Live2DImportException implements Exception {
   String toString() => message;
 }
 
+class Live2DImportedPackage {
+  final String directoryPath;
+  final List<Live2DModelDefinition> models;
+
+  Live2DImportedPackage({
+    required this.directoryPath,
+    required List<Live2DModelDefinition> models,
+  }) : models = List.unmodifiable(models);
+}
+
+class Live2DPackageDeletionResult {
+  final Live2DImportedPackage package;
+  final bool cleanupPending;
+
+  const Live2DPackageDeletionResult({
+    required this.package,
+    required this.cleanupPending,
+  });
+}
+
 /// Imports user-owned Live2D ZIP packages into NativeTavern's data directory.
 class Live2DImportService {
   static const maxArchiveBytes = 128 * 1024 * 1024;
   static const maxExtractedBytes = 512 * 1024 * 1024;
   static const maxSingleFileBytes = 128 * 1024 * 1024;
   static const maxEntries = 5000;
+  static const orphanStagingGracePeriod = Duration(hours: 1);
   static const _metadataFileName = '.nativetavern-live2d.json';
+  static const _importMarkerFileName = '.nativetavern-importing';
   static const _uuid = Uuid();
 
   static const _allowedExtensions = {
@@ -55,6 +77,7 @@ class Live2DImportService {
   Directory get _modelsRoot => Directory(p.join(dataPath, 'live2d_models'));
 
   Future<List<Live2DModelDefinition>> listImportedModels() async {
+    await cleanupOrphanDirectories();
     final root = _modelsRoot;
     if (!root.existsSync()) return const [];
 
@@ -67,6 +90,146 @@ class Live2DImportService {
     }
     models.sort((a, b) => a.displayName.compareTo(b.displayName));
     return models;
+  }
+
+  /// Removes staging and quarantined directories left by interrupted imports
+  /// or deletions. Normal package directories are never touched here.
+  Future<void> cleanupOrphanDirectories() async {
+    final root = _modelsRoot;
+    if (!root.existsSync()) return;
+    final staleBefore = DateTime.now().subtract(orphanStagingGracePeriod);
+    await for (final entity in root.list(followLinks: false)) {
+      final name = p.basename(entity.path);
+      if (!name.startsWith('.import-') && !name.startsWith('.deleting-')) {
+        continue;
+      }
+      if (name.startsWith('.import-')) {
+        final marker = File(p.join(entity.path, _importMarkerFileName));
+        final modified = marker.existsSync()
+            ? marker.lastModifiedSync()
+            : entity.statSync().modified;
+        if (modified.isAfter(staleBefore)) continue;
+      }
+      try {
+        await entity.delete(recursive: entity is Directory);
+      } catch (_) {
+        // A later library refresh retries cleanup without hiding valid models.
+      }
+    }
+  }
+
+  /// Resolves the package containing [definition] and verifies that it is a
+  /// real, metadata-backed child of the managed Live2D directory.
+  Future<Live2DImportedPackage> inspectImportedPackage(
+    Live2DModelDefinition definition,
+  ) async {
+    if (definition.source != Live2DModelSource.appData) {
+      throw const Live2DImportException(
+        'Only imported Live2D models can be deleted.',
+      );
+    }
+    final relativeDirectory = definition.modelDirectory.replaceAll('\\', '/');
+    if (_isAbsolutePath(relativeDirectory)) {
+      throw const Live2DImportException(
+        'The imported model path is outside the managed Live2D directory.',
+      );
+    }
+
+    final root = _modelsRoot;
+    if (!root.existsSync()) {
+      throw const Live2DImportException(
+        'The imported model package is missing.',
+      );
+    }
+    final rootPath = p.normalize(p.absolute(root.path));
+    final modelDirectory = p.normalize(
+      p.absolute(p.join(dataPath, relativeDirectory)),
+    );
+    if (!p.isWithin(rootPath, modelDirectory)) {
+      throw const Live2DImportException(
+        'The imported model path is outside the managed Live2D directory.',
+      );
+    }
+
+    final relativeToRoot = p.relative(modelDirectory, from: rootPath);
+    final segments = p.split(relativeToRoot);
+    if (segments.isEmpty ||
+        segments.first == '.' ||
+        segments.first == '..' ||
+        segments.first.startsWith('.')) {
+      throw const Live2DImportException('Invalid imported model package path.');
+    }
+    final packageDirectory = Directory(p.join(rootPath, segments.first));
+    final entityType = FileSystemEntity.typeSync(
+      packageDirectory.path,
+      followLinks: false,
+    );
+    if (entityType != FileSystemEntityType.directory) {
+      throw const Live2DImportException(
+        'The imported model package is missing.',
+      );
+    }
+
+    final resolvedRoot = p.normalize(await root.resolveSymbolicLinks());
+    final resolvedPackage =
+        p.normalize(await packageDirectory.resolveSymbolicLinks());
+    if (!p.isWithin(resolvedRoot, resolvedPackage)) {
+      throw const Live2DImportException(
+        'The imported model package resolves outside the managed directory.',
+      );
+    }
+
+    final models = await _readPackageModels(packageDirectory);
+    final containsTarget = models.any((model) {
+      return model.id == definition.id &&
+          model.modelFileName == definition.modelFileName &&
+          p.equals(
+            p.normalize(model.modelDirectory),
+            p.normalize(definition.modelDirectory),
+          );
+    });
+    if (!containsTarget) {
+      throw const Live2DImportException(
+        'The imported model does not match its package metadata.',
+      );
+    }
+    return Live2DImportedPackage(
+      directoryPath: packageDirectory.path,
+      models: models,
+    );
+  }
+
+  /// Atomically hides a validated package before deleting its files. Once the
+  /// rename succeeds, a failed recursive cleanup is safe to retry later.
+  Future<Live2DPackageDeletionResult> deleteImportedPackage(
+    Live2DModelDefinition definition,
+  ) async {
+    final package = await inspectImportedPackage(definition);
+    final packageDirectory = Directory(package.directoryPath);
+    final quarantine = Directory(
+      p.join(
+        _modelsRoot.path,
+        '.deleting-${p.basename(package.directoryPath)}-${_uuid.v4()}',
+      ),
+    );
+    try {
+      await packageDirectory.rename(quarantine.path);
+    } on FileSystemException catch (error) {
+      throw Live2DImportException(
+        'The imported model package could not be quarantined: ${error.message}',
+      );
+    }
+
+    var cleanupPending = false;
+    try {
+      await quarantine.delete(recursive: true);
+    } catch (_) {
+      cleanupPending = true;
+    }
+    return Live2DPackageDeletionResult(
+      package: package,
+      cleanupPending: cleanupPending,
+    );
   }
 
   Future<List<Live2DModelDefinition>> importZip(File zipFile) async {
@@ -132,6 +295,11 @@ class Live2DImportService {
 
     try {
       await staging.create(recursive: true);
+      final importMarker = File(p.join(staging.path, _importMarkerFileName));
+      await importMarker.writeAsString(
+        DateTime.now().toUtc().toIso8601String(),
+        flush: true,
+      );
       for (final (entry, relativePath) in validatedEntries) {
         final content = entry.content;
         if (content is! List<int> || content.length > maxSingleFileBytes) {
@@ -222,6 +390,7 @@ class Live2DImportService {
         jsonEncode(metadata),
         flush: true,
       );
+      await importMarker.delete();
       await staging.rename(destination.path);
       return _definitionsFromMetadata(destination, metadataModels);
     } catch (_) {
@@ -300,6 +469,12 @@ class Live2DImportService {
       return null;
     }
     return p.joinAll(segments);
+  }
+
+  bool _isAbsolutePath(String value) {
+    return p.isAbsolute(value) ||
+        value.startsWith('/') ||
+        RegExp(r'^[a-zA-Z]:/').hasMatch(value);
   }
 
   bool _shouldExtract(String path) {

--- a/lib/domain/services/live2d_model_lifecycle_service.dart
+++ b/lib/domain/services/live2d_model_lifecycle_service.dart
@@ -1,0 +1,163 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:native_tavern/data/models/character.dart';
+import 'package:native_tavern/data/models/live2d.dart';
+import 'package:native_tavern/data/repositories/character_repository.dart';
+import 'package:native_tavern/domain/services/live2d_import_service.dart';
+import 'package:path/path.dart' as p;
+
+class Live2DDeletionException implements Exception {
+  final String message;
+
+  const Live2DDeletionException(this.message);
+
+  @override
+  String toString() => message;
+}
+
+class Live2DDeletionPlan {
+  final Live2DModelDefinition target;
+  final List<Live2DModelDefinition> packageModels;
+  final List<Character> affectedCharacters;
+
+  Live2DDeletionPlan({
+    required this.target,
+    required List<Live2DModelDefinition> packageModels,
+    required List<Character> affectedCharacters,
+  })  : packageModels = List.unmodifiable(packageModels),
+        affectedCharacters = List.unmodifiable(affectedCharacters);
+}
+
+class Live2DDeletionResult {
+  final Live2DDeletionPlan plan;
+  final bool cleanupPending;
+
+  const Live2DDeletionResult({
+    required this.plan,
+    required this.cleanupPending,
+  });
+}
+
+class Live2DModelLifecycleService {
+  final CharacterRepository characterRepository;
+  final Live2DImportService importService;
+
+  const Live2DModelLifecycleService({
+    required this.characterRepository,
+    required this.importService,
+  });
+
+  Future<Live2DDeletionPlan> planDeletion(
+    Live2DModelDefinition definition,
+  ) async {
+    final package = await importService.inspectImportedPackage(definition);
+    final characters = await characterRepository.getAllCharacters();
+    final affected = characters
+        .where((character) => _referencesAny(character, package.models))
+        .toList()
+      ..sort((a, b) => a.name.compareTo(b.name));
+    return Live2DDeletionPlan(
+      target: definition,
+      packageModels: package.models,
+      affectedCharacters: affected,
+    );
+  }
+
+  Future<Live2DDeletionResult> deleteImportedModel(
+    Live2DModelDefinition definition, {
+    Set<String>? confirmedCharacterIds,
+  }) async {
+    final plan = await planDeletion(definition);
+    if (confirmedCharacterIds != null) {
+      final currentIds = plan.affectedCharacters.map((c) => c.id).toSet();
+      if (!_sameSet(currentIds, confirmedCharacterIds)) {
+        throw const Live2DDeletionException(
+          'Model references changed. Review the affected characters again.',
+        );
+      }
+    }
+
+    final changed = <Character>[];
+    try {
+      for (final character in plan.affectedCharacters) {
+        await characterRepository.updateCharacter(_withoutLive2D(character));
+        changed.add(character);
+      }
+    } catch (error) {
+      await _restoreCharacters(changed);
+      throw Live2DDeletionException(
+        'Character references could not be updated: $error',
+      );
+    }
+
+    try {
+      final deletion = await importService.deleteImportedPackage(definition);
+      return Live2DDeletionResult(
+        plan: plan,
+        cleanupPending: deletion.cleanupPending,
+      );
+    } catch (error) {
+      await _restoreCharacters(changed);
+      throw Live2DDeletionException(
+        'The model package could not be deleted: $error',
+      );
+    }
+  }
+
+  bool _referencesAny(
+    Character character,
+    List<Live2DModelDefinition> definitions,
+  ) {
+    final config = character.assets?.live2d;
+    if (config == null || config.source != Live2DModelSource.appData) {
+      return false;
+    }
+    return definitions.any((definition) {
+      return config.modelId == definition.id ||
+          (config.modelFileName == definition.modelFileName &&
+              p.equals(
+                p.normalize(config.modelDirectory),
+                p.normalize(definition.modelDirectory),
+              ));
+    });
+  }
+
+  Character _withoutLive2D(Character character) {
+    final assets = character.assets;
+    if (assets == null) return character;
+    final updatedAssets = assets.copyWith(clearLive2D: true);
+    return character.copyWith(
+      assets: updatedAssets.hasAssets ? updatedAssets : null,
+      clearAssets: !updatedAssets.hasAssets,
+      modifiedAt: DateTime.now(),
+    );
+  }
+
+  Future<void> _restoreCharacters(List<Character> originals) async {
+    Object? firstError;
+    for (final character in originals.reversed) {
+      try {
+        await characterRepository.updateCharacter(character);
+      } catch (error) {
+        firstError ??= error;
+      }
+    }
+    if (firstError != null) {
+      throw Live2DDeletionException(
+        'Deletion failed and character references could not be restored: '
+        '$firstError',
+      );
+    }
+  }
+
+  bool _sameSet(Set<String> left, Set<String> right) {
+    return left.length == right.length && left.containsAll(right);
+  }
+}
+
+final live2DModelLifecycleServiceProvider =
+    Provider<Live2DModelLifecycleService>((ref) {
+  return Live2DModelLifecycleService(
+    characterRepository: ref.watch(characterRepositoryProvider),
+    importService: ref.watch(live2DImportServiceProvider),
+  );
+});

--- a/lib/presentation/screens/chat/chat_screen.dart
+++ b/lib/presentation/screens/chat/chat_screen.dart
@@ -11,6 +11,7 @@ import 'package:image_picker/image_picker.dart';
 import 'package:native_tavern/data/models/character.dart';
 import 'package:native_tavern/data/models/chat.dart';
 import 'package:native_tavern/data/models/chat_background.dart';
+import 'package:native_tavern/data/models/live2d.dart';
 import 'package:native_tavern/core/utils/share_utils.dart';
 import 'package:native_tavern/domain/services/chat_export_service.dart';
 import 'package:native_tavern/domain/services/llm_service.dart';
@@ -45,6 +46,7 @@ import 'package:native_tavern/domain/services/image_generation_service.dart';
 import 'package:native_tavern/presentation/widgets/chat/visual_novel_message_view.dart';
 import 'package:native_tavern/presentation/widgets/chat/sprite_display.dart';
 import 'package:native_tavern/presentation/widgets/live2d/live2d_character_view.dart';
+import 'package:native_tavern/presentation/widgets/live2d/live2d_stage_gestures.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:path/path.dart' as p;
 import 'package:uuid/uuid.dart';
@@ -1221,14 +1223,37 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     }
 
     if (hasLive2D) {
-      return Stack(
-        fit: StackFit.expand,
-        children: [
-          Positioned.fill(
-            child: IgnorePointer(child: _buildLive2DStage(chatState)),
-          ),
-          _buildMessageList(chatState),
-        ],
+      final character = chatState.character!;
+      final live2d = character.assets!.live2d!;
+      return Live2DTwoFingerGestureRegion(
+        initialTransform: Live2DStageTransform.constrained(
+          scale: live2d.scale,
+          offsetX: live2d.offsetX,
+          offsetY: live2d.offsetY,
+        ),
+        onTransformEnd: (transform) {
+          unawaited(_saveLive2DTransform(character.id, transform));
+        },
+        builder: (context, transform) => Stack(
+          fit: StackFit.expand,
+          children: [
+            Positioned.fill(
+              child: IgnorePointer(
+                child: _buildLive2DStage(
+                  chatState,
+                  configOverride: live2d.copyWith(
+                    scale: transform.scale,
+                    offsetX: transform.offsetX,
+                    offsetY: transform.offsetY,
+                  ),
+                  interactive: false,
+                  persistTransform: false,
+                ),
+              ),
+            ),
+            _buildMessageList(chatState),
+          ],
+        ),
       );
     }
 
@@ -1264,9 +1289,14 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     );
   }
 
-  Widget _buildLive2DStage(ActiveChatState chatState) {
+  Widget _buildLive2DStage(
+    ActiveChatState chatState, {
+    Live2DConfig? configOverride,
+    bool interactive = true,
+    bool persistTransform = true,
+  }) {
     final character = chatState.character;
-    final live2d = character?.assets?.live2d;
+    final live2d = configOverride ?? character?.assets?.live2d;
     if (character == null || live2d?.enabled != true) {
       return const SizedBox.shrink();
     }
@@ -1282,10 +1312,12 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     return Live2DCharacterView(
       config: live2d!,
       isSpeaking: chatState.isGenerating,
-      interactive: true,
-      onTransformChanged: (transform) {
-        unawaited(_saveLive2DTransform(character.id, transform));
-      },
+      interactive: interactive,
+      onTransformChanged: persistTransform
+          ? (transform) {
+              unawaited(_saveLive2DTransform(character.id, transform));
+            }
+          : null,
       fallback: latestAssistantMessage == null
           ? const SizedBox.shrink()
           : Align(

--- a/lib/presentation/screens/settings/live2d_settings_screen.dart
+++ b/lib/presentation/screens/settings/live2d_settings_screen.dart
@@ -9,6 +9,7 @@ import 'package:native_tavern/data/models/live2d.dart';
 import 'package:native_tavern/data/repositories/character_repository.dart';
 import 'package:native_tavern/domain/services/live2d_service.dart';
 import 'package:native_tavern/domain/services/live2d_import_service.dart';
+import 'package:native_tavern/domain/services/live2d_model_lifecycle_service.dart';
 import 'package:native_tavern/l10n/generated/app_localizations.dart';
 import 'package:native_tavern/presentation/providers/character_providers.dart';
 import 'package:native_tavern/presentation/providers/chat_providers.dart';
@@ -79,6 +80,7 @@ class _Live2DSettingsEditorState extends ConsumerState<_Live2DSettingsEditor> {
   Live2DMotionRef? _selectedMotion;
   bool _isLoadingModel = false;
   bool _isImporting = false;
+  bool _isDeleting = false;
   bool _isSaving = false;
   String? _error;
 
@@ -187,6 +189,128 @@ class _Live2DSettingsEditorState extends ConsumerState<_Live2DSettingsEditor> {
     } finally {
       if (mounted) setState(() => _isImporting = false);
     }
+  }
+
+  Future<void> _deleteImportedModel(
+    Live2DModelDefinition definition,
+  ) async {
+    if (_isDeleting) return;
+    final lifecycle = ref.read(live2DModelLifecycleServiceProvider);
+    try {
+      final plan = await lifecycle.planDeletion(definition);
+      if (!mounted) return;
+      final confirmed = await _confirmDeletion(plan);
+      if (confirmed != true || !mounted) return;
+      setState(() {
+        _isDeleting = true;
+        _error = null;
+      });
+
+      final result = await lifecycle.deleteImportedModel(
+        definition,
+        confirmedCharacterIds:
+            plan.affectedCharacters.map((character) => character.id).toSet(),
+      );
+      if (!mounted) return;
+      final deletedModels = result.plan.packageModels;
+      final currentConfig = _config;
+      final clearsCurrent = currentConfig != null &&
+          _configReferencesAny(currentConfig, deletedModels);
+      final imported = await _importService.listImportedModels();
+      if (!mounted) return;
+      setState(() {
+        _availableModels = [
+          ...Live2DService.bundledModels,
+          ...imported,
+        ];
+        if (clearsCurrent) {
+          _config = null;
+          _manifest = null;
+          _selectedMotion = null;
+        }
+      });
+
+      for (final character in result.plan.affectedCharacters) {
+        ref.invalidate(characterDetailProvider(character.id));
+      }
+      await ref.read(characterListProvider.notifier).refresh();
+      final activeChat = ref.read(activeChatProvider);
+      final affectedIds =
+          result.plan.affectedCharacters.map((character) => character.id).toSet();
+      if (activeChat.chat != null &&
+          affectedIds.contains(activeChat.character?.id)) {
+        await ref
+            .read(activeChatProvider.notifier)
+            .loadChat(activeChat.chat!.id);
+      }
+      if (!mounted) return;
+      final suffix = result.cleanupPending
+          ? ' File cleanup will be retried on the next library refresh.'
+          : '';
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Imported Live2D model deleted.$suffix')),
+      );
+    } catch (error) {
+      if (mounted) setState(() => _error = error.toString());
+    } finally {
+      if (mounted) setState(() => _isDeleting = false);
+    }
+  }
+
+  Future<bool?> _confirmDeletion(Live2DDeletionPlan plan) {
+    final removesPackage = plan.packageModels.length > 1;
+    return showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Delete imported model?'),
+        content: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                removesPackage
+                    ? 'This package contains ${plan.packageModels.length} models. '
+                        'All of them will be deleted.'
+                    : '"${plan.target.displayName}" will be deleted from this device.',
+              ),
+              if (plan.affectedCharacters.isNotEmpty) ...[
+                const SizedBox(height: 16),
+                const Text('Live2D will be disabled for:'),
+                const SizedBox(height: 8),
+                ...plan.affectedCharacters.map(
+                  (character) => Padding(
+                    padding: const EdgeInsets.only(bottom: 4),
+                    child: Text('- ${character.name}'),
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  bool _configReferencesAny(
+    Live2DConfig config,
+    List<Live2DModelDefinition> definitions,
+  ) {
+    return definitions.any((definition) {
+      return config.modelId == definition.id ||
+          (config.modelDirectory == definition.modelDirectory &&
+              config.modelFileName == definition.modelFileName);
+    });
   }
 
   Future<void> _loadManifest(
@@ -312,6 +436,9 @@ class _Live2DSettingsEditorState extends ConsumerState<_Live2DSettingsEditor> {
     final availableIds = _availableModels.map((m) => m.id).toSet();
     final hasCustomModel =
         config != null && !availableIds.contains(config.modelId);
+    final importedModels = _availableModels
+        .where((model) => model.source == Live2DModelSource.appData)
+        .toList();
 
     return Scaffold(
       appBar: AppBar(
@@ -377,7 +504,7 @@ class _Live2DSettingsEditorState extends ConsumerState<_Live2DSettingsEditor> {
                   ),
                 ),
               ],
-              onChanged: _isLoadingModel || _isImporting
+              onChanged: _isLoadingModel || _isImporting || _isDeleting
                   ? null
                   : (value) {
                       if (value != null) _selectModel(value);
@@ -397,10 +524,30 @@ class _Live2DSettingsEditorState extends ConsumerState<_Live2DSettingsEditor> {
                       )
                     : const Icon(Icons.archive_outlined),
                 label: const Text('Import ZIP'),
-                onPressed: _isImporting ? null : _importZip,
+                onPressed: _isImporting || _isDeleting ? null : _importZip,
               ),
             ),
           ),
+          if (importedModels.isNotEmpty) ...[
+            const Divider(),
+            ...importedModels.map(
+              (model) => ListTile(
+                leading: const Icon(Icons.view_in_ar),
+                title: Text(model.displayName),
+                subtitle: Text(
+                  model.modelFileName,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                trailing: IconButton(
+                  icon: const Icon(Icons.delete_outline),
+                  tooltip: 'Delete imported model',
+                  onPressed: _isDeleting || _isImporting
+                      ? null
+                      : () => _deleteImportedModel(model),
+                ),
+              ),
+            ),
+          ],
           if (_error != null)
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16),

--- a/lib/presentation/widgets/live2d/live2d_character_view.dart
+++ b/lib/presentation/widgets/live2d/live2d_character_view.dart
@@ -9,6 +9,10 @@ import 'package:flutter_live2d/flutter_live2d.dart';
 import 'package:native_tavern/core/utils/path_utils.dart';
 import 'package:native_tavern/data/models/live2d.dart';
 import 'package:native_tavern/presentation/widgets/live2d/macos_live2d_view.dart';
+import 'package:native_tavern/presentation/widgets/live2d/live2d_stage_gestures.dart';
+
+export 'package:native_tavern/presentation/widgets/live2d/live2d_stage_gestures.dart'
+    show Live2DStageTransform;
 
 abstract interface class _NativeLive2DController {
   ValueListenable<Live2DViewState> get listenable;
@@ -185,19 +189,6 @@ class Live2DCharacterController {
   }
 }
 
-/// Transparent Live2D stage with lifecycle, motion, and graceful fallback.
-class Live2DStageTransform {
-  final double scale;
-  final double offsetX;
-  final double offsetY;
-
-  const Live2DStageTransform({
-    required this.scale,
-    required this.offsetX,
-    required this.offsetY,
-  });
-}
-
 class Live2DCharacterView extends StatefulWidget {
   final Live2DConfig config;
   final bool isSpeaking;
@@ -227,10 +218,6 @@ class Live2DCharacterView extends StatefulWidget {
 
 class _Live2DCharacterViewState extends State<Live2DCharacterView>
     with WidgetsBindingObserver {
-  static const double _minScale = 0.1;
-  static const double _maxScale = 10;
-  static const double _maxOffset = 10;
-
   late final _NativeLive2DController _nativeController;
   Timer? _returnToIdleTimer;
   Timer? _scrollSaveTimer;
@@ -239,7 +226,8 @@ class _Live2DCharacterViewState extends State<Live2DCharacterView>
   double _stageScale = 1;
   double _offsetX = 0;
   double _offsetY = 0;
-  double _gestureStartScale = 1;
+  Live2DStageTransform? _gestureStartTransform;
+  Offset? _gestureStartFocalPoint;
   bool _transformDirty = false;
 
   @override
@@ -247,9 +235,7 @@ class _Live2DCharacterViewState extends State<Live2DCharacterView>
     super.initState();
     _nativeController =
         Platform.isMacOS ? _MacOSLive2DController() : _MobileLive2DController();
-    _stageScale = widget.config.scale.clamp(_minScale, _maxScale);
-    _offsetX = widget.config.offsetX.clamp(-_maxOffset, _maxOffset);
-    _offsetY = widget.config.offsetY.clamp(-_maxOffset, _maxOffset);
+    _applyConfigTransform(widget.config);
     WidgetsBinding.instance.addObserver(this);
     if (Live2DCharacterView.isPlatformSupported) {
       WidgetsBinding.instance.addPostFrameCallback((_) => _loadModel());
@@ -264,9 +250,7 @@ class _Live2DCharacterViewState extends State<Live2DCharacterView>
     if (oldConfig.scale != config.scale ||
         oldConfig.offsetX != config.offsetX ||
         oldConfig.offsetY != config.offsetY) {
-      _stageScale = config.scale.clamp(_minScale, _maxScale);
-      _offsetX = config.offsetX.clamp(-_maxOffset, _maxOffset);
-      _offsetY = config.offsetY.clamp(-_maxOffset, _maxOffset);
+      _applyConfigTransform(config);
     }
     if (oldConfig.modelDirectory != config.modelDirectory ||
         oldConfig.modelFileName != config.modelFileName) {
@@ -376,42 +360,41 @@ class _Live2DCharacterViewState extends State<Live2DCharacterView>
 
   void _handleScaleStart(ScaleStartDetails details) {
     _scrollSaveTimer?.cancel();
-    _gestureStartScale = _stageScale;
+    _gestureStartTransform = _currentTransform;
+    _gestureStartFocalPoint = details.localFocalPoint;
     _transformDirty = false;
   }
 
   void _handleScaleUpdate(ScaleUpdateDetails details) {
     final size = context.size;
-    if (!widget.interactive || size == null || size.isEmpty) return;
-
-    final previousScale = _stageScale;
-    final nextScale =
-        (_gestureStartScale * details.scale).clamp(_minScale, _maxScale);
-    var translation = Offset(
-      _offsetX * size.width,
-      _offsetY * size.height,
+    final startTransform = _gestureStartTransform;
+    final startFocalPoint = _gestureStartFocalPoint;
+    if (!widget.interactive ||
+        size == null ||
+        size.isEmpty ||
+        startTransform == null ||
+        startFocalPoint == null) {
+      return;
+    }
+    final next = Live2DStageTransform.applyGesture(
+      start: startTransform,
+      startFocalPoint: startFocalPoint,
+      currentFocalPoint: details.localFocalPoint,
+      scaleDelta: details.scale,
+      size: size,
     );
 
-    if (nextScale != previousScale) {
-      final scaleRatio = nextScale / previousScale;
-      final focalFromCenter =
-          details.localFocalPoint - size.center(Offset.zero);
-      translation = translation * scaleRatio +
-          focalFromCenter * (1 - scaleRatio) +
-          details.focalPointDelta * scaleRatio;
-    } else {
-      translation += details.focalPointDelta;
-    }
-
     setState(() {
-      _stageScale = nextScale;
-      _offsetX = (translation.dx / size.width).clamp(-_maxOffset, _maxOffset);
-      _offsetY = (translation.dy / size.height).clamp(-_maxOffset, _maxOffset);
+      _stageScale = next.scale;
+      _offsetX = next.offsetX;
+      _offsetY = next.offsetY;
       _transformDirty = true;
     });
   }
 
   void _handleScaleEnd(ScaleEndDetails details) {
+    _gestureStartTransform = null;
+    _gestureStartFocalPoint = null;
     if (_transformDirty) _notifyTransformChanged();
   }
 
@@ -423,7 +406,10 @@ class _Live2DCharacterViewState extends State<Live2DCharacterView>
       if (size == null || size.isEmpty) return;
       final scaleFactor = math.exp(-scrollEvent.scrollDelta.dy * 0.0015);
       _scaleAroundPoint(
-        (_stageScale * scaleFactor).clamp(_minScale, _maxScale),
+        (_stageScale * scaleFactor).clamp(
+          Live2DStageTransform.minScale,
+          Live2DStageTransform.maxScale,
+        ),
         scrollEvent.localPosition,
         size,
       );
@@ -437,21 +423,36 @@ class _Live2DCharacterViewState extends State<Live2DCharacterView>
 
   void _scaleAroundPoint(double nextScale, Offset focalPoint, Size size) {
     if (nextScale == _stageScale) return;
-    final scaleRatio = nextScale / _stageScale;
-    final translation = Offset(
-      _offsetX * size.width,
-      _offsetY * size.height,
+    final next = Live2DStageTransform.applyGesture(
+      start: _currentTransform,
+      startFocalPoint: focalPoint,
+      currentFocalPoint: focalPoint,
+      scaleDelta: nextScale / _stageScale,
+      size: size,
     );
-    final focalFromCenter = focalPoint - size.center(Offset.zero);
-    final nextTranslation =
-        translation * scaleRatio + focalFromCenter * (1 - scaleRatio);
     setState(() {
-      _stageScale = nextScale;
-      _offsetX =
-          (nextTranslation.dx / size.width).clamp(-_maxOffset, _maxOffset);
-      _offsetY =
-          (nextTranslation.dy / size.height).clamp(-_maxOffset, _maxOffset);
+      _stageScale = next.scale;
+      _offsetX = next.offsetX;
+      _offsetY = next.offsetY;
     });
+  }
+
+  Live2DStageTransform get _currentTransform =>
+      Live2DStageTransform.constrained(
+        scale: _stageScale,
+        offsetX: _offsetX,
+        offsetY: _offsetY,
+      );
+
+  void _applyConfigTransform(Live2DConfig config) {
+    final transform = Live2DStageTransform.constrained(
+      scale: config.scale,
+      offsetX: config.offsetX,
+      offsetY: config.offsetY,
+    );
+    _stageScale = transform.scale;
+    _offsetX = transform.offsetX;
+    _offsetY = transform.offsetY;
   }
 
   void _resetTransform() {

--- a/lib/presentation/widgets/live2d/live2d_stage_gestures.dart
+++ b/lib/presentation/widgets/live2d/live2d_stage_gestures.dart
@@ -1,0 +1,260 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/widgets.dart';
+
+@immutable
+class Live2DStageTransform {
+  static const double minScale = 0.1;
+  static const double maxScale = 10;
+  static const double maxOffset = 10;
+
+  final double scale;
+  final double offsetX;
+  final double offsetY;
+
+  const Live2DStageTransform({
+    required this.scale,
+    required this.offsetX,
+    required this.offsetY,
+  });
+
+  factory Live2DStageTransform.constrained({
+    required double scale,
+    required double offsetX,
+    required double offsetY,
+  }) {
+    return Live2DStageTransform(
+      scale: scale.clamp(minScale, maxScale),
+      offsetX: offsetX.clamp(-maxOffset, maxOffset),
+      offsetY: offsetY.clamp(-maxOffset, maxOffset),
+    );
+  }
+
+  /// Applies a gesture relative to its initial focal point and transform.
+  /// Offsets are stored as fractions of the stage size.
+  static Live2DStageTransform applyGesture({
+    required Live2DStageTransform start,
+    required Offset startFocalPoint,
+    required Offset currentFocalPoint,
+    required double scaleDelta,
+    required Size size,
+  }) {
+    if (size.isEmpty) return start;
+    final startScale = start.scale.clamp(minScale, maxScale);
+    final nextScale = (startScale * scaleDelta).clamp(minScale, maxScale);
+    final scaleRatio = nextScale / startScale;
+    final center = size.center(Offset.zero);
+    final startTranslation = Offset(
+      start.offsetX * size.width,
+      start.offsetY * size.height,
+    );
+    final nextTranslation = currentFocalPoint -
+        center -
+        (startFocalPoint - center - startTranslation) * scaleRatio;
+    return Live2DStageTransform.constrained(
+      scale: nextScale,
+      offsetX: nextTranslation.dx / size.width,
+      offsetY: nextTranslation.dy / size.height,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is Live2DStageTransform &&
+        other.scale == scale &&
+        other.offsetX == offsetX &&
+        other.offsetY == offsetY;
+  }
+
+  @override
+  int get hashCode => Object.hash(scale, offsetX, offsetY);
+}
+
+typedef Live2DTransformBuilder = Widget Function(
+    BuildContext context, Live2DStageTransform transform);
+
+/// Waits for a second touch before accepting the gesture. A one-finger drag can
+/// therefore be won by the message list, while a two-finger gesture transforms
+/// the Live2D stage without scrolling messages at the same time.
+class Live2DTwoFingerGestureRegion extends StatefulWidget {
+  final Live2DStageTransform initialTransform;
+  final Live2DTransformBuilder builder;
+  final ValueChanged<Live2DStageTransform>? onTransformEnd;
+
+  const Live2DTwoFingerGestureRegion({
+    super.key,
+    required this.initialTransform,
+    required this.builder,
+    this.onTransformEnd,
+  });
+
+  @override
+  State<Live2DTwoFingerGestureRegion> createState() =>
+      _Live2DTwoFingerGestureRegionState();
+}
+
+class _Live2DTwoFingerGestureRegionState
+    extends State<Live2DTwoFingerGestureRegion> {
+  final Map<int, Offset> _touches = {};
+  late Live2DStageTransform _transform;
+  Live2DStageTransform? _gestureStartTransform;
+  Offset? _gestureStartFocalPoint;
+  double? _gestureStartDistance;
+  bool _changed = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _transform = widget.initialTransform;
+  }
+
+  @override
+  void didUpdateWidget(Live2DTwoFingerGestureRegion oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (_gestureStartTransform == null &&
+        oldWidget.initialTransform != widget.initialTransform) {
+      _transform = widget.initialTransform;
+    }
+  }
+
+  bool _isTouch(PointerEvent event) => event.kind == PointerDeviceKind.touch;
+
+  List<Offset> get _primaryTouches {
+    final pointers = _touches.keys.toList()..sort();
+    return pointers.take(2).map((pointer) => _touches[pointer]!).toList();
+  }
+
+  void _handlePointerDown(PointerDownEvent event) {
+    if (!_isTouch(event)) return;
+    _touches[event.pointer] = event.localPosition;
+    if (_touches.length == 2) {
+      final touches = _primaryTouches;
+      _gestureStartTransform = _transform;
+      _gestureStartFocalPoint = _centroid(touches);
+      _gestureStartDistance = (touches[0] - touches[1]).distance;
+      _changed = false;
+    }
+  }
+
+  void _handlePointerMove(PointerMoveEvent event) {
+    if (!_touches.containsKey(event.pointer)) return;
+    _touches[event.pointer] = event.localPosition;
+    final startTransform = _gestureStartTransform;
+    final startFocalPoint = _gestureStartFocalPoint;
+    final startDistance = _gestureStartDistance;
+    final size = context.size;
+    if (_touches.length < 2 ||
+        startTransform == null ||
+        startFocalPoint == null ||
+        startDistance == null ||
+        size == null ||
+        size.isEmpty) {
+      return;
+    }
+
+    final touches = _primaryTouches;
+    final currentDistance = (touches[0] - touches[1]).distance;
+    final scaleDelta =
+        startDistance <= 0.000001 ? 1.0 : currentDistance / startDistance;
+    final next = Live2DStageTransform.applyGesture(
+      start: startTransform,
+      startFocalPoint: startFocalPoint,
+      currentFocalPoint: _centroid(touches),
+      scaleDelta: scaleDelta,
+      size: size,
+    );
+    if (next == _transform) return;
+    setState(() => _transform = next);
+    _changed = true;
+  }
+
+  void _handlePointerEnd(int pointer) {
+    if (!_touches.containsKey(pointer)) return;
+    _touches.remove(pointer);
+    if (_gestureStartTransform != null && _touches.length < 2) {
+      _gestureStartTransform = null;
+      _gestureStartFocalPoint = null;
+      _gestureStartDistance = null;
+      if (_changed) widget.onTransformEnd?.call(_transform);
+      _changed = false;
+    }
+  }
+
+  Offset _centroid(List<Offset> touches) {
+    return Offset(
+      touches.map((point) => point.dx).reduce((a, b) => a + b) / touches.length,
+      touches.map((point) => point.dy).reduce((a, b) => a + b) / touches.length,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return RawGestureDetector(
+      behavior: HitTestBehavior.translucent,
+      gestures: {
+        _TwoFingerGestureRecognizer:
+            GestureRecognizerFactoryWithHandlers<_TwoFingerGestureRecognizer>(
+          _TwoFingerGestureRecognizer.new,
+          (recognizer) {
+            recognizer
+              ..onPointerDown = _handlePointerDown
+              ..onPointerMove = _handlePointerMove
+              ..onPointerEnd = _handlePointerEnd;
+          },
+        ),
+      },
+      child: widget.builder(context, _transform),
+    );
+  }
+}
+
+class _TwoFingerGestureRecognizer extends OneSequenceGestureRecognizer {
+  final Set<int> _trackedPointers = {};
+  ValueChanged<PointerDownEvent>? onPointerDown;
+  ValueChanged<PointerMoveEvent>? onPointerMove;
+  ValueChanged<int>? onPointerEnd;
+
+  @override
+  void addAllowedPointer(PointerDownEvent event) {
+    if (event.kind != PointerDeviceKind.touch || _trackedPointers.length >= 2) {
+      return;
+    }
+    startTrackingPointer(event.pointer, event.transform);
+    _trackedPointers.add(event.pointer);
+    onPointerDown?.call(event);
+    if (_trackedPointers.length == 2) {
+      resolve(GestureDisposition.accepted);
+    }
+  }
+
+  @override
+  void handleEvent(PointerEvent event) {
+    if (!_trackedPointers.contains(event.pointer)) return;
+    if (event is PointerMoveEvent) {
+      onPointerMove?.call(event);
+    } else if (event is PointerUpEvent || event is PointerCancelEvent) {
+      _finishPointer(event.pointer);
+    }
+  }
+
+  @override
+  void acceptGesture(int pointer) {}
+
+  @override
+  void rejectGesture(int pointer) {
+    _finishPointer(pointer);
+  }
+
+  void _finishPointer(int pointer) {
+    if (!_trackedPointers.remove(pointer)) return;
+    onPointerEnd?.call(pointer);
+    stopTrackingPointer(pointer);
+  }
+
+  @override
+  void didStopTrackingLastPointer(int pointer) {
+    resolve(GestureDisposition.rejected);
+  }
+
+  @override
+  String get debugDescription => 'two finger Live2D transform';
+}

--- a/test/live2d_import_service_test.dart
+++ b/test/live2d_import_service_test.dart
@@ -118,6 +118,63 @@ void main() {
 
     expect(await importService.listImportedModels(), isEmpty);
   });
+
+  test('repeated imports stay isolated and stale staging directories are removed',
+      () async {
+    final zipFile = _writeZip(
+      tempDirectory,
+      'repeated.zip',
+      _validModelEntries(),
+    );
+    final staleImport = Directory(
+      p.join(tempDirectory.path, 'live2d_models', '.import-stale'),
+    )..createSync(recursive: true);
+    final staleMarker = File(
+      p.join(staleImport.path, '.nativetavern-importing'),
+    )..writeAsStringSync('stale');
+    staleMarker.setLastModifiedSync(
+      DateTime.now().subtract(const Duration(hours: 2)),
+    );
+    final staleDeletion = Directory(
+      p.join(tempDirectory.path, 'live2d_models', '.deleting-stale'),
+    )..createSync(recursive: true);
+    final activeImport = Directory(
+      p.join(tempDirectory.path, 'live2d_models', '.import-active'),
+    )..createSync(recursive: true);
+    File(
+      p.join(activeImport.path, '.nativetavern-importing'),
+    ).writeAsStringSync('active');
+
+    final first = await importService.importZip(zipFile);
+    final second = await importService.importZip(zipFile);
+    final models = await importService.listImportedModels();
+
+    expect(models, hasLength(2));
+    expect(first.single.id, isNot(second.single.id));
+    expect(models.map((model) => model.id).toSet(), hasLength(2));
+    expect(staleImport.existsSync(), isFalse);
+    expect(staleDeletion.existsSync(), isFalse);
+    expect(activeImport.existsSync(), isTrue);
+  });
+
+  test('deletion rejects bundled and out-of-root model definitions', () async {
+    await expectLater(
+      importService.deleteImportedPackage(Live2DService.bundledModels.single),
+      throwsA(isA<Live2DImportException>()),
+    );
+    await expectLater(
+      importService.deleteImportedPackage(
+        const Live2DModelDefinition(
+          id: 'outside',
+          displayName: 'Outside',
+          modelDirectory: '../outside',
+          modelFileName: 'outside.model3.json',
+          source: Live2DModelSource.appData,
+        ),
+      ),
+      throwsA(isA<Live2DImportException>()),
+    );
+  });
 }
 
 Map<String, List<int>> _validModelEntries() {

--- a/test/live2d_model_lifecycle_service_test.dart
+++ b/test/live2d_model_lifecycle_service_test.dart
@@ -1,0 +1,280 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:archive/archive.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:native_tavern/data/database/database.dart' hide Character;
+import 'package:native_tavern/data/models/character.dart';
+import 'package:native_tavern/data/models/live2d.dart';
+import 'package:native_tavern/data/repositories/character_repository.dart';
+import 'package:native_tavern/domain/services/live2d_import_service.dart';
+import 'package:native_tavern/domain/services/live2d_model_lifecycle_service.dart';
+import 'package:native_tavern/domain/services/live2d_service.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  late Directory tempDirectory;
+  late AppDatabase database;
+  late CharacterRepository characterRepository;
+  late Live2DImportService importService;
+
+  setUp(() {
+    tempDirectory = Directory.systemTemp.createTempSync('nt_live2d_lifecycle');
+    database = AppDatabase.forTesting(NativeDatabase.memory());
+    characterRepository = CharacterRepository(database, tempDirectory.path);
+    importService = Live2DImportService(
+      dataPath: tempDirectory.path,
+      modelService: Live2DService(dataPath: tempDirectory.path),
+    );
+  });
+
+  tearDown(() async {
+    await database.close();
+    if (tempDirectory.existsSync()) {
+      tempDirectory.deleteSync(recursive: true);
+    }
+  });
+
+  test('deletion clears affected assignments and preserves unrelated assets',
+      () async {
+    final definition = await _importModel(tempDirectory, importService);
+    final now = DateTime.now();
+    await characterRepository.createCharacter(
+      Character(
+        id: 'affected',
+        name: 'Affected',
+        assets: CharacterAssets(
+          avatarPath: '/avatars/affected.png',
+          expressionPack: const {'happy': '/sprites/happy.png'},
+          live2d: _configFor(definition),
+        ),
+        createdAt: now,
+        modifiedAt: now,
+      ),
+    );
+    await characterRepository.createCharacter(
+      Character(
+        id: 'bundled',
+        name: 'Bundled',
+        assets: CharacterAssets(
+          live2d: _configFor(Live2DService.bundledModels.single),
+        ),
+        createdAt: now,
+        modifiedAt: now,
+      ),
+    );
+    final lifecycle = Live2DModelLifecycleService(
+      characterRepository: characterRepository,
+      importService: importService,
+    );
+
+    final plan = await lifecycle.planDeletion(definition);
+    expect(
+        plan.affectedCharacters.map((character) => character.id), ['affected']);
+
+    final result = await lifecycle.deleteImportedModel(
+      definition,
+      confirmedCharacterIds: {'affected'},
+    );
+
+    expect(result.plan.affectedCharacters, hasLength(1));
+    expect(await importService.listImportedModels(), isEmpty);
+    final affected = await characterRepository.getCharacter('affected');
+    expect(affected?.assets?.live2d, isNull);
+    expect(affected?.assets?.avatarPath, '/avatars/affected.png');
+    expect(affected?.assets?.expressionPack?['happy'], '/sprites/happy.png');
+    final bundled = await characterRepository.getCharacter('bundled');
+    expect(bundled?.assets?.live2d?.modelId, 'hiyori_free');
+  });
+
+  test('a partial reference update failure restores changed characters',
+      () async {
+    final definition = await _importModel(tempDirectory, importService);
+    final failingRepository = _FailSecondClearCharacterRepository(
+      database,
+      tempDirectory.path,
+    );
+    final now = DateTime.now();
+    for (final id in ['first', 'second']) {
+      await failingRepository.createCharacter(
+        Character(
+          id: id,
+          name: id,
+          assets: CharacterAssets(live2d: _configFor(definition)),
+          createdAt: now,
+          modifiedAt: now,
+        ),
+      );
+    }
+    final lifecycle = Live2DModelLifecycleService(
+      characterRepository: failingRepository,
+      importService: importService,
+    );
+
+    await expectLater(
+      lifecycle.deleteImportedModel(definition),
+      throwsA(isA<Live2DDeletionException>()),
+    );
+
+    expect(
+      (await failingRepository.getCharacter('first'))?.assets?.live2d,
+      isNotNull,
+    );
+    expect(
+      (await failingRepository.getCharacter('second'))?.assets?.live2d,
+      isNotNull,
+    );
+    expect(await importService.listImportedModels(), hasLength(1));
+  });
+
+  test('deleting one model removes its package and clears sibling references',
+      () async {
+    final definitions = await _importModels(
+      tempDirectory,
+      importService,
+      includeSecondModel: true,
+    );
+    final now = DateTime.now();
+    await characterRepository.createCharacter(
+      Character(
+        id: 'sibling-reference',
+        name: 'Sibling reference',
+        assets: CharacterAssets(live2d: _configFor(definitions.last)),
+        createdAt: now,
+        modifiedAt: now,
+      ),
+    );
+    final lifecycle = Live2DModelLifecycleService(
+      characterRepository: characterRepository,
+      importService: importService,
+    );
+
+    final plan = await lifecycle.planDeletion(definitions.first);
+    expect(plan.packageModels, hasLength(2));
+    expect(plan.affectedCharacters.single.id, 'sibling-reference');
+
+    await lifecycle.deleteImportedModel(
+      definitions.first,
+      confirmedCharacterIds: {'sibling-reference'},
+    );
+
+    expect(await importService.listImportedModels(), isEmpty);
+    expect(
+      (await characterRepository.getCharacter('sibling-reference'))
+          ?.assets
+          ?.live2d,
+      isNull,
+    );
+  });
+
+  test('changed references require a fresh confirmation', () async {
+    final definition = await _importModel(tempDirectory, importService);
+    final now = DateTime.now();
+    await characterRepository.createCharacter(
+      Character(
+        id: 'new-reference',
+        name: 'New reference',
+        assets: CharacterAssets(live2d: _configFor(definition)),
+        createdAt: now,
+        modifiedAt: now,
+      ),
+    );
+    final lifecycle = Live2DModelLifecycleService(
+      characterRepository: characterRepository,
+      importService: importService,
+    );
+
+    await expectLater(
+      lifecycle.deleteImportedModel(
+        definition,
+        confirmedCharacterIds: const {},
+      ),
+      throwsA(isA<Live2DDeletionException>()),
+    );
+
+    expect(await importService.listImportedModels(), hasLength(1));
+    expect(
+      (await characterRepository.getCharacter('new-reference'))?.assets?.live2d,
+      isNotNull,
+    );
+  });
+}
+
+class _FailSecondClearCharacterRepository extends CharacterRepository {
+  var _clearAttempts = 0;
+  var _hasFailed = false;
+
+  _FailSecondClearCharacterRepository(super.database, super.dataPath);
+
+  @override
+  Future<Character> updateCharacter(Character character) {
+    if (!_hasFailed && character.assets?.live2d == null) {
+      _clearAttempts++;
+      if (_clearAttempts == 2) {
+        _hasFailed = true;
+        throw StateError('simulated update failure');
+      }
+    }
+    return super.updateCharacter(character);
+  }
+}
+
+Live2DConfig _configFor(Live2DModelDefinition definition) {
+  return Live2DConfig(
+    modelId: definition.id,
+    displayName: definition.displayName,
+    modelDirectory: definition.modelDirectory,
+    modelFileName: definition.modelFileName,
+    source: definition.source,
+  );
+}
+
+Future<Live2DModelDefinition> _importModel(
+  Directory directory,
+  Live2DImportService importService,
+) async {
+  return (await _importModels(directory, importService)).single;
+}
+
+Future<List<Live2DModelDefinition>> _importModels(
+  Directory directory,
+  Live2DImportService importService, {
+  bool includeSecondModel = false,
+}) async {
+  final entries = _validModelEntries();
+  if (includeSecondModel) {
+    entries['package/second_model.model3.json'] =
+        entries['package/test_model.model3.json']!;
+  }
+  final zip = _writeZip(directory, 'model.zip', entries);
+  return importService.importZip(zip);
+}
+
+Map<String, List<int>> _validModelEntries() {
+  final model = {
+    'Version': 3,
+    'FileReferences': {
+      'Moc': 'test_model.moc3',
+      'Textures': ['textures/texture.png'],
+    },
+  };
+  return {
+    'package/test_model.model3.json': utf8.encode(jsonEncode(model)),
+    'package/test_model.moc3': [0x4d, 0x4f, 0x43, 0x33],
+    'package/textures/texture.png': [0x89, 0x50, 0x4e, 0x47],
+  };
+}
+
+File _writeZip(
+  Directory directory,
+  String name,
+  Map<String, List<int>> entries,
+) {
+  final archive = Archive();
+  for (final entry in entries.entries) {
+    archive.addFile(ArchiveFile(entry.key, entry.value.length, entry.value));
+  }
+  final encoded = ZipEncoder().encode(archive);
+  return File(p.join(directory.path, name))..writeAsBytesSync(encoded!);
+}

--- a/test/live2d_stage_gestures_test.dart
+++ b/test/live2d_stage_gestures_test.dart
@@ -1,0 +1,149 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:native_tavern/presentation/widgets/live2d/live2d_stage_gestures.dart';
+
+void main() {
+  group('Live2D stage transform math', () {
+    const initial = Live2DStageTransform(
+      scale: 1,
+      offsetX: 0,
+      offsetY: 0,
+    );
+    const size = Size(200, 100);
+
+    test('keeps an off-center focal point anchored while scaling', () {
+      final transformed = Live2DStageTransform.applyGesture(
+        start: initial,
+        startFocalPoint: const Offset(150, 50),
+        currentFocalPoint: const Offset(150, 50),
+        scaleDelta: 2,
+        size: size,
+      );
+
+      expect(transformed.scale, 2);
+      expect(transformed.offsetX, -0.25);
+      expect(transformed.offsetY, 0);
+    });
+
+    test('normalizes pan deltas to the stage dimensions', () {
+      final transformed = Live2DStageTransform.applyGesture(
+        start: initial,
+        startFocalPoint: const Offset(100, 50),
+        currentFocalPoint: const Offset(120, 60),
+        scaleDelta: 1,
+        size: size,
+      );
+
+      expect(transformed.scale, 1);
+      expect(transformed.offsetX, closeTo(0.1, 0.000001));
+      expect(transformed.offsetY, closeTo(0.1, 0.000001));
+    });
+
+    test('clamps scale and offsets to supported limits', () {
+      final transformed = Live2DStageTransform.applyGesture(
+        start: const Live2DStageTransform(
+          scale: 10,
+          offsetX: 10,
+          offsetY: -10,
+        ),
+        startFocalPoint: Offset.zero,
+        currentFocalPoint: const Offset(100000, -100000),
+        scaleDelta: 100,
+        size: size,
+      );
+
+      expect(transformed.scale, Live2DStageTransform.maxScale);
+      expect(transformed.offsetX, Live2DStageTransform.maxOffset);
+      expect(transformed.offsetY, -Live2DStageTransform.maxOffset);
+    });
+  });
+
+  testWidgets('one-finger drag scrolls without transforming the stage',
+      (tester) async {
+    final scrollController = ScrollController();
+    final completed = <Live2DStageTransform>[];
+    addTearDown(scrollController.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SizedBox(
+          width: 240,
+          height: 320,
+          child: Live2DTwoFingerGestureRegion(
+            initialTransform: const Live2DStageTransform(
+              scale: 1,
+              offsetX: 0,
+              offsetY: 0,
+            ),
+            onTransformEnd: completed.add,
+            builder: (context, transform) => ListView(
+              controller: scrollController,
+              children: const [SizedBox(height: 1200)],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.drag(find.byType(ListView), const Offset(0, -140));
+    await tester.pumpAndSettle();
+
+    expect(scrollController.offset, greaterThan(0));
+    expect(completed, isEmpty);
+  });
+
+  testWidgets('two fingers scale the stage and emit one completed transform',
+      (tester) async {
+    final completed = <Live2DStageTransform>[];
+    final scrollController = ScrollController();
+    Live2DStageTransform? displayed;
+    addTearDown(scrollController.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SizedBox(
+          width: 240,
+          height: 320,
+          child: Live2DTwoFingerGestureRegion(
+            initialTransform: const Live2DStageTransform(
+              scale: 1,
+              offsetX: 0,
+              offsetY: 0,
+            ),
+            onTransformEnd: completed.add,
+            builder: (context, transform) {
+              displayed = transform;
+              return ListView(
+                key: const ValueKey('gesture-surface'),
+                controller: scrollController,
+                children: const [SizedBox(height: 1200)],
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    final center =
+        tester.getCenter(find.byKey(const ValueKey('gesture-surface')));
+    final first = await tester.startGesture(
+      center - const Offset(20, 0),
+      pointer: 1,
+    );
+    final second = await tester.startGesture(
+      center + const Offset(20, 0),
+      pointer: 2,
+    );
+    await first.moveTo(center - const Offset(40, 0));
+    await second.moveTo(center + const Offset(40, 0));
+    await tester.pump();
+    await first.up();
+    await second.up();
+    await tester.pump();
+
+    expect(displayed?.scale, closeTo(2, 0.000001));
+    expect(scrollController.offset, 0);
+    expect(completed, hasLength(1));
+    expect(completed.single.scale, closeTo(2, 0.000001));
+  });
+}


### PR DESCRIPTION
## Summary
- coordinate one-finger chat scrolling with two-finger Live2D pan and pinch
- add managed imported-model deletion with reference confirmation and rollback
- cover transform math, gesture arbitration, path safety, repeated imports, and deletion recovery

## Validation
- `flutter test --no-pub test/live2d_stage_gestures_test.dart test/live2d_import_service_test.dart test/live2d_model_lifecycle_service_test.dart` (15/15)
- `flutter test --no-pub` (133/133)
- targeted `flutter analyze --no-pub` clean

Closes #5