### PR TITLE
fix: complete Live2D stabilization acceptance

### DIFF
--- a/lib/domain/services/live2d_model_lifecycle_service.dart
+++ b/lib/domain/services/live2d_model_lifecycle_service.dart
@@ -37,11 +37,27 @@ class Live2DDeletionResult {
   });
 }
 
+class Live2DDeletionConfirmation {
+  final Live2DDeletionPlan _reviewedPlan;
+  final Object _issuer;
+  final Object _nonce;
+
+  const Live2DDeletionConfirmation._({
+    required Live2DDeletionPlan reviewedPlan,
+    required Object issuer,
+    required Object nonce,
+  })  : _reviewedPlan = reviewedPlan,
+        _issuer = issuer,
+        _nonce = nonce;
+}
+
 class Live2DModelLifecycleService {
   final CharacterRepository characterRepository;
   final Live2DImportService importService;
+  final Object _confirmationIssuer = Object();
+  final Set<Object> _pendingConfirmations = Set.identity();
 
-  const Live2DModelLifecycleService({
+  Live2DModelLifecycleService({
     required this.characterRepository,
     required this.importService,
   });
@@ -62,18 +78,32 @@ class Live2DModelLifecycleService {
     );
   }
 
+  Live2DDeletionConfirmation confirmDeletion(Live2DDeletionPlan reviewedPlan) {
+    final nonce = Object();
+    _pendingConfirmations.add(nonce);
+    return Live2DDeletionConfirmation._(
+      reviewedPlan: reviewedPlan,
+      issuer: _confirmationIssuer,
+      nonce: nonce,
+    );
+  }
+
   Future<Live2DDeletionResult> deleteImportedModel(
-    Live2DModelDefinition definition, {
-    Set<String>? confirmedCharacterIds,
-  }) async {
-    final plan = await planDeletion(definition);
-    if (confirmedCharacterIds != null) {
-      final currentIds = plan.affectedCharacters.map((c) => c.id).toSet();
-      if (!_sameSet(currentIds, confirmedCharacterIds)) {
-        throw const Live2DDeletionException(
-          'Model references changed. Review the affected characters again.',
-        );
-      }
+    Live2DDeletionConfirmation confirmation,
+  ) async {
+    if (!identical(confirmation._issuer, _confirmationIssuer) ||
+        !_pendingConfirmations.remove(confirmation._nonce)) {
+      throw const Live2DDeletionException(
+        'A fresh deletion confirmation is required.',
+      );
+    }
+
+    final reviewedPlan = confirmation._reviewedPlan;
+    final plan = await planDeletion(reviewedPlan.target);
+    if (!_samePlan(plan, reviewedPlan)) {
+      throw const Live2DDeletionException(
+        'Model references changed. Review the affected characters again.',
+      );
     }
 
     final changed = <Character>[];
@@ -90,7 +120,8 @@ class Live2DModelLifecycleService {
     }
 
     try {
-      final deletion = await importService.deleteImportedPackage(definition);
+      final deletion =
+          await importService.deleteImportedPackage(reviewedPlan.target);
       return Live2DDeletionResult(
         plan: plan,
         cleanupPending: deletion.cleanupPending,
@@ -149,7 +180,36 @@ class Live2DModelLifecycleService {
     }
   }
 
-  bool _sameSet(Set<String> left, Set<String> right) {
+  bool _samePlan(Live2DDeletionPlan current, Live2DDeletionPlan reviewed) {
+    return _sameDefinition(current.target, reviewed.target) &&
+        _sameSet(
+          current.packageModels.map(_definitionKey).toSet(),
+          reviewed.packageModels.map(_definitionKey).toSet(),
+        ) &&
+        _sameSet(
+          current.affectedCharacters.map((character) => character.id).toSet(),
+          reviewed.affectedCharacters.map((character) => character.id).toSet(),
+        );
+  }
+
+  bool _sameDefinition(
+    Live2DModelDefinition left,
+    Live2DModelDefinition right,
+  ) {
+    return _definitionKey(left) == _definitionKey(right);
+  }
+
+  String _definitionKey(Live2DModelDefinition definition) {
+    return [
+      definition.id,
+      definition.displayName,
+      p.normalize(definition.modelDirectory),
+      p.normalize(definition.modelFileName),
+      definition.source.name,
+    ].join('\u0000');
+  }
+
+  bool _sameSet<T>(Set<T> left, Set<T> right) {
     return left.length == right.length && left.containsAll(right);
   }
 }

--- a/lib/presentation/screens/chat/chat_screen.dart
+++ b/lib/presentation/screens/chat/chat_screen.dart
@@ -1231,6 +1231,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
           offsetX: live2d.offsetX,
           offsetY: live2d.offsetY,
         ),
+        resetOnDoubleTap: true,
         onTransformEnd: (transform) {
           unawaited(_saveLive2DTransform(character.id, transform));
         },

--- a/lib/presentation/screens/settings/live2d_settings_screen.dart
+++ b/lib/presentation/screens/settings/live2d_settings_screen.dart
@@ -206,10 +206,9 @@ class _Live2DSettingsEditorState extends ConsumerState<_Live2DSettingsEditor> {
         _error = null;
       });
 
+      final confirmation = lifecycle.confirmDeletion(plan);
       final result = await lifecycle.deleteImportedModel(
-        definition,
-        confirmedCharacterIds:
-            plan.affectedCharacters.map((character) => character.id).toSet(),
+        confirmation,
       );
       if (!mounted) return;
       final deletedModels = result.plan.packageModels;

--- a/lib/presentation/widgets/live2d/live2d_stage_gestures.dart
+++ b/lib/presentation/widgets/live2d/live2d_stage_gestures.dart
@@ -79,12 +79,14 @@ class Live2DTwoFingerGestureRegion extends StatefulWidget {
   final Live2DStageTransform initialTransform;
   final Live2DTransformBuilder builder;
   final ValueChanged<Live2DStageTransform>? onTransformEnd;
+  final bool resetOnDoubleTap;
 
   const Live2DTwoFingerGestureRegion({
     super.key,
     required this.initialTransform,
     required this.builder,
     this.onTransformEnd,
+    this.resetOnDoubleTap = false,
   });
 
   @override
@@ -179,6 +181,17 @@ class _Live2DTwoFingerGestureRegionState
     }
   }
 
+  void _handleDoubleTap() {
+    const reset = Live2DStageTransform(
+      scale: 1,
+      offsetX: 0,
+      offsetY: 0,
+    );
+    if (_transform == reset) return;
+    setState(() => _transform = reset);
+    widget.onTransformEnd?.call(reset);
+  }
+
   Offset _centroid(List<Offset> touches) {
     return Offset(
       touches.map((point) => point.dx).reduce((a, b) => a + b) / touches.length,
@@ -201,6 +214,12 @@ class _Live2DTwoFingerGestureRegionState
               ..onPointerEnd = _handlePointerEnd;
           },
         ),
+        if (widget.resetOnDoubleTap)
+          DoubleTapGestureRecognizer:
+              GestureRecognizerFactoryWithHandlers<DoubleTapGestureRecognizer>(
+            DoubleTapGestureRecognizer.new,
+            (recognizer) => recognizer.onDoubleTap = _handleDoubleTap,
+          ),
       },
       child: widget.builder(context, _transform),
     );

--- a/test/live2d_model_lifecycle_service_test.dart
+++ b/test/live2d_model_lifecycle_service_test.dart
@@ -73,9 +73,9 @@ void main() {
     expect(
         plan.affectedCharacters.map((character) => character.id), ['affected']);
 
+    final confirmation = lifecycle.confirmDeletion(plan);
     final result = await lifecycle.deleteImportedModel(
-      definition,
-      confirmedCharacterIds: {'affected'},
+      confirmation,
     );
 
     expect(result.plan.affectedCharacters, hasLength(1));
@@ -111,9 +111,11 @@ void main() {
       characterRepository: failingRepository,
       importService: importService,
     );
+    final plan = await lifecycle.planDeletion(definition);
+    final confirmation = lifecycle.confirmDeletion(plan);
 
     await expectLater(
-      lifecycle.deleteImportedModel(definition),
+      lifecycle.deleteImportedModel(confirmation),
       throwsA(isA<Live2DDeletionException>()),
     );
 
@@ -154,9 +156,9 @@ void main() {
     expect(plan.packageModels, hasLength(2));
     expect(plan.affectedCharacters.single.id, 'sibling-reference');
 
+    final confirmation = lifecycle.confirmDeletion(plan);
     await lifecycle.deleteImportedModel(
-      definitions.first,
-      confirmedCharacterIds: {'sibling-reference'},
+      confirmation,
     );
 
     expect(await importService.listImportedModels(), isEmpty);
@@ -170,6 +172,12 @@ void main() {
 
   test('changed references require a fresh confirmation', () async {
     final definition = await _importModel(tempDirectory, importService);
+    final lifecycle = Live2DModelLifecycleService(
+      characterRepository: characterRepository,
+      importService: importService,
+    );
+    final plan = await lifecycle.planDeletion(definition);
+    final confirmation = lifecycle.confirmDeletion(plan);
     final now = DateTime.now();
     await characterRepository.createCharacter(
       Character(
@@ -180,16 +188,9 @@ void main() {
         modifiedAt: now,
       ),
     );
-    final lifecycle = Live2DModelLifecycleService(
-      characterRepository: characterRepository,
-      importService: importService,
-    );
 
     await expectLater(
-      lifecycle.deleteImportedModel(
-        definition,
-        confirmedCharacterIds: const {},
-      ),
+      lifecycle.deleteImportedModel(confirmation),
       throwsA(isA<Live2DDeletionException>()),
     );
 
@@ -197,6 +198,43 @@ void main() {
     expect(
       (await characterRepository.getCharacter('new-reference'))?.assets?.live2d,
       isNotNull,
+    );
+  });
+
+  test('confirmation token is bound to the service that issued it', () async {
+    final definition = await _importModel(tempDirectory, importService);
+    final issuer = Live2DModelLifecycleService(
+      characterRepository: characterRepository,
+      importService: importService,
+    );
+    final otherService = Live2DModelLifecycleService(
+      characterRepository: characterRepository,
+      importService: importService,
+    );
+    final plan = await issuer.planDeletion(definition);
+    final confirmation = issuer.confirmDeletion(plan);
+
+    await expectLater(
+      otherService.deleteImportedModel(confirmation),
+      throwsA(isA<Live2DDeletionException>()),
+    );
+
+    expect(await importService.listImportedModels(), hasLength(1));
+  });
+
+  test('confirmation token can only be used once', () async {
+    final definition = await _importModel(tempDirectory, importService);
+    final lifecycle = Live2DModelLifecycleService(
+      characterRepository: characterRepository,
+      importService: importService,
+    );
+    final plan = await lifecycle.planDeletion(definition);
+    final confirmation = lifecycle.confirmDeletion(plan);
+
+    await lifecycle.deleteImportedModel(confirmation);
+    await expectLater(
+      lifecycle.deleteImportedModel(confirmation),
+      throwsA(isA<Live2DDeletionException>()),
     );
   });
 }

--- a/test/live2d_stage_gestures_test.dart
+++ b/test/live2d_stage_gestures_test.dart
@@ -75,6 +75,7 @@ void main() {
               offsetX: 0,
               offsetY: 0,
             ),
+            resetOnDoubleTap: true,
             onTransformEnd: completed.add,
             builder: (context, transform) => ListView(
               controller: scrollController,
@@ -90,6 +91,47 @@ void main() {
 
     expect(scrollController.offset, greaterThan(0));
     expect(completed, isEmpty);
+  });
+
+  testWidgets('double tap resets and persists the stage transform',
+      (tester) async {
+    final completed = <Live2DStageTransform>[];
+    Live2DStageTransform? displayed;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SizedBox(
+          width: 240,
+          height: 320,
+          child: Live2DTwoFingerGestureRegion(
+            initialTransform: const Live2DStageTransform(
+              scale: 2,
+              offsetX: 0.25,
+              offsetY: -0.5,
+            ),
+            resetOnDoubleTap: true,
+            onTransformEnd: completed.add,
+            builder: (context, transform) {
+              displayed = transform;
+              return const ColoredBox(
+                key: ValueKey('double-tap-surface'),
+                color: Colors.transparent,
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    final surface = find.byKey(const ValueKey('double-tap-surface'));
+    await tester.tap(surface);
+    await tester.pump(const Duration(milliseconds: 50));
+    await tester.tap(surface);
+    await tester.pump(const Duration(milliseconds: 500));
+
+    const reset = Live2DStageTransform(scale: 1, offsetX: 0, offsetY: 0);
+    expect(displayed, reset);
+    expect(completed, [reset]);
   });
 
   testWidgets('two fingers scale the stage and emit one completed transform',


### PR DESCRIPTION
## Summary

- enable double-tap reset in standard chat while retaining one-finger message scrolling and two-finger Live2D transforms
- require a one-time, service-bound confirmation token for imported-model deletion and invalidate stale reference/package reviews
- add widget and real SQLite/filesystem regression coverage

## Roadmap completion

- A01: completed; standard chat double-tap reset now persists through the existing transform callback, with scrolling and two-finger regression coverage
- A02: completed; model deletion now requires a typed confirmation token bound to the reviewed target, package contents, affected characters, and issuing service

## Verification

- flutter test test/live2d_stage_gestures_test.dart test/live2d_model_lifecycle_service_test.dart (12 passed)
- flutter test (136 passed)
- dart analyze on the five directly changed service/settings/gesture/test files (no issues)
- full flutter analyze remains non-zero on the repository baseline (1177 pre-existing findings); the added chat_screen line introduces no diagnostic

Closes #5