### PR TITLE
feat: add capability diagnostics and external call audit

### DIFF
--- a/lib/core/services/network_status_probe.dart
+++ b/lib/core/services/network_status_probe.dart
@@ -1,0 +1,6 @@
+import 'network_status_probe_stub.dart'
+    if (dart.library.io) 'network_status_probe_io.dart' as implementation;
+
+Future<bool?> probeLocalNetworkAvailability() {
+  return implementation.probeLocalNetworkAvailability();
+}

--- a/lib/core/services/network_status_probe_io.dart
+++ b/lib/core/services/network_status_probe_io.dart
@@ -1,0 +1,15 @@
+import 'dart:io';
+
+Future<bool?> probeLocalNetworkAvailability() async {
+  try {
+    final interfaces = await NetworkInterface.list(
+      includeLinkLocal: true,
+      includeLoopback: false,
+    );
+    return interfaces.any((interface) => interface.addresses.isNotEmpty);
+  } on SocketException {
+    return false;
+  } on UnsupportedError {
+    return null;
+  }
+}

--- a/lib/core/services/network_status_probe_stub.dart
+++ b/lib/core/services/network_status_probe_stub.dart
@@ -1,0 +1,1 @@
+Future<bool?> probeLocalNetworkAvailability() async => null;

--- a/lib/domain/services/capability_registry.dart
+++ b/lib/domain/services/capability_registry.dart
@@ -1,0 +1,305 @@
+enum CapabilityId {
+  llm,
+  systemTts,
+  systemStt,
+  embedding,
+  imageGeneration,
+  mcp,
+  live2d,
+}
+
+enum CapabilityRequirement {
+  builtIn,
+  currentAi,
+  permission,
+  download,
+  externalService,
+}
+
+enum CapabilityAvailability {
+  ready,
+  disabled,
+  needsConfiguration,
+  needsPermission,
+  permissionDenied,
+  needsDownload,
+  offline,
+  unsupported,
+}
+
+enum CapabilityPermissionState { notRequired, unknown, granted, denied }
+
+enum CapabilityNetworkState { unknown, online, offline }
+
+enum CapabilityFixKind { openSettings, requestPermission, retry }
+
+class CapabilityDescriptor {
+  final CapabilityId id;
+  final String name;
+  final String description;
+  final CapabilityRequirement requirement;
+  final String? settingsRoute;
+
+  const CapabilityDescriptor({
+    required this.id,
+    required this.name,
+    required this.description,
+    required this.requirement,
+    this.settingsRoute,
+  });
+}
+
+class CapabilityDiagnosticInput {
+  final CapabilityId id;
+  final bool enabled;
+  final bool configured;
+  final bool supported;
+  final bool downloaded;
+  final bool requiresNetwork;
+  final String? configurationIssue;
+
+  const CapabilityDiagnosticInput({
+    required this.id,
+    this.enabled = true,
+    this.configured = true,
+    this.supported = true,
+    this.downloaded = true,
+    this.requiresNetwork = false,
+    this.configurationIssue,
+  });
+}
+
+class CapabilityRuntimeSignals {
+  final CapabilityNetworkState network;
+  final Map<CapabilityId, CapabilityPermissionState> permissions;
+
+  const CapabilityRuntimeSignals({
+    this.network = CapabilityNetworkState.unknown,
+    this.permissions = const {},
+  });
+
+  CapabilityPermissionState permissionFor(CapabilityId id) {
+    return permissions[id] ?? CapabilityPermissionState.notRequired;
+  }
+}
+
+class CapabilityDiagnosticResult {
+  final CapabilityDescriptor capability;
+  final CapabilityAvailability availability;
+  final String message;
+  final CapabilityFixKind? fixKind;
+
+  const CapabilityDiagnosticResult({
+    required this.capability,
+    required this.availability,
+    required this.message,
+    this.fixKind,
+  });
+
+  bool get isReady => availability == CapabilityAvailability.ready;
+}
+
+class CapabilityDiagnosticReport {
+  final List<CapabilityDiagnosticResult> results;
+
+  const CapabilityDiagnosticReport(this.results);
+
+  int get readyCount => results.where((result) => result.isReady).length;
+  int get attentionCount => results.length - readyCount;
+
+  CapabilityDiagnosticResult resultFor(CapabilityId id) {
+    return results.firstWhere((result) => result.capability.id == id);
+  }
+}
+
+class CapabilityRegistry {
+  final Map<CapabilityId, CapabilityDescriptor> _capabilities;
+
+  CapabilityRegistry([Iterable<CapabilityDescriptor> capabilities = const []])
+      : _capabilities = {
+          for (final capability in capabilities) capability.id: capability,
+        } {
+    if (_capabilities.length != capabilities.length) {
+      throw ArgumentError('Capability IDs must be unique.');
+    }
+  }
+
+  factory CapabilityRegistry.nativeTavern() {
+    return CapabilityRegistry(const [
+      CapabilityDescriptor(
+        id: CapabilityId.llm,
+        name: 'Current AI',
+        description: 'Chat generation connection',
+        requirement: CapabilityRequirement.currentAi,
+        settingsRoute: '/ai-config',
+      ),
+      CapabilityDescriptor(
+        id: CapabilityId.systemTts,
+        name: 'System speech',
+        description: 'Device text-to-speech',
+        requirement: CapabilityRequirement.builtIn,
+        settingsRoute: '/tts-settings',
+      ),
+      CapabilityDescriptor(
+        id: CapabilityId.systemStt,
+        name: 'Voice input',
+        description: 'Device speech recognition',
+        requirement: CapabilityRequirement.permission,
+        settingsRoute: '/stt-settings',
+      ),
+      CapabilityDescriptor(
+        id: CapabilityId.embedding,
+        name: 'Semantic search',
+        description: 'Optional embedding connection',
+        requirement: CapabilityRequirement.externalService,
+        settingsRoute: '/vector-storage-settings',
+      ),
+      CapabilityDescriptor(
+        id: CapabilityId.imageGeneration,
+        name: 'Image generation',
+        description: 'Optional image connection',
+        requirement: CapabilityRequirement.externalService,
+        settingsRoute: '/image-gen-settings',
+      ),
+      CapabilityDescriptor(
+        id: CapabilityId.mcp,
+        name: 'MCP tools',
+        description: 'External tool servers',
+        requirement: CapabilityRequirement.externalService,
+      ),
+      CapabilityDescriptor(
+        id: CapabilityId.live2d,
+        name: 'Live2D',
+        description: 'Bundled character rendering',
+        requirement: CapabilityRequirement.builtIn,
+        settingsRoute: '/characters',
+      ),
+    ]);
+  }
+
+  List<CapabilityDescriptor> get capabilities =>
+      List.unmodifiable(_capabilities.values);
+
+  CapabilityDescriptor? find(CapabilityId id) => _capabilities[id];
+
+  CapabilityDiagnosticReport diagnose(
+    Iterable<CapabilityDiagnosticInput> inputs,
+    CapabilityRuntimeSignals signals,
+  ) {
+    final byId = {for (final input in inputs) input.id: input};
+    return CapabilityDiagnosticReport([
+      for (final descriptor in capabilities)
+        _diagnose(
+          descriptor,
+          byId[descriptor.id] ??
+              CapabilityDiagnosticInput(
+                id: descriptor.id,
+                configured: false,
+                supported: false,
+              ),
+          signals,
+        ),
+    ]);
+  }
+
+  CapabilityDiagnosticResult _diagnose(
+    CapabilityDescriptor descriptor,
+    CapabilityDiagnosticInput input,
+    CapabilityRuntimeSignals signals,
+  ) {
+    if (!input.supported) {
+      return _result(
+        descriptor,
+        CapabilityAvailability.unsupported,
+        'Not available in this build',
+      );
+    }
+    if (!input.enabled) {
+      return _result(
+        descriptor,
+        CapabilityAvailability.disabled,
+        'Off',
+        fixKind: descriptor.settingsRoute == null
+            ? null
+            : CapabilityFixKind.openSettings,
+      );
+    }
+
+    if (descriptor.requirement == CapabilityRequirement.permission) {
+      switch (signals.permissionFor(descriptor.id)) {
+        case CapabilityPermissionState.denied:
+          return _result(
+            descriptor,
+            CapabilityAvailability.permissionDenied,
+            'Permission denied',
+            fixKind: descriptor.settingsRoute == null
+                ? null
+                : CapabilityFixKind.openSettings,
+          );
+        case CapabilityPermissionState.unknown:
+          return _result(
+            descriptor,
+            CapabilityAvailability.needsPermission,
+            'Permission required',
+            fixKind: CapabilityFixKind.requestPermission,
+          );
+        case CapabilityPermissionState.granted:
+        case CapabilityPermissionState.notRequired:
+          break;
+      }
+    }
+
+    if (descriptor.requirement == CapabilityRequirement.download &&
+        !input.downloaded) {
+      return _result(
+        descriptor,
+        CapabilityAvailability.needsDownload,
+        'Download required',
+        fixKind: descriptor.settingsRoute == null
+            ? null
+            : CapabilityFixKind.openSettings,
+      );
+    }
+
+    if (!input.configured) {
+      return _result(
+        descriptor,
+        CapabilityAvailability.needsConfiguration,
+        input.configurationIssue ?? 'Configuration required',
+        fixKind: descriptor.settingsRoute == null
+            ? null
+            : CapabilityFixKind.openSettings,
+      );
+    }
+
+    if (input.requiresNetwork &&
+        signals.network == CapabilityNetworkState.offline) {
+      return _result(
+        descriptor,
+        CapabilityAvailability.offline,
+        'Unavailable while offline',
+        fixKind: CapabilityFixKind.retry,
+      );
+    }
+
+    return _result(
+      descriptor,
+      CapabilityAvailability.ready,
+      input.requiresNetwork ? 'Configured' : 'Available',
+    );
+  }
+
+  CapabilityDiagnosticResult _result(
+    CapabilityDescriptor capability,
+    CapabilityAvailability availability,
+    String message, {
+    CapabilityFixKind? fixKind,
+  }) {
+    return CapabilityDiagnosticResult(
+      capability: capability,
+      availability: availability,
+      message: message,
+      fixKind: fixKind,
+    );
+  }
+}

--- a/lib/domain/services/embedding_service.dart
+++ b/lib/domain/services/embedding_service.dart
@@ -1,5 +1,6 @@
 import 'package:dio/dio.dart';
 import 'package:native_tavern/data/models/vector_storage.dart';
+import 'package:native_tavern/domain/services/external_call_audit_service.dart';
 
 /// Generates text embeddings for RAG / vector storage.
 ///
@@ -8,7 +9,20 @@ import 'package:native_tavern/data/models/vector_storage.dart';
 class EmbeddingService {
   final Dio _dio;
 
-  EmbeddingService({Dio? dio}) : _dio = dio ?? Dio();
+  EmbeddingService({
+    Dio? dio,
+    ExternalCallAuditRepository auditRepository =
+        const NoopExternalCallAuditRepository(),
+  }) : _dio = dio ?? Dio() {
+    _dio.interceptors.add(ExternalCallAuditInterceptor(
+      repository: auditRepository,
+      capabilityId: 'embedding',
+      classifyData: (request) => metadataForGet(
+        request,
+        const {ExternalDataType.documentText},
+      ),
+    ));
+  }
 
   /// Embed a single text
   Future<List<double>> embed(

--- a/lib/domain/services/external_call_audit_service.dart
+++ b/lib/domain/services/external_call_audit_service.dart
@@ -1,0 +1,291 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:path/path.dart' as p;
+
+enum ExternalDataType {
+  metadata,
+  prompt,
+  chatText,
+  documentText,
+  image,
+  audio,
+  characterCard,
+  toolArguments,
+}
+
+enum ExternalCallOutcome { succeeded, failed, cancelled }
+
+enum ExternalCostAttribution { userServiceAccount, noExternalCharge, unknown }
+
+class ExternalCallAuditRecord {
+  final DateTime timestamp;
+  final String targetDomain;
+  final String capabilityId;
+  final Set<ExternalDataType> dataTypes;
+  final ExternalCallOutcome outcome;
+  final ExternalCostAttribution costAttribution;
+  final int? statusCode;
+  final int durationMilliseconds;
+
+  const ExternalCallAuditRecord({
+    required this.timestamp,
+    required this.targetDomain,
+    required this.capabilityId,
+    required this.dataTypes,
+    required this.outcome,
+    required this.costAttribution,
+    this.statusCode,
+    this.durationMilliseconds = 0,
+  });
+
+  factory ExternalCallAuditRecord.forRequest({
+    required Uri requestUri,
+    required String capabilityId,
+    required Set<ExternalDataType> dataTypes,
+    required ExternalCallOutcome outcome,
+    required ExternalCostAttribution costAttribution,
+    int? statusCode,
+    int durationMilliseconds = 0,
+    DateTime? timestamp,
+  }) {
+    return ExternalCallAuditRecord(
+      timestamp: timestamp ?? DateTime.now().toUtc(),
+      targetDomain: _targetDomain(requestUri),
+      capabilityId: capabilityId,
+      dataTypes: Set.unmodifiable(dataTypes),
+      outcome: outcome,
+      costAttribution: costAttribution,
+      statusCode: statusCode,
+      durationMilliseconds: durationMilliseconds,
+    );
+  }
+
+  factory ExternalCallAuditRecord.fromJson(Map<String, dynamic> json) {
+    return ExternalCallAuditRecord(
+      timestamp: DateTime.parse(json['timestamp'] as String),
+      targetDomain: json['targetDomain'] as String,
+      capabilityId: json['capabilityId'] as String,
+      dataTypes: (json['dataTypes'] as List<dynamic>? ?? const [])
+          .whereType<String>()
+          .map(
+            (value) => ExternalDataType.values.firstWhere(
+              (candidate) => candidate.name == value,
+            ),
+          )
+          .toSet(),
+      outcome: ExternalCallOutcome.values.firstWhere(
+        (candidate) => candidate.name == json['outcome'],
+      ),
+      costAttribution: ExternalCostAttribution.values.firstWhere(
+        (candidate) => candidate.name == json['costAttribution'],
+      ),
+      statusCode: json['statusCode'] as int?,
+      durationMilliseconds: json['durationMilliseconds'] as int? ?? 0,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'timestamp': timestamp.toUtc().toIso8601String(),
+        'targetDomain': targetDomain,
+        'capabilityId': capabilityId,
+        'dataTypes': dataTypes.map((type) => type.name).toList()..sort(),
+        'outcome': outcome.name,
+        'costAttribution': costAttribution.name,
+        'statusCode': statusCode,
+        'durationMilliseconds': durationMilliseconds,
+      };
+
+  static String _targetDomain(Uri uri) {
+    if (uri.host.isEmpty) return 'local';
+    final host = uri.host.toLowerCase();
+    return uri.hasPort ? '$host:${uri.port}' : host;
+  }
+}
+
+abstract class ExternalCallAuditRepository {
+  Future<void> record(ExternalCallAuditRecord record);
+
+  Future<List<ExternalCallAuditRecord>> readRecent({int limit = 100});
+}
+
+class NoopExternalCallAuditRepository implements ExternalCallAuditRepository {
+  const NoopExternalCallAuditRepository();
+
+  @override
+  Future<void> record(ExternalCallAuditRecord record) async {}
+
+  @override
+  Future<List<ExternalCallAuditRecord>> readRecent({int limit = 100}) async {
+    return const [];
+  }
+}
+
+class MemoryExternalCallAuditRepository implements ExternalCallAuditRepository {
+  final List<ExternalCallAuditRecord> _records = [];
+
+  @override
+  Future<void> record(ExternalCallAuditRecord record) async {
+    _records.add(record);
+  }
+
+  @override
+  Future<List<ExternalCallAuditRecord>> readRecent({int limit = 100}) async {
+    final start = (_records.length - limit).clamp(0, _records.length);
+    return _records.sublist(start).reversed.toList(growable: false);
+  }
+}
+
+class FileExternalCallAuditRepository implements ExternalCallAuditRepository {
+  static const _relativePath = 'audit/external_calls.jsonl';
+
+  final String dataPath;
+  Future<void> _writeTail = Future.value();
+
+  FileExternalCallAuditRepository({required this.dataPath});
+
+  File get _file => File(p.join(dataPath, _relativePath));
+
+  @override
+  Future<void> record(ExternalCallAuditRecord record) {
+    final operation = _writeTail.then((_) async {
+      final file = _file;
+      await file.parent.create(recursive: true);
+      await file.writeAsString(
+        '${jsonEncode(record.toJson())}\n',
+        mode: FileMode.append,
+        flush: true,
+      );
+    });
+    _writeTail = operation.catchError((_) {});
+    return operation;
+  }
+
+  @override
+  Future<List<ExternalCallAuditRecord>> readRecent({int limit = 100}) async {
+    if (limit <= 0) return const [];
+    await _writeTail;
+    final file = _file;
+    if (!file.existsSync()) return const [];
+
+    final lines = await file.readAsLines();
+    final records = <ExternalCallAuditRecord>[];
+    for (final line in lines.reversed) {
+      if (records.length >= limit) break;
+      if (line.trim().isEmpty) continue;
+      try {
+        records.add(
+          ExternalCallAuditRecord.fromJson(
+            jsonDecode(line) as Map<String, dynamic>,
+          ),
+        );
+      } on FormatException {
+        continue;
+      } on TypeError {
+        continue;
+      } on StateError {
+        continue;
+      }
+    }
+    return records;
+  }
+}
+
+typedef ExternalDataClassifier = Set<ExternalDataType> Function(
+    RequestOptions request);
+
+class ExternalCallAuditInterceptor extends Interceptor {
+  static const _startKey = 'nativeTavernAuditStartedAt';
+
+  final ExternalCallAuditRepository repository;
+  final String capabilityId;
+  final ExternalCostAttribution costAttribution;
+  final ExternalDataClassifier classifyData;
+  final DateTime Function() _clock;
+
+  ExternalCallAuditInterceptor({
+    required this.repository,
+    required this.capabilityId,
+    required this.classifyData,
+    this.costAttribution = ExternalCostAttribution.userServiceAccount,
+    DateTime Function()? clock,
+  }) : _clock = clock ?? DateTime.now;
+
+  @override
+  void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
+    options.extra[_startKey] = _clock().toUtc().toIso8601String();
+    handler.next(options);
+  }
+
+  @override
+  void onResponse(
+    Response<dynamic> response,
+    ResponseInterceptorHandler handler,
+  ) {
+    _record(
+      response.requestOptions,
+      outcome: ExternalCallOutcome.succeeded,
+      statusCode: response.statusCode,
+    );
+    handler.next(response);
+  }
+
+  @override
+  void onError(DioException err, ErrorInterceptorHandler handler) {
+    _record(
+      err.requestOptions,
+      outcome: err.type == DioExceptionType.cancel
+          ? ExternalCallOutcome.cancelled
+          : ExternalCallOutcome.failed,
+      statusCode: err.response?.statusCode,
+    );
+    handler.next(err);
+  }
+
+  void _record(
+    RequestOptions request, {
+    required ExternalCallOutcome outcome,
+    int? statusCode,
+  }) {
+    final now = _clock().toUtc();
+    final startedAt = DateTime.tryParse(
+      request.extra[_startKey] as String? ?? '',
+    );
+    final duration = startedAt == null
+        ? 0
+        : now.difference(startedAt).inMilliseconds.clamp(0, 1 << 31);
+
+    final record = ExternalCallAuditRecord.forRequest(
+      requestUri: request.uri,
+      capabilityId: capabilityId,
+      dataTypes: classifyData(request),
+      outcome: outcome,
+      costAttribution: _isLocalRequest(request.uri)
+          ? ExternalCostAttribution.noExternalCharge
+          : costAttribution,
+      statusCode: statusCode,
+      durationMilliseconds: duration,
+      timestamp: now,
+    );
+    unawaited(repository.record(record).catchError((_) {}));
+  }
+
+  bool _isLocalRequest(Uri uri) {
+    final host = uri.host.toLowerCase();
+    return host == 'localhost' ||
+        host == '127.0.0.1' ||
+        host == '::1' ||
+        host.endsWith('.local');
+  }
+}
+
+Set<ExternalDataType> metadataForGet(
+  RequestOptions request,
+  Set<ExternalDataType> transmittedData,
+) {
+  return request.method.toUpperCase() == 'GET'
+      ? const {ExternalDataType.metadata}
+      : transmittedData;
+}

--- a/lib/domain/services/image_generation_service.dart
+++ b/lib/domain/services/image_generation_service.dart
@@ -3,6 +3,7 @@ import 'dart:math' as math;
 import 'package:flutter/foundation.dart';
 import 'package:dio/dio.dart';
 import 'package:archive/archive.dart';
+import 'package:native_tavern/domain/services/external_call_audit_service.dart';
 
 /// Image Generation Provider types (channels, not models)
 enum ImageGenProvider {
@@ -533,7 +534,28 @@ class ImageAspectRatio {
 /// Image Generation Service
 class ImageGenerationService {
   ImageGenSettings _settings = const ImageGenSettings();
-  final Dio _dio = Dio();
+  final Dio _dio;
+
+  ImageGenerationService({
+    Dio? dio,
+    ExternalCallAuditRepository auditRepository =
+        const NoopExternalCallAuditRepository(),
+  }) : _dio = dio ?? Dio() {
+    _dio.interceptors.add(ExternalCallAuditInterceptor(
+      repository: auditRepository,
+      capabilityId: 'imageGeneration',
+      classifyData: (request) {
+        if (request.method.toUpperCase() == 'GET' &&
+            (request.uri.path.contains('models') ||
+                request.uri.path.contains('object_info'))) {
+          return const {ExternalDataType.metadata};
+        }
+        return request.method.toUpperCase() == 'GET'
+            ? const {ExternalDataType.image}
+            : const {ExternalDataType.prompt, ExternalDataType.image};
+      },
+    ));
+  }
 
   /// Callbacks
   void Function(double)? onProgress;

--- a/lib/domain/services/llm_service.dart
+++ b/lib/domain/services/llm_service.dart
@@ -4,6 +4,7 @@ import 'dart:developer' as developer;
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:native_tavern/domain/services/context_window_service.dart';
+import 'package:native_tavern/domain/services/external_call_audit_service.dart';
 
 /// LLM Provider enum
 enum LLMProvider {
@@ -409,8 +410,23 @@ class LLMConfig {
 
 /// LLM Service for generating responses
 class LLMService {
-  final Dio _dio = Dio();
+  final Dio _dio;
   final ContextWindowService _contextWindowService = ContextWindowService();
+
+  LLMService({
+    Dio? dio,
+    ExternalCallAuditRepository auditRepository =
+        const NoopExternalCallAuditRepository(),
+  }) : _dio = dio ?? Dio() {
+    _dio.interceptors.add(ExternalCallAuditInterceptor(
+      repository: auditRepository,
+      capabilityId: 'llm',
+      classifyData: (request) => metadataForGet(
+        request,
+        const {ExternalDataType.prompt, ExternalDataType.chatText},
+      ),
+    ));
+  }
 
   /// Token for the in-flight request so cancellation actually aborts the
   /// HTTP connection (stops server-side generation/billing) instead of

--- a/lib/domain/services/stt_service.dart
+++ b/lib/domain/services/stt_service.dart
@@ -148,6 +148,7 @@ class STTResult {
 class STTService {
   bool _isInitialized = false;
   bool _isListening = false;
+  bool _permissionRequestAttempted = false;
   STTSettings _settings = const STTSettings();
 
   /// Platform speech recognition engine
@@ -161,13 +162,17 @@ class STTService {
 
   bool get isInitialized => _isInitialized;
   bool get isListening => _isListening;
+  bool get permissionRequestAttempted => _permissionRequestAttempted;
   STTSettings get settings => _settings;
+
+  Future<bool> hasPermission() => _speech.hasPermission;
 
   /// Initialize the STT service (requests microphone permission)
   Future<void> initialize() async {
     if (_isInitialized) return;
 
     try {
+      _permissionRequestAttempted = true;
       _isInitialized = await _speech.initialize(
         onError: (SpeechRecognitionError error) {
           _isListening = false;

--- a/lib/domain/services/tts_service.dart
+++ b/lib/domain/services/tts_service.dart
@@ -6,6 +6,7 @@ import 'package:flutter_tts/flutter_tts.dart';
 import 'package:just_audio/just_audio.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
+import 'package:native_tavern/domain/services/external_call_audit_service.dart';
 
 /// TTS Provider types
 enum TTSProvider {
@@ -201,6 +202,22 @@ class TTSService {
 
   /// Player for remote-synthesized audio
   final AudioPlayer _audioPlayer = AudioPlayer();
+  final Dio _dio;
+
+  TTSService({
+    Dio? dio,
+    ExternalCallAuditRepository auditRepository =
+        const NoopExternalCallAuditRepository(),
+  }) : _dio = dio ?? Dio() {
+    _dio.interceptors.add(ExternalCallAuditInterceptor(
+      repository: auditRepository,
+      capabilityId: 'tts',
+      classifyData: (request) => const {
+        ExternalDataType.chatText,
+        ExternalDataType.audio,
+      },
+    ));
+  }
 
   /// Available voices (populated after initialization)
   List<TTSVoice> _availableVoices = [];
@@ -491,8 +508,6 @@ class TTSService {
   }
 
   // ==================== Remote synthesis ====================
-
-  final Dio _dio = Dio();
 
   /// Synthesize [text] to audio bytes with the configured remote provider.
   /// Returns null for providers without a remote API (system TTS).

--- a/lib/domain/services/url_import_service.dart
+++ b/lib/domain/services/url_import_service.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 import 'package:dio/dio.dart';
 import 'package:native_tavern/domain/services/import_service.dart';
 import 'package:native_tavern/data/models/character.dart';
+import 'package:native_tavern/domain/services/external_call_audit_service.dart';
 
 enum UrlSource {
   nativeTavern,
@@ -32,14 +33,28 @@ class UrlImportService {
   final ImportService _importService;
   final Dio _dio;
 
-  UrlImportService(this._importService, {Dio? dio})
+  UrlImportService(
+    this._importService, {
+    Dio? dio,
+    ExternalCallAuditRepository auditRepository =
+        const NoopExternalCallAuditRepository(),
+  })
       : _dio = dio ?? Dio(BaseOptions(
           connectTimeout: const Duration(seconds: 30),
           receiveTimeout: const Duration(seconds: 60),
           headers: {
             'User-Agent': 'NativeTavern/1.0',
           },
-        ));
+        )) {
+    _dio.interceptors.add(ExternalCallAuditInterceptor(
+      repository: auditRepository,
+      capabilityId: 'characterImport',
+      classifyData: (request) => const {
+        ExternalDataType.metadata,
+        ExternalDataType.characterCard,
+      },
+    ));
+  }
 
   UrlSource identifySource(String url) {
     final uri = Uri.tryParse(url.trim());

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,8 @@ import 'package:native_tavern/data/repositories/chat_repository.dart';
 import 'package:native_tavern/data/repositories/world_info_repository.dart';
 import 'package:native_tavern/domain/services/llm_service.dart';
 import 'package:native_tavern/domain/services/import_service.dart';
+import 'package:native_tavern/domain/services/external_call_audit_service.dart';
+import 'package:native_tavern/presentation/providers/external_call_audit_providers.dart';
 import 'package:native_tavern/presentation/providers/settings_providers.dart';
 import 'package:native_tavern/presentation/screens/import/import_screen.dart';
 
@@ -27,7 +29,10 @@ void main() async {
   final worldInfoRepo = WorldInfoRepository(database);
 
   // Create services
-  final llmService = LLMService();
+  final externalCallAudit = FileExternalCallAuditRepository(
+    dataPath: initData.dataPath,
+  );
+  final llmService = LLMService(auditRepository: externalCallAudit);
   final importService = ImportService(initData.dataPath);
 
   runApp(
@@ -45,6 +50,9 @@ void main() async {
         // Services
         llmServiceProvider.overrideWithValue(llmService),
         importServiceProvider.overrideWithValue(importService),
+        externalCallAuditRepositoryProvider.overrideWithValue(
+          externalCallAudit,
+        ),
 
         // Shared preferences
         sharedPreferencesProvider.overrideWithValue(prefs),

--- a/lib/presentation/providers/capability_providers.dart
+++ b/lib/presentation/providers/capability_providers.dart
@@ -1,0 +1,176 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:native_tavern/core/services/network_status_probe.dart';
+import 'package:native_tavern/data/models/vector_storage.dart';
+import 'package:native_tavern/domain/services/capability_registry.dart';
+import 'package:native_tavern/domain/services/image_generation_service.dart';
+import 'package:native_tavern/domain/services/llm_service.dart';
+import 'package:native_tavern/domain/services/stt_service.dart';
+import 'package:native_tavern/domain/services/tts_service.dart';
+import 'package:native_tavern/presentation/providers/image_gen_providers.dart';
+import 'package:native_tavern/presentation/providers/settings_providers.dart';
+import 'package:native_tavern/presentation/providers/stt_providers.dart';
+import 'package:native_tavern/presentation/providers/tts_providers.dart';
+import 'package:native_tavern/presentation/providers/vector_storage_providers.dart';
+
+final capabilityRegistryProvider = Provider<CapabilityRegistry>((ref) {
+  return CapabilityRegistry.nativeTavern();
+});
+
+final localNetworkProbeProvider = Provider<Future<bool?> Function()>((ref) {
+  return probeLocalNetworkAvailability;
+});
+
+final microphonePermissionProbeProvider =
+    Provider<Future<CapabilityPermissionState> Function()>((ref) {
+  final service = ref.watch(sttServiceProvider);
+  return () async {
+    try {
+      if (await service.hasPermission()) {
+        return CapabilityPermissionState.granted;
+      }
+      return service.permissionRequestAttempted
+          ? CapabilityPermissionState.denied
+          : CapabilityPermissionState.unknown;
+    } catch (_) {
+      return CapabilityPermissionState.unknown;
+    }
+  };
+});
+
+final capabilityRuntimeSignalsProvider =
+    FutureProvider<CapabilityRuntimeSignals>((ref) async {
+  final sttSettings = ref.watch(sttSettingsProvider);
+  final networkResult = await ref.watch(localNetworkProbeProvider)();
+  final network = switch (networkResult) {
+    true => CapabilityNetworkState.online,
+    false => CapabilityNetworkState.offline,
+    null => CapabilityNetworkState.unknown,
+  };
+
+  var microphonePermission = CapabilityPermissionState.notRequired;
+  if (sttSettings.enabled && sttSettings.provider == STTProvider.system) {
+    microphonePermission = await ref.watch(
+      microphonePermissionProbeProvider,
+    )();
+  }
+
+  return CapabilityRuntimeSignals(
+    network: network,
+    permissions: {CapabilityId.systemStt: microphonePermission},
+  );
+});
+
+final capabilityDiagnosticInputsProvider =
+    Provider<List<CapabilityDiagnosticInput>>((ref) {
+  return CapabilityInputFactory.create(
+    llm: ref.watch(llmConfigProvider),
+    tts: ref.watch(ttsSettingsProvider),
+    stt: ref.watch(sttSettingsProvider),
+    vector: ref.watch(vectorStorageSettingsProvider),
+    image: ref.watch(imageGenSettingsProvider),
+  );
+});
+
+final capabilityDiagnosticsProvider =
+    Provider<AsyncValue<CapabilityDiagnosticReport>>((ref) {
+  final registry = ref.watch(capabilityRegistryProvider);
+  final inputs = ref.watch(capabilityDiagnosticInputsProvider);
+  return ref
+      .watch(capabilityRuntimeSignalsProvider)
+      .whenData((signals) => registry.diagnose(inputs, signals));
+});
+
+abstract class CapabilityInputFactory {
+  static List<CapabilityDiagnosticInput> create({
+    required LLMConfig llm,
+    required TTSSettings tts,
+    required STTSettings stt,
+    required VectorStorageSettings vector,
+    required ImageGenSettings image,
+  }) {
+    final llmLocalProvider = llm.provider == LLMProvider.ollama ||
+        llm.provider == LLMProvider.koboldCpp;
+    final llmNeedsKey =
+        !llmLocalProvider && llm.provider != LLMProvider.openAICompatible;
+    final llmNeedsModel = llm.provider != LLMProvider.koboldCpp;
+    final llmConfigured = _validHttpEndpoint(llm.apiUrl) &&
+        (!llmNeedsModel || llm.model.trim().isNotEmpty) &&
+        (!llmNeedsKey || llm.apiKey.trim().isNotEmpty);
+
+    final vectorKeyRequired = {
+      EmbeddingProvider.openai,
+      EmbeddingProvider.cohere,
+      EmbeddingProvider.gemini,
+      EmbeddingProvider.siliconflow,
+    }.contains(vector.embeddingProvider);
+    final vectorEndpoint = vector.embeddingEndpoint?.trim().isNotEmpty == true
+        ? vector.embeddingEndpoint!
+        : vector.embeddingProvider.defaultEndpoint;
+    final vectorConfigured = _validHttpEndpoint(vectorEndpoint) &&
+        (!vectorKeyRequired ||
+            vector.embeddingApiKey?.trim().isNotEmpty == true);
+
+    final imageConfigured = _validHttpEndpoint(image.effectiveEndpoint) &&
+        (!image.provider.requiresApiKey ||
+            image.apiKey?.trim().isNotEmpty == true) &&
+        (image.provider.isLocalProvider || image.model.trim().isNotEmpty);
+
+    return [
+      CapabilityDiagnosticInput(
+        id: CapabilityId.llm,
+        configured: llmConfigured,
+        requiresNetwork: !llmLocalProvider && !_isLocalEndpoint(llm.apiUrl),
+        configurationIssue:
+            llmConfigured ? null : 'Complete the current AI connection',
+      ),
+      CapabilityDiagnosticInput(
+        id: CapabilityId.systemTts,
+        enabled: tts.enabled && tts.provider == TTSProvider.system,
+      ),
+      CapabilityDiagnosticInput(
+        id: CapabilityId.systemStt,
+        enabled: stt.enabled && stt.provider == STTProvider.system,
+      ),
+      CapabilityDiagnosticInput(
+        id: CapabilityId.embedding,
+        enabled: vector.enabled,
+        supported: vector.embeddingProvider != EmbeddingProvider.local,
+        configured: vectorConfigured,
+        requiresNetwork: vector.embeddingProvider != EmbeddingProvider.ollama &&
+            !_isLocalEndpoint(vectorEndpoint),
+        configurationIssue:
+            vectorConfigured ? null : 'Complete the embedding connection',
+      ),
+      CapabilityDiagnosticInput(
+        id: CapabilityId.imageGeneration,
+        enabled: image.enabled,
+        configured: imageConfigured,
+        requiresNetwork: !image.provider.isLocalProvider &&
+            !_isLocalEndpoint(image.effectiveEndpoint),
+        configurationIssue:
+            imageConfigured ? null : 'Complete the image connection',
+      ),
+      const CapabilityDiagnosticInput(
+        id: CapabilityId.mcp,
+        configured: false,
+        supported: false,
+      ),
+      const CapabilityDiagnosticInput(id: CapabilityId.live2d),
+    ];
+  }
+
+  static bool _validHttpEndpoint(String value) {
+    final uri = Uri.tryParse(value.trim());
+    return uri != null &&
+        (uri.scheme == 'http' || uri.scheme == 'https') &&
+        uri.host.isNotEmpty;
+  }
+
+  static bool _isLocalEndpoint(String value) {
+    final host = Uri.tryParse(value.trim())?.host.toLowerCase();
+    return host == 'localhost' ||
+        host == '127.0.0.1' ||
+        host == '::1' ||
+        host?.endsWith('.local') == true;
+  }
+}

--- a/lib/presentation/providers/external_call_audit_providers.dart
+++ b/lib/presentation/providers/external_call_audit_providers.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:native_tavern/core/services/initialization_service.dart';
+import 'package:native_tavern/domain/services/external_call_audit_service.dart';
+
+final externalCallAuditRepositoryProvider =
+    Provider<ExternalCallAuditRepository>((ref) {
+  return FileExternalCallAuditRepository(
+    dataPath: ref.watch(dataPathProvider),
+  );
+});
+
+final recentExternalCallsProvider =
+    FutureProvider<List<ExternalCallAuditRecord>>((ref) {
+  return ref.watch(externalCallAuditRepositoryProvider).readRecent(limit: 20);
+});

--- a/lib/presentation/providers/image_gen_providers.dart
+++ b/lib/presentation/providers/image_gen_providers.dart
@@ -3,10 +3,13 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:native_tavern/domain/services/image_generation_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:native_tavern/presentation/providers/external_call_audit_providers.dart';
 
 /// Provider for image generation service
 final imageGenServiceProvider = Provider<ImageGenerationService>((ref) {
-  final service = ImageGenerationService();
+  final service = ImageGenerationService(
+    auditRepository: ref.watch(externalCallAuditRepositoryProvider),
+  );
   ref.onDispose(() => service.dispose());
   return service;
 });

--- a/lib/presentation/providers/tts_providers.dart
+++ b/lib/presentation/providers/tts_providers.dart
@@ -2,10 +2,13 @@ import 'dart:convert';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:native_tavern/domain/services/tts_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:native_tavern/presentation/providers/external_call_audit_providers.dart';
 
 /// Provider for TTS service
 final ttsServiceProvider = Provider<TTSService>((ref) {
-  final service = TTSService();
+  final service = TTSService(
+    auditRepository: ref.watch(externalCallAuditRepositoryProvider),
+  );
   ref.onDispose(() => service.dispose());
   return service;
 });

--- a/lib/presentation/providers/vector_storage_providers.dart
+++ b/lib/presentation/providers/vector_storage_providers.dart
@@ -3,6 +3,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:native_tavern/data/models/vector_storage.dart';
 import 'package:native_tavern/domain/services/embedding_service.dart';
 import 'package:native_tavern/domain/services/vector_storage_service.dart';
+import 'package:native_tavern/presentation/providers/external_call_audit_providers.dart';
 
 /// Provider for VectorStorageService (loads persisted collections)
 final vectorStorageServiceProvider = Provider<VectorStorageService>((ref) {
@@ -13,7 +14,9 @@ final vectorStorageServiceProvider = Provider<VectorStorageService>((ref) {
 
 /// Provider for EmbeddingService
 final embeddingServiceProvider = Provider<EmbeddingService>((ref) {
-  return EmbeddingService();
+  return EmbeddingService(
+    auditRepository: ref.watch(externalCallAuditRepositoryProvider),
+  );
 });
 
 /// Provider for vector storage settings

--- a/lib/presentation/router/app_router.dart
+++ b/lib/presentation/router/app_router.dart
@@ -28,6 +28,7 @@ import 'package:native_tavern/presentation/screens/settings/logit_bias_settings_
 import 'package:native_tavern/presentation/screens/settings/cfg_scale_settings_screen.dart';
 import 'package:native_tavern/presentation/screens/settings/tokenizer_settings_screen.dart';
 import 'package:native_tavern/presentation/screens/settings/vector_storage_settings_screen.dart';
+import 'package:native_tavern/presentation/screens/settings/capability_diagnostics_screen.dart';
 import 'package:native_tavern/presentation/widgets/chat/logprobs_panel.dart';
 import 'package:native_tavern/presentation/screens/ai_config/ai_config_screen.dart';
 import 'package:native_tavern/presentation/screens/import/import_screen.dart';
@@ -78,6 +79,7 @@ abstract class AppRoutes {
   static const logprobsSettings = '/logprobs-settings';
   static const tokenizerSettings = '/tokenizer-settings';
   static const vectorStorageSettings = '/vector-storage-settings';
+  static const capabilityDiagnostics = '/capability-diagnostics';
 }
 
 /// Navigation keys for nested navigation
@@ -365,6 +367,12 @@ final appRouterProvider = Provider<GoRouter>((ref) {
         name: 'vectorStorageSettings',
         parentNavigatorKey: _rootNavigatorKey,
         builder: (context, state) => const VectorStorageSettingsScreen(),
+      ),
+      GoRoute(
+        path: AppRoutes.capabilityDiagnostics,
+        name: 'capabilityDiagnostics',
+        parentNavigatorKey: _rootNavigatorKey,
+        builder: (context, state) => const CapabilityDiagnosticsScreen(),
       ),
     ],
     errorBuilder: (context, state) => Scaffold(

--- a/lib/presentation/screens/import/import_screen.dart
+++ b/lib/presentation/screens/import/import_screen.dart
@@ -14,6 +14,7 @@ import 'package:native_tavern/domain/services/character_regex_import_service.dar
 import 'package:native_tavern/domain/services/url_import_service.dart';
 import 'package:native_tavern/presentation/providers/character_providers.dart';
 import 'package:native_tavern/presentation/providers/regex_providers.dart';
+import 'package:native_tavern/presentation/providers/external_call_audit_providers.dart';
 import 'package:native_tavern/presentation/theme/app_theme.dart';
 import 'package:native_tavern/l10n/generated/app_localizations.dart';
 
@@ -25,7 +26,10 @@ final importServiceProvider = Provider<ImportService>((ref) {
 /// URL import service provider
 final urlImportServiceProvider = Provider<UrlImportService>((ref) {
   final importService = ref.watch(importServiceProvider);
-  return UrlImportService(importService);
+  return UrlImportService(
+    importService,
+    auditRepository: ref.watch(externalCallAuditRepositoryProvider),
+  );
 });
 
 /// Import result for a single file or URL

--- a/lib/presentation/screens/settings/capability_diagnostics_screen.dart
+++ b/lib/presentation/screens/settings/capability_diagnostics_screen.dart
@@ -1,0 +1,276 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:native_tavern/domain/services/capability_registry.dart';
+import 'package:native_tavern/domain/services/external_call_audit_service.dart';
+import 'package:native_tavern/presentation/providers/capability_providers.dart';
+import 'package:native_tavern/presentation/providers/external_call_audit_providers.dart';
+import 'package:native_tavern/presentation/providers/stt_providers.dart';
+
+class CapabilityDiagnosticsScreen extends ConsumerWidget {
+  const CapabilityDiagnosticsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final diagnostics = ref.watch(capabilityDiagnosticsProvider);
+    final externalCalls = ref.watch(recentExternalCallsProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Capability check'),
+        actions: [
+          IconButton(
+            tooltip: 'Refresh',
+            icon: const Icon(Icons.refresh),
+            onPressed: () => _refresh(ref),
+          ),
+        ],
+      ),
+      body: RefreshIndicator(
+        onRefresh: () async => _refresh(ref),
+        child: ListView(
+          physics: const AlwaysScrollableScrollPhysics(),
+          children: [
+            diagnostics.when(
+              loading: () => const Padding(
+                padding: EdgeInsets.all(24),
+                child: Center(child: CircularProgressIndicator()),
+              ),
+              error: (_, __) => ListTile(
+                leading: const Icon(Icons.error_outline, color: Colors.red),
+                title: const Text('Capability check failed'),
+                trailing: IconButton(
+                  tooltip: 'Retry',
+                  icon: const Icon(Icons.refresh),
+                  onPressed: () => _refresh(ref),
+                ),
+              ),
+              data: (report) => _CapabilityReport(
+                report: report,
+                onAction: (result) => _runAction(context, ref, result),
+              ),
+            ),
+            const Divider(height: 32),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+              child: Text(
+                'Recent external activity',
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+            ),
+            externalCalls.when(
+              loading: () => const Padding(
+                padding: EdgeInsets.all(16),
+                child: LinearProgressIndicator(),
+              ),
+              error: (_, __) => const ListTile(
+                leading: Icon(Icons.error_outline),
+                title: Text('Audit history unavailable'),
+              ),
+              data: (records) => records.isEmpty
+                  ? const ListTile(
+                      leading: Icon(Icons.history),
+                      title: Text('No external calls recorded'),
+                    )
+                  : Column(
+                      children: [
+                        for (final record in records)
+                          _ExternalCallTile(record: record),
+                      ],
+                    ),
+            ),
+            const SizedBox(height: 24),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _refresh(WidgetRef ref) {
+    ref.invalidate(capabilityRuntimeSignalsProvider);
+    ref.invalidate(recentExternalCallsProvider);
+  }
+
+  Future<void> _runAction(
+    BuildContext context,
+    WidgetRef ref,
+    CapabilityDiagnosticResult result,
+  ) async {
+    switch (result.fixKind) {
+      case CapabilityFixKind.openSettings:
+        final route = result.capability.settingsRoute;
+        if (route != null) await context.push(route);
+      case CapabilityFixKind.requestPermission:
+        await ref.read(sttServiceProvider).initialize();
+      case CapabilityFixKind.retry:
+        break;
+      case null:
+        return;
+    }
+    ref.invalidate(capabilityRuntimeSignalsProvider);
+  }
+}
+
+class _CapabilityReport extends StatelessWidget {
+  final CapabilityDiagnosticReport report;
+  final ValueChanged<CapabilityDiagnosticResult> onAction;
+
+  const _CapabilityReport({required this.report, required this.onAction});
+
+  @override
+  Widget build(BuildContext context) {
+    final total = report.results.length;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+          child: Row(
+            children: [
+              Expanded(
+                child: Text(
+                  '${report.readyCount} of $total ready',
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+              ),
+              Icon(
+                report.attentionCount == 0
+                    ? Icons.check_circle
+                    : Icons.info_outline,
+                color: report.attentionCount == 0
+                    ? Colors.green
+                    : Theme.of(context).colorScheme.primary,
+              ),
+            ],
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: LinearProgressIndicator(
+            value: total == 0 ? 0 : report.readyCount / total,
+          ),
+        ),
+        const SizedBox(height: 8),
+        for (final result in report.results) ...[
+          _CapabilityTile(result: result, onAction: onAction),
+          const Divider(height: 1, indent: 72),
+        ],
+      ],
+    );
+  }
+}
+
+class _CapabilityTile extends StatelessWidget {
+  final CapabilityDiagnosticResult result;
+  final ValueChanged<CapabilityDiagnosticResult> onAction;
+
+  const _CapabilityTile({required this.result, required this.onAction});
+
+  @override
+  Widget build(BuildContext context) {
+    final color = _statusColor(context, result.availability);
+    return ListTile(
+      contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+      leading: SizedBox.square(
+        dimension: 40,
+        child: Icon(_capabilityIcon(result.capability.id)),
+      ),
+      title: Text(result.capability.name),
+      subtitle: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(result.capability.description),
+          const SizedBox(height: 4),
+          Row(
+            children: [
+              Icon(_statusIcon(result.availability), size: 16, color: color),
+              const SizedBox(width: 6),
+              Flexible(
+                child: Text(result.message, style: TextStyle(color: color)),
+              ),
+            ],
+          ),
+        ],
+      ),
+      trailing: switch (result.fixKind) {
+        CapabilityFixKind.openSettings => IconButton(
+            tooltip: 'Open settings',
+            icon: const Icon(Icons.chevron_right),
+            onPressed: () => onAction(result),
+          ),
+        CapabilityFixKind.requestPermission => IconButton(
+            tooltip: 'Request permission',
+            icon: const Icon(Icons.security),
+            onPressed: () => onAction(result),
+          ),
+        CapabilityFixKind.retry => IconButton(
+            tooltip: 'Retry',
+            icon: const Icon(Icons.refresh),
+            onPressed: () => onAction(result),
+          ),
+        null => null,
+      },
+    );
+  }
+
+  IconData _capabilityIcon(CapabilityId id) => switch (id) {
+        CapabilityId.llm => Icons.auto_awesome,
+        CapabilityId.systemTts => Icons.volume_up,
+        CapabilityId.systemStt => Icons.mic,
+        CapabilityId.embedding => Icons.manage_search,
+        CapabilityId.imageGeneration => Icons.image,
+        CapabilityId.mcp => Icons.extension,
+        CapabilityId.live2d => Icons.emoji_emotions,
+      };
+
+  IconData _statusIcon(CapabilityAvailability availability) {
+    return switch (availability) {
+      CapabilityAvailability.ready => Icons.check_circle,
+      CapabilityAvailability.disabled => Icons.pause_circle_outline,
+      CapabilityAvailability.offline => Icons.cloud_off,
+      CapabilityAvailability.permissionDenied => Icons.block,
+      CapabilityAvailability.unsupported => Icons.not_interested,
+      CapabilityAvailability.needsPermission => Icons.security,
+      CapabilityAvailability.needsDownload => Icons.download,
+      CapabilityAvailability.needsConfiguration => Icons.settings_outlined,
+    };
+  }
+
+  Color _statusColor(
+    BuildContext context,
+    CapabilityAvailability availability,
+  ) {
+    return switch (availability) {
+      CapabilityAvailability.ready => Colors.green,
+      CapabilityAvailability.disabled ||
+      CapabilityAvailability.unsupported =>
+        Theme.of(context).colorScheme.onSurfaceVariant,
+      _ => Theme.of(context).colorScheme.error,
+    };
+  }
+}
+
+class _ExternalCallTile extends StatelessWidget {
+  final ExternalCallAuditRecord record;
+
+  const _ExternalCallTile({required this.record});
+
+  @override
+  Widget build(BuildContext context) {
+    final succeeded = record.outcome == ExternalCallOutcome.succeeded;
+    final types = record.dataTypes.map((type) => type.name).join(', ');
+    final localTime = record.timestamp.toLocal();
+    final time = '${localTime.hour.toString().padLeft(2, '0')}:'
+        '${localTime.minute.toString().padLeft(2, '0')}';
+    return ListTile(
+      dense: true,
+      leading: Icon(
+        succeeded ? Icons.check_circle_outline : Icons.error_outline,
+        color: succeeded ? Colors.green : Theme.of(context).colorScheme.error,
+      ),
+      title: Text(record.targetDomain),
+      subtitle: Text('${record.capabilityId} · $types'),
+      trailing: Text(time),
+    );
+  }
+}

--- a/lib/presentation/screens/settings/settings_screen.dart
+++ b/lib/presentation/screens/settings/settings_screen.dart
@@ -117,6 +117,13 @@ class SettingsScreen extends ConsumerWidget {
           const Divider(height: 32),
           _buildSectionHeader(context, l10n.advanced),
           ListTile(
+            leading: const Icon(Icons.health_and_safety_outlined),
+            title: const Text('Capability check'),
+            subtitle: const Text('Availability, permissions, and configuration'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () => context.push(AppRoutes.capabilityDiagnostics),
+          ),
+          ListTile(
             leading: const Icon(Icons.find_replace),
             title: Text(l10n.regex),
             trailing: const Icon(Icons.chevron_right),

--- a/test/capability_diagnostics_end_to_end_test.dart
+++ b/test/capability_diagnostics_end_to_end_test.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:native_tavern/domain/services/capability_registry.dart';
+import 'package:native_tavern/domain/services/external_call_audit_service.dart';
+import 'package:native_tavern/presentation/providers/capability_providers.dart';
+import 'package:native_tavern/presentation/providers/external_call_audit_providers.dart';
+import 'package:native_tavern/presentation/screens/settings/capability_diagnostics_screen.dart';
+
+void main() {
+  testWidgets('diagnoses configuration and opens the repair destination',
+      (tester) async {
+    tester.view.physicalSize = const Size(800, 1200);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final audit = MemoryExternalCallAuditRepository();
+    await audit.record(ExternalCallAuditRecord.forRequest(
+      requestUri: Uri.parse('https://api.example.com/v1/chat?key=hidden'),
+      capabilityId: 'llm',
+      dataTypes: const {ExternalDataType.chatText},
+      outcome: ExternalCallOutcome.failed,
+      costAttribution: ExternalCostAttribution.userServiceAccount,
+      statusCode: 401,
+    ));
+    final router = GoRouter(
+      initialLocation: '/capability-diagnostics',
+      routes: [
+        GoRoute(
+          path: '/capability-diagnostics',
+          builder: (_, __) => const CapabilityDiagnosticsScreen(),
+        ),
+        GoRoute(
+          path: '/ai-config',
+          builder: (_, __) => const Scaffold(
+            body: Center(child: Text('AI repair destination')),
+          ),
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          externalCallAuditRepositoryProvider.overrideWithValue(audit),
+          capabilityDiagnosticInputsProvider.overrideWithValue(const [
+            CapabilityDiagnosticInput(
+              id: CapabilityId.llm,
+              configured: false,
+              configurationIssue: 'Complete the current AI connection',
+            ),
+            CapabilityDiagnosticInput(id: CapabilityId.systemTts),
+            CapabilityDiagnosticInput(
+              id: CapabilityId.systemStt,
+              enabled: false,
+            ),
+            CapabilityDiagnosticInput(
+              id: CapabilityId.embedding,
+              enabled: false,
+            ),
+            CapabilityDiagnosticInput(
+              id: CapabilityId.imageGeneration,
+              enabled: false,
+            ),
+            CapabilityDiagnosticInput(
+              id: CapabilityId.mcp,
+              configured: false,
+              supported: false,
+            ),
+            CapabilityDiagnosticInput(id: CapabilityId.live2d),
+          ]),
+          capabilityRuntimeSignalsProvider.overrideWith(
+            (ref) async => const CapabilityRuntimeSignals(
+              network: CapabilityNetworkState.online,
+            ),
+          ),
+        ],
+        child: MaterialApp.router(routerConfig: router),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Capability check'), findsOneWidget);
+    expect(find.text('Complete the current AI connection'), findsOneWidget);
+
+    expect(find.text('api.example.com'), findsOneWidget);
+    expect(find.textContaining('hidden'), findsNothing);
+
+    await tester.tap(find.byTooltip('Open settings').first);
+    await tester.pumpAndSettle();
+
+    expect(find.text('AI repair destination'), findsOneWidget);
+  });
+}

--- a/test/capability_registry_test.dart
+++ b/test/capability_registry_test.dart
@@ -1,0 +1,167 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:native_tavern/data/models/vector_storage.dart';
+import 'package:native_tavern/domain/services/capability_registry.dart';
+import 'package:native_tavern/domain/services/image_generation_service.dart';
+import 'package:native_tavern/domain/services/llm_service.dart';
+import 'package:native_tavern/domain/services/stt_service.dart';
+import 'package:native_tavern/domain/services/tts_service.dart';
+import 'package:native_tavern/presentation/providers/capability_providers.dart';
+
+void main() {
+  group('CapabilityRegistry', () {
+    test('registers all NativeTavern capability families', () {
+      final registry = CapabilityRegistry.nativeTavern();
+
+      expect(
+        registry.capabilities.map((capability) => capability.id).toSet(),
+        CapabilityId.values.toSet(),
+      );
+      expect(
+        registry.find(CapabilityId.llm)?.requirement,
+        CapabilityRequirement.currentAi,
+      );
+      expect(
+        registry.find(CapabilityId.systemStt)?.requirement,
+        CapabilityRequirement.permission,
+      );
+      expect(
+        registry.find(CapabilityId.embedding)?.requirement,
+        CapabilityRequirement.externalService,
+      );
+    });
+
+    test('rejects duplicate IDs', () {
+      const descriptor = CapabilityDescriptor(
+        id: CapabilityId.llm,
+        name: 'AI',
+        description: 'AI',
+        requirement: CapabilityRequirement.currentAi,
+      );
+
+      expect(
+        () => CapabilityRegistry(const [descriptor, descriptor]),
+        throwsArgumentError,
+      );
+    });
+
+    test('reports permission denial and offline degradation', () {
+      final registry = CapabilityRegistry.nativeTavern();
+      const inputs = [
+        CapabilityDiagnosticInput(
+          id: CapabilityId.llm,
+          requiresNetwork: true,
+        ),
+        CapabilityDiagnosticInput(id: CapabilityId.systemTts),
+        CapabilityDiagnosticInput(id: CapabilityId.systemStt),
+        CapabilityDiagnosticInput(id: CapabilityId.embedding),
+        CapabilityDiagnosticInput(id: CapabilityId.imageGeneration),
+        CapabilityDiagnosticInput(id: CapabilityId.mcp),
+        CapabilityDiagnosticInput(id: CapabilityId.live2d),
+      ];
+      final onlineReport = registry.diagnose(
+        inputs,
+        const CapabilityRuntimeSignals(
+          network: CapabilityNetworkState.online,
+          permissions: {
+            CapabilityId.systemStt: CapabilityPermissionState.granted,
+          },
+        ),
+      );
+      final offlineReport = registry.diagnose(
+        inputs,
+        const CapabilityRuntimeSignals(
+          network: CapabilityNetworkState.offline,
+          permissions: {
+            CapabilityId.systemStt: CapabilityPermissionState.denied,
+          },
+        ),
+      );
+
+      expect(
+        onlineReport.resultFor(CapabilityId.llm).availability,
+        CapabilityAvailability.ready,
+      );
+      expect(
+        offlineReport.resultFor(CapabilityId.llm).availability,
+        CapabilityAvailability.offline,
+      );
+      expect(
+        offlineReport.resultFor(CapabilityId.systemStt).availability,
+        CapabilityAvailability.permissionDenied,
+      );
+      expect(
+        offlineReport.resultFor(CapabilityId.live2d).availability,
+        CapabilityAvailability.ready,
+      );
+    });
+
+    test('supports the download-required state', () {
+      final registry = CapabilityRegistry(const [
+        CapabilityDescriptor(
+          id: CapabilityId.live2d,
+          name: 'Downloaded renderer',
+          description: 'Renderer package',
+          requirement: CapabilityRequirement.download,
+          settingsRoute: '/download',
+        ),
+      ]);
+
+      final result = registry.diagnose(
+        const [
+          CapabilityDiagnosticInput(
+            id: CapabilityId.live2d,
+            downloaded: false,
+          ),
+        ],
+        const CapabilityRuntimeSignals(),
+      ).resultFor(CapabilityId.live2d);
+
+      expect(result.availability, CapabilityAvailability.needsDownload);
+      expect(result.fixKind, CapabilityFixKind.openSettings);
+    });
+  });
+
+  group('CapabilityInputFactory', () {
+    test('requires complete remote configuration but keeps local AI offline',
+        () {
+      const incompleteRemote = LLMConfig(
+        provider: LLMProvider.claude,
+        model: 'claude-test',
+        apiKey: '',
+        apiUrl: 'https://api.example.com',
+      );
+      const local = LLMConfig(
+        provider: LLMProvider.ollama,
+        model: 'local-model',
+        apiKey: '',
+        apiUrl: 'http://localhost:11434',
+      );
+
+      final remoteInputs = CapabilityInputFactory.create(
+        llm: incompleteRemote,
+        tts: const TTSSettings(),
+        stt: const STTSettings(),
+        vector: const VectorStorageSettings(),
+        image: const ImageGenSettings(),
+      );
+      final localInputs = CapabilityInputFactory.create(
+        llm: local,
+        tts: const TTSSettings(enabled: true),
+        stt: const STTSettings(enabled: true),
+        vector: const VectorStorageSettings(),
+        image: const ImageGenSettings(),
+      );
+
+      final remoteLlm = remoteInputs.firstWhere(
+        (input) => input.id == CapabilityId.llm,
+      );
+      final localLlm = localInputs.firstWhere(
+        (input) => input.id == CapabilityId.llm,
+      );
+      expect(remoteLlm.configured, isFalse);
+      expect(remoteLlm.requiresNetwork, isTrue);
+      expect(localLlm.configured, isTrue);
+      expect(localLlm.requiresNetwork, isFalse);
+    });
+  });
+}

--- a/test/external_call_audit_service_test.dart
+++ b/test/external_call_audit_service_test.dart
@@ -1,0 +1,164 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:native_tavern/domain/services/external_call_audit_service.dart';
+
+void main() {
+  group('FileExternalCallAuditRepository', () {
+    late Directory directory;
+    late FileExternalCallAuditRepository repository;
+
+    setUp(() async {
+      directory = await Directory.systemTemp.createTemp('native_tavern_audit_');
+      repository = FileExternalCallAuditRepository(dataPath: directory.path);
+    });
+
+    tearDown(() async {
+      await directory.delete(recursive: true);
+    });
+
+    test('persists only structured, redacted request metadata', () async {
+      final record = ExternalCallAuditRecord.forRequest(
+        requestUri: Uri.parse(
+          'https://user:password@example.com/v1/chat/completions'
+          '?key=super-secret',
+        ),
+        capabilityId: 'llm',
+        dataTypes: const {
+          ExternalDataType.prompt,
+          ExternalDataType.chatText,
+        },
+        outcome: ExternalCallOutcome.succeeded,
+        costAttribution: ExternalCostAttribution.userServiceAccount,
+        statusCode: 200,
+      );
+
+      await repository.record(record);
+      final records = await repository.readRecent();
+      final raw = await File(
+        '${directory.path}/audit/external_calls.jsonl',
+      ).readAsString();
+
+      expect(records.single.targetDomain, 'example.com');
+      expect(raw, contains('example.com'));
+      expect(raw, isNot(contains('super-secret')));
+      expect(raw, isNot(contains('password')));
+      expect(raw, isNot(contains('/v1/chat/completions')));
+      expect(raw, isNot(contains('prompt text')));
+    });
+
+    test('serializes concurrent writes without losing records', () async {
+      await Future.wait([
+        for (var index = 0; index < 25; index++)
+          repository.record(ExternalCallAuditRecord.forRequest(
+            requestUri: Uri.parse('https://api$index.example.com/request'),
+            capabilityId: 'imageGeneration',
+            dataTypes: const {ExternalDataType.image},
+            outcome: ExternalCallOutcome.succeeded,
+            costAttribution: ExternalCostAttribution.userServiceAccount,
+          )),
+      ]);
+
+      expect(await repository.readRecent(limit: 50), hasLength(25));
+    });
+  });
+
+  test('Dio interceptor records outcome without inspecting request bodies',
+      () async {
+    final repository = MemoryExternalCallAuditRepository();
+    final dio = Dio()..httpClientAdapter = _SuccessAdapter();
+    dio.interceptors.add(ExternalCallAuditInterceptor(
+      repository: repository,
+      capabilityId: 'embedding',
+      classifyData: (request) => const {ExternalDataType.documentText},
+    ));
+
+    await dio.post<void>(
+      'https://api.example.com/v1/embeddings?key=hidden',
+      data: {'input': 'private document body'},
+    );
+
+    final record = (await repository.readRecent()).single;
+    expect(record.targetDomain, 'api.example.com');
+    expect(record.outcome, ExternalCallOutcome.succeeded);
+    expect(record.statusCode, 200);
+    expect(record.dataTypes, {ExternalDataType.documentText});
+    expect(
+      record.costAttribution,
+      ExternalCostAttribution.userServiceAccount,
+    );
+  });
+
+  test('Dio interceptor records local cost and connection failures', () async {
+    final localRepository = MemoryExternalCallAuditRepository();
+    final localDio = Dio()..httpClientAdapter = _SuccessAdapter();
+    localDio.interceptors.add(ExternalCallAuditInterceptor(
+      repository: localRepository,
+      capabilityId: 'llm',
+      classifyData: (request) => const {ExternalDataType.chatText},
+    ));
+    await localDio.post<void>('http://localhost:11434/api/chat');
+
+    final localRecord = (await localRepository.readRecent()).single;
+    expect(
+      localRecord.costAttribution,
+      ExternalCostAttribution.noExternalCharge,
+    );
+
+    final failureRepository = MemoryExternalCallAuditRepository();
+    final failingDio = Dio()..httpClientAdapter = _FailureAdapter();
+    failingDio.interceptors.add(ExternalCallAuditInterceptor(
+      repository: failureRepository,
+      capabilityId: 'imageGeneration',
+      classifyData: (request) => const {ExternalDataType.prompt},
+    ));
+    await expectLater(
+      failingDio.post<void>('https://images.example.com/generate'),
+      throwsA(isA<DioException>()),
+    );
+
+    final failureRecord = (await failureRepository.readRecent()).single;
+    expect(failureRecord.outcome, ExternalCallOutcome.failed);
+    expect(failureRecord.statusCode, isNull);
+  });
+}
+
+class _SuccessAdapter implements HttpClientAdapter {
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    return ResponseBody.fromString(
+      '{}',
+      200,
+      headers: {
+        Headers.contentTypeHeader: ['application/json'],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+class _FailureAdapter implements HttpClientAdapter {
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    throw DioException(
+      requestOptions: options,
+      type: DioExceptionType.connectionError,
+      message: 'offline',
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}


### PR DESCRIPTION
## 完成内容

- J01 Capability Registry：定义五类能力需求与统一诊断结果，注册 LLM、系统 TTS/STT、Embedding、图片、MCP、Live2D，并覆盖禁用、未配置、权限拒绝、离线、不支持等状态。
- J04 外部调用审计：为 LLM、Embedding、图片、远程 TTS、URL 角色卡导入记录 JSONL 审计，只保存域名、能力、数据类型、结果、状态码、耗时和费用归属，不保存密钥、Prompt、正文或 URL 路径/查询。
- J06 首次使用与配置诊断：设置页新增 Capability check，提供无外部请求的网络/权限检查、明确降级信息、修复跳转及最近外部活动。

## 测试

- flutter test --no-pub test/capability_diagnostics_end_to_end_test.dart test/capability_registry_test.dart test/external_call_audit_service_test.dart（10/10 通过）
- flutter test --no-pub（146/146 通过，基于最新 main）
- flutter analyze --no-pub --no-fatal-infos --no-fatal-warnings（无 error；仓库既有 1177 条 warning/info）
- git diff --check

Closes #15