### PR TITLE
feat(chat): add generation extension pipeline

### DIFF
--- a/docs/chat_generation_extensions.md
+++ b/docs/chat_generation_extensions.md
@@ -1,0 +1,62 @@
+# Chat generation extensions
+
+`ChatGenerationPipeline` is the shared boundary for features that add chat
+context or wrap an LLM generation. Feature modules register extensions through
+`chatExtensionRegistryProvider`; they do not modify `chat_providers.dart`.
+
+## Context contributors
+
+A contributor declares a stable ID, deterministic order, and optional token
+limit. Registration returns a handle that must be disposed with the feature
+provider.
+
+```dart
+final registration = ref
+    .read(chatExtensionRegistryProvider)
+    .registerContributor(MemoryContextContributor(repository));
+ref.onDispose(registration.dispose);
+```
+
+Implement `ContextContributor.contribute` to return one or more provider-ready
+message maps. The available global budget and cancellation token are included
+in `ChatContextRequest`.
+
+- Lower `order` values run first. Equal values are ordered by extension ID.
+- `maxTokens` limits one contributor. The pipeline also enforces the remaining
+  request budget across all contributors.
+- Oversized string messages are truncated deterministically; later messages
+  are dropped when the allocation is exhausted.
+- `beforeBase` is for instructions that must lead the request.
+- `beforeConversation` is the default for retrieved context and inserts after
+  the base system preamble but before the first conversational message.
+- `afterBase` is for post-history instructions.
+- Disabled, failed, and cancelled contributors do not block ordinary chat.
+
+`lastContextAssemblyProvider` exposes the base and final messages, token totals,
+injected messages, contributor order, trimming, elapsed time, and isolated
+errors. It is in-memory diagnostic state and is not persisted or logged.
+
+## Generation middleware
+
+Register `ChatGenerationMiddleware` through the same registry. Pre-generation
+hooks run in ascending order; post-generation and error hooks run in reverse
+order. A pre-generation hook may return `request.copyWith` to change messages,
+the LLM configuration, or metadata. It cannot replace the session ID, chat
+scope, generation mode, or cancellation token.
+
+`recoverFromError` may return an `LLMResponse` to recover a provider failure.
+Returning `null` lets the next outer middleware inspect the error; an
+unrecovered error returns to the existing chat error path. Hook failures are
+recorded and isolated. `lastChatGenerationTraceProvider` exposes the latest
+middleware phases, recovery, cancellation, and terminal error.
+
+## Cancellation and lifecycle
+
+Each generation owns a `ChatCancellationToken`. Contributors and middleware
+should check `isCancelled`, await `whenCancelled` for interruptible work, or
+call `throwIfCancelled` between expensive steps. User cancellation propagates
+to that token, registered cancellation hooks, and the active LLM HTTP request.
+
+Keep registration ownership inside the feature provider and dispose the
+returned handle. Registry snapshots are taken for each phase, so registering or
+unregistering an extension does not mutate an in-flight iteration.

--- a/lib/domain/services/chat_generation_pipeline.dart
+++ b/lib/domain/services/chat_generation_pipeline.dart
@@ -1,0 +1,1165 @@
+import 'dart:async';
+import 'dart:math';
+
+import 'package:native_tavern/domain/services/context_window_service.dart';
+import 'package:native_tavern/domain/services/llm_service.dart';
+import 'package:native_tavern/domain/services/tokenizer_service.dart';
+
+typedef ChatMessageMap = Map<String, dynamic>;
+typedef ChatGenerationTransport = Future<LLMResponse> Function(
+  ChatGenerationRequest request,
+);
+typedef ChatGenerationStreamTransport = Stream<LLMStreamChunk> Function(
+  ChatGenerationRequest request,
+);
+
+enum ChatGenerationMode {
+  send,
+  regenerate,
+  continueResponse,
+  impersonate,
+  groupResponse,
+}
+
+enum ContextContributionPlacement {
+  beforeBase,
+  beforeConversation,
+  afterBase,
+}
+
+enum ContextContributionStatus {
+  applied,
+  disabled,
+  failed,
+  cancelled,
+  skippedNoBudget,
+}
+
+enum GenerationMiddlewarePhase {
+  before,
+  after,
+  error,
+  cancelled,
+}
+
+class ChatGenerationCancelledException implements Exception {
+  const ChatGenerationCancelledException([this.reason = 'Cancelled']);
+
+  final String reason;
+
+  @override
+  String toString() => 'ChatGenerationCancelledException: $reason';
+}
+
+class ChatCancellationToken {
+  final Completer<void> _cancelled = Completer<void>();
+  String? _reason;
+
+  bool get isCancelled => _cancelled.isCompleted;
+  String? get reason => _reason;
+  Future<void> get whenCancelled => _cancelled.future;
+
+  void cancel([String reason = 'Cancelled']) {
+    if (isCancelled) return;
+    _reason = reason;
+    _cancelled.complete();
+  }
+
+  void throwIfCancelled() {
+    if (isCancelled) {
+      throw ChatGenerationCancelledException(_reason ?? 'Cancelled');
+    }
+  }
+}
+
+class ChatContextRequest {
+  ChatContextRequest({
+    required this.sessionId,
+    required this.chatId,
+    required this.mode,
+    required List<ChatMessageMap> baseMessages,
+    required this.inputTokenBudget,
+    required this.availableContributionTokens,
+    required this.cancellationToken,
+    this.characterId,
+    this.groupId,
+    Map<String, Object?> metadata = const {},
+  })  : baseMessages = _immutableMessages(baseMessages),
+        metadata = Map<String, Object?>.unmodifiable(metadata);
+
+  final String sessionId;
+  final String chatId;
+  final String? characterId;
+  final String? groupId;
+  final ChatGenerationMode mode;
+  final List<ChatMessageMap> baseMessages;
+  final int inputTokenBudget;
+  final int availableContributionTokens;
+  final ChatCancellationToken cancellationToken;
+  final Map<String, Object?> metadata;
+
+  ChatContextRequest copyWith({
+    List<ChatMessageMap>? baseMessages,
+    int? availableContributionTokens,
+  }) {
+    return ChatContextRequest(
+      sessionId: sessionId,
+      chatId: chatId,
+      characterId: characterId,
+      groupId: groupId,
+      mode: mode,
+      baseMessages: baseMessages ?? this.baseMessages,
+      inputTokenBudget: inputTokenBudget,
+      availableContributionTokens:
+          availableContributionTokens ?? this.availableContributionTokens,
+      cancellationToken: cancellationToken,
+      metadata: metadata,
+    );
+  }
+}
+
+class ContextContribution {
+  ContextContribution({
+    required List<ChatMessageMap> messages,
+    this.placement = ContextContributionPlacement.beforeConversation,
+  }) : messages = _immutableMessages(messages);
+
+  final List<ChatMessageMap> messages;
+  final ContextContributionPlacement placement;
+}
+
+abstract class ContextContributor {
+  String get id;
+  int get order => 0;
+  int? get maxTokens => null;
+
+  FutureOr<bool> isEnabled(ChatContextRequest request) => true;
+
+  Future<ContextContribution> contribute(ChatContextRequest request);
+
+  FutureOr<void> onCancelled(ChatContextRequest request) {}
+}
+
+class ContextContributionTrace {
+  ContextContributionTrace({
+    required this.contributorId,
+    required this.order,
+    required this.status,
+    required this.allocatedTokens,
+    required this.originalTokens,
+    required this.usedTokens,
+    required this.originalMessageCount,
+    required this.truncatedMessageCount,
+    required this.droppedMessageCount,
+    required this.elapsed,
+    required List<ChatMessageMap> injectedMessages,
+    this.placement,
+    this.error,
+  }) : injectedMessages = _immutableMessages(injectedMessages);
+
+  final String contributorId;
+  final int order;
+  final ContextContributionStatus status;
+  final ContextContributionPlacement? placement;
+  final int allocatedTokens;
+  final int originalTokens;
+  final int usedTokens;
+  final int originalMessageCount;
+  final int truncatedMessageCount;
+  final int droppedMessageCount;
+  final Duration elapsed;
+  final List<ChatMessageMap> injectedMessages;
+  final String? error;
+}
+
+class ContextAssemblyResult {
+  ContextAssemblyResult({
+    required this.sessionId,
+    required List<ChatMessageMap> baseMessages,
+    required List<ChatMessageMap> messages,
+    required this.inputTokenBudget,
+    required this.baseEstimatedTokens,
+    required this.estimatedTokens,
+    required List<ContextContributionTrace> traces,
+    required this.startedAt,
+    required this.completedAt,
+    required this.cancelled,
+  })  : baseMessages = _immutableMessages(baseMessages),
+        messages = _immutableMessages(messages),
+        traces = List<ContextContributionTrace>.unmodifiable(traces);
+
+  final String sessionId;
+  final List<ChatMessageMap> baseMessages;
+  final List<ChatMessageMap> messages;
+  final int inputTokenBudget;
+  final int baseEstimatedTokens;
+  final int estimatedTokens;
+  final List<ContextContributionTrace> traces;
+  final DateTime startedAt;
+  final DateTime completedAt;
+  final bool cancelled;
+
+  int get contributedTokens => max(0, estimatedTokens - baseEstimatedTokens);
+  bool get wasTrimmed => traces.any(
+        (trace) =>
+            trace.truncatedMessageCount > 0 || trace.droppedMessageCount > 0,
+      );
+}
+
+class ChatGenerationRequest {
+  ChatGenerationRequest({
+    required this.sessionId,
+    required this.chatId,
+    required this.mode,
+    required List<ChatMessageMap> messages,
+    required this.config,
+    required this.cancellationToken,
+    this.characterId,
+    this.groupId,
+    Map<String, Object?> metadata = const {},
+  })  : messages = _immutableMessages(messages),
+        metadata = Map<String, Object?>.unmodifiable(metadata);
+
+  final String sessionId;
+  final String chatId;
+  final String? characterId;
+  final String? groupId;
+  final ChatGenerationMode mode;
+  final List<ChatMessageMap> messages;
+  final LLMConfig config;
+  final ChatCancellationToken cancellationToken;
+  final Map<String, Object?> metadata;
+
+  ChatGenerationRequest copyWith({
+    List<ChatMessageMap>? messages,
+    LLMConfig? config,
+    Map<String, Object?>? metadata,
+  }) {
+    return ChatGenerationRequest(
+      sessionId: sessionId,
+      chatId: chatId,
+      characterId: characterId,
+      groupId: groupId,
+      mode: mode,
+      messages: messages ?? this.messages,
+      config: config ?? this.config,
+      cancellationToken: cancellationToken,
+      metadata: metadata ?? this.metadata,
+    );
+  }
+}
+
+class ChatGenerationOutcome {
+  const ChatGenerationOutcome({
+    required this.response,
+    required this.streaming,
+    required this.cancelled,
+    required this.recovered,
+    required this.elapsed,
+  });
+
+  final LLMResponse response;
+  final bool streaming;
+  final bool cancelled;
+  final bool recovered;
+  final Duration elapsed;
+}
+
+abstract class ChatGenerationMiddleware {
+  String get id;
+  int get order => 0;
+
+  FutureOr<bool> isEnabled(ChatGenerationRequest request) => true;
+
+  FutureOr<ChatGenerationRequest> beforeGeneration(
+    ChatGenerationRequest request,
+  ) =>
+      request;
+
+  FutureOr<void> afterGeneration(
+    ChatGenerationRequest request,
+    ChatGenerationOutcome outcome,
+  ) {}
+
+  FutureOr<LLMResponse?> recoverFromError(
+    ChatGenerationRequest request,
+    Object error,
+    StackTrace stackTrace,
+  ) =>
+      null;
+
+  FutureOr<void> onCancelled(ChatGenerationRequest request) {}
+}
+
+class GenerationMiddlewareTrace {
+  const GenerationMiddlewareTrace({
+    required this.middlewareId,
+    required this.order,
+    required this.phase,
+    required this.elapsed,
+    this.error,
+    this.recovered = false,
+  });
+
+  final String middlewareId;
+  final int order;
+  final GenerationMiddlewarePhase phase;
+  final Duration elapsed;
+  final String? error;
+  final bool recovered;
+}
+
+class ChatGenerationTrace {
+  ChatGenerationTrace({
+    required this.sessionId,
+    required this.mode,
+    required this.streaming,
+    required this.cancelled,
+    required this.recovered,
+    required List<GenerationMiddlewareTrace> middlewareTraces,
+    required this.startedAt,
+    required this.completedAt,
+    this.error,
+  }) : middlewareTraces =
+            List<GenerationMiddlewareTrace>.unmodifiable(middlewareTraces);
+
+  final String sessionId;
+  final ChatGenerationMode mode;
+  final bool streaming;
+  final bool cancelled;
+  final bool recovered;
+  final List<GenerationMiddlewareTrace> middlewareTraces;
+  final DateTime startedAt;
+  final DateTime completedAt;
+  final String? error;
+}
+
+class ChatExtensionRegistration {
+  ChatExtensionRegistration(this._dispose);
+
+  final void Function() _dispose;
+  bool _isDisposed = false;
+
+  void dispose() {
+    if (_isDisposed) return;
+    _isDisposed = true;
+    _dispose();
+  }
+}
+
+class ChatExtensionRegistry {
+  final Map<String, ContextContributor> _contributors = {};
+  final Map<String, ChatGenerationMiddleware> _middlewares = {};
+
+  List<ContextContributor> get contributors => _sorted(_contributors.values);
+  List<ChatGenerationMiddleware> get middlewares =>
+      _sorted(_middlewares.values);
+
+  ChatExtensionRegistration registerContributor(
+    ContextContributor contributor,
+  ) {
+    _register(_contributors, contributor.id, contributor);
+    return ChatExtensionRegistration(() {
+      if (identical(_contributors[contributor.id], contributor)) {
+        _contributors.remove(contributor.id);
+      }
+    });
+  }
+
+  ChatExtensionRegistration registerMiddleware(
+    ChatGenerationMiddleware middleware,
+  ) {
+    _register(_middlewares, middleware.id, middleware);
+    return ChatExtensionRegistration(() {
+      if (identical(_middlewares[middleware.id], middleware)) {
+        _middlewares.remove(middleware.id);
+      }
+    });
+  }
+
+  void clear() {
+    _contributors.clear();
+    _middlewares.clear();
+  }
+
+  static void _register<T>(Map<String, T> values, String id, T value) {
+    if (id.trim().isEmpty) {
+      throw ArgumentError.value(id, 'id', 'Extension ID cannot be empty.');
+    }
+    if (values.containsKey(id)) {
+      throw StateError('A chat extension with ID "$id" is already registered.');
+    }
+    values[id] = value;
+  }
+
+  static List<T> _sorted<T>(Iterable<T> values) {
+    final result = values.toList();
+    result.sort((left, right) {
+      final leftOrder = left is ContextContributor
+          ? left.order
+          : (left as ChatGenerationMiddleware).order;
+      final rightOrder = right is ContextContributor
+          ? right.order
+          : (right as ChatGenerationMiddleware).order;
+      final byOrder = leftOrder.compareTo(rightOrder);
+      if (byOrder != 0) return byOrder;
+      final leftId = left is ContextContributor
+          ? left.id
+          : (left as ChatGenerationMiddleware).id;
+      final rightId = right is ContextContributor
+          ? right.id
+          : (right as ChatGenerationMiddleware).id;
+      return leftId.compareTo(rightId);
+    });
+    return List<T>.unmodifiable(result);
+  }
+}
+
+class ChatGenerationPipeline {
+  ChatGenerationPipeline({
+    required this.registry,
+    TokenizerService? tokenizer,
+    ContextWindowService? contextWindowService,
+    this.onContextAssembled,
+    this.onGenerationFinished,
+  })  : _tokenizer = tokenizer ?? TokenizerService(),
+        _contextWindowService = contextWindowService ?? ContextWindowService();
+
+  final ChatExtensionRegistry registry;
+  final TokenizerService _tokenizer;
+  final ContextWindowService _contextWindowService;
+  final void Function(ContextAssemblyResult result)? onContextAssembled;
+  final void Function(ChatGenerationTrace trace)? onGenerationFinished;
+  final Set<ChatGenerationSession> _activeSessions = {};
+  int _nextSessionId = 0;
+
+  ChatGenerationSession startSession({
+    required String chatId,
+    required ChatGenerationMode mode,
+    required LLMConfig config,
+    String? characterId,
+    String? groupId,
+    Map<String, Object?> metadata = const {},
+  }) {
+    final session = ChatGenerationSession._(
+      pipeline: this,
+      sessionId: '${DateTime.now().microsecondsSinceEpoch}-${_nextSessionId++}',
+      chatId: chatId,
+      characterId: characterId,
+      groupId: groupId,
+      mode: mode,
+      config: config,
+      metadata: metadata,
+    );
+    _activeSessions.add(session);
+    return session;
+  }
+
+  Future<void> cancelActiveSessions([
+    String reason = 'Cancelled by user',
+  ]) async {
+    final sessions = _activeSessions.toList(growable: false);
+    await Future.wait(sessions.map((session) => session.cancel(reason)));
+  }
+
+  Future<void> dispose() async {
+    await cancelActiveSessions('Pipeline disposed');
+    for (final session in _activeSessions.toList(growable: false)) {
+      session.close();
+    }
+  }
+
+  void _remove(ChatGenerationSession session) {
+    _activeSessions.remove(session);
+  }
+
+  int _inputBudget(LLMConfig config) {
+    if (config.contextLength <= 0) return 1 << 30;
+    final responseTokens = _contextWindowService.effectiveResponseTokenLimit(
+      contextLength: config.contextLength,
+      requestedTokens: config.maxTokens,
+    );
+    final availableForInput = max(1, config.contextLength - responseTokens);
+    final safetyMargin = min(
+      max(32, (config.contextLength * 0.05).ceil()),
+      max(0, availableForInput - 1),
+    );
+    return max(1, availableForInput - safetyMargin);
+  }
+
+  int _estimateMessages(List<ChatMessageMap> messages) => messages.fold(
+        0,
+        (total, message) => total + _estimateMessage(message),
+      );
+
+  int _estimateMessage(ChatMessageMap message) {
+    final content = message['content'];
+    var tokens = 4;
+    if (content is String) {
+      tokens += _tokenizer.estimateTokenCount(content);
+    } else if (content is List) {
+      for (final part in content) {
+        if (part is Map && part['text'] is String) {
+          tokens += _tokenizer.estimateTokenCount(part['text'] as String);
+        } else {
+          tokens += 1024;
+        }
+      }
+    } else if (content != null) {
+      tokens += _tokenizer.estimateTokenCount(content.toString());
+    }
+    return tokens;
+  }
+
+  _FittedContribution _fitContribution(
+    List<ChatMessageMap> messages,
+    int tokenBudget,
+  ) {
+    final fitted = <ChatMessageMap>[];
+    var remaining = max(0, tokenBudget);
+    var truncated = 0;
+    var dropped = 0;
+
+    for (var index = 0; index < messages.length; index++) {
+      final message = Map<String, dynamic>.from(messages[index]);
+      final tokens = _estimateMessage(message);
+      if (tokens <= remaining) {
+        fitted.add(message);
+        remaining -= tokens;
+        continue;
+      }
+
+      final content = message['content'];
+      if (content is String && remaining > 12) {
+        final availableContentTokens = max(1, remaining - 4);
+        final maximumCharacters = max(
+          1,
+          (availableContentTokens * TokenizerService.charsPerTokenRatio)
+              .floor(),
+        );
+        const marker = '\n[truncated]';
+        var candidateLength = max(
+          1,
+          min(content.length, maximumCharacters - marker.length),
+        );
+        message['content'] = '${content.substring(0, candidateLength)}$marker';
+        while (_estimateMessage(message) > remaining && candidateLength > 1) {
+          candidateLength = max(1, candidateLength - 4);
+          message['content'] =
+              '${content.substring(0, candidateLength)}$marker';
+        }
+        if (_estimateMessage(message) <= remaining) {
+          fitted.add(message);
+          remaining -= _estimateMessage(message);
+          truncated++;
+        } else {
+          dropped++;
+        }
+      } else {
+        dropped++;
+      }
+      dropped += messages.length - index - 1;
+      break;
+    }
+
+    return _FittedContribution(
+      messages: fitted,
+      tokens: tokenBudget - remaining,
+      truncatedMessages: truncated,
+      droppedMessages: dropped,
+    );
+  }
+}
+
+class ChatGenerationSession {
+  ChatGenerationSession._({
+    required ChatGenerationPipeline pipeline,
+    required this.sessionId,
+    required this.chatId,
+    required this.characterId,
+    required this.groupId,
+    required this.mode,
+    required this.config,
+    required Map<String, Object?> metadata,
+  })  : _pipeline = pipeline,
+        metadata = Map<String, Object?>.unmodifiable(metadata);
+
+  final ChatGenerationPipeline _pipeline;
+  final String sessionId;
+  final String chatId;
+  final String? characterId;
+  final String? groupId;
+  final ChatGenerationMode mode;
+  final LLMConfig config;
+  final Map<String, Object?> metadata;
+  final ChatCancellationToken cancellationToken = ChatCancellationToken();
+
+  ChatContextRequest? _lastContextRequest;
+  ChatGenerationRequest? _lastGenerationRequest;
+  bool _closed = false;
+  bool _cancellationNotified = false;
+
+  Future<ContextAssemblyResult> assemble(
+    List<ChatMessageMap> baseMessages,
+  ) async {
+    final startedAt = DateTime.now();
+    final inputBudget = _pipeline._inputBudget(config);
+    final immutableBase = _immutableMessages(baseMessages);
+    final baseTokens = _pipeline._estimateMessages(immutableBase);
+    var remaining = max(0, inputBudget - baseTokens);
+    final traces = <ContextContributionTrace>[];
+    final beforeBase = <ChatMessageMap>[];
+    final beforeConversation = <ChatMessageMap>[];
+    final afterBase = <ChatMessageMap>[];
+
+    var request = ChatContextRequest(
+      sessionId: sessionId,
+      chatId: chatId,
+      characterId: characterId,
+      groupId: groupId,
+      mode: mode,
+      baseMessages: immutableBase,
+      inputTokenBudget: inputBudget,
+      availableContributionTokens: remaining,
+      cancellationToken: cancellationToken,
+      metadata: metadata,
+    );
+    _lastContextRequest = request;
+
+    for (final contributor in _pipeline.registry.contributors) {
+      final stopwatch = Stopwatch()..start();
+      if (cancellationToken.isCancelled) {
+        traces.add(_emptyContributionTrace(
+          contributor,
+          ContextContributionStatus.cancelled,
+          stopwatch.elapsed,
+        ));
+        break;
+      }
+
+      bool enabled;
+      try {
+        enabled = await contributor.isEnabled(request);
+      } catch (error) {
+        traces.add(_emptyContributionTrace(
+          contributor,
+          ContextContributionStatus.failed,
+          stopwatch.elapsed,
+          error: error.toString(),
+        ));
+        continue;
+      }
+      if (!enabled) {
+        traces.add(_emptyContributionTrace(
+          contributor,
+          ContextContributionStatus.disabled,
+          stopwatch.elapsed,
+        ));
+        continue;
+      }
+
+      final allocation = min(remaining, contributor.maxTokens ?? remaining);
+      if (allocation <= 0) {
+        traces.add(_emptyContributionTrace(
+          contributor,
+          ContextContributionStatus.skippedNoBudget,
+          stopwatch.elapsed,
+        ));
+        continue;
+      }
+
+      try {
+        request = request.copyWith(availableContributionTokens: remaining);
+        _lastContextRequest = request;
+        final contribution = await contributor.contribute(request);
+        if (cancellationToken.isCancelled) {
+          traces.add(_emptyContributionTrace(
+            contributor,
+            ContextContributionStatus.cancelled,
+            stopwatch.elapsed,
+          ));
+          break;
+        }
+
+        final originalTokens =
+            _pipeline._estimateMessages(contribution.messages);
+        final fitted =
+            _pipeline._fitContribution(contribution.messages, allocation);
+        remaining -= fitted.tokens;
+        switch (contribution.placement) {
+          case ContextContributionPlacement.beforeBase:
+            beforeBase.addAll(fitted.messages);
+          case ContextContributionPlacement.beforeConversation:
+            beforeConversation.addAll(fitted.messages);
+          case ContextContributionPlacement.afterBase:
+            afterBase.addAll(fitted.messages);
+        }
+        traces.add(ContextContributionTrace(
+          contributorId: contributor.id,
+          order: contributor.order,
+          status: ContextContributionStatus.applied,
+          placement: contribution.placement,
+          allocatedTokens: allocation,
+          originalTokens: originalTokens,
+          usedTokens: fitted.tokens,
+          originalMessageCount: contribution.messages.length,
+          truncatedMessageCount: fitted.truncatedMessages,
+          droppedMessageCount: fitted.droppedMessages,
+          elapsed: stopwatch.elapsed,
+          injectedMessages: fitted.messages,
+        ));
+      } catch (error) {
+        traces.add(_emptyContributionTrace(
+          contributor,
+          cancellationToken.isCancelled
+              ? ContextContributionStatus.cancelled
+              : ContextContributionStatus.failed,
+          stopwatch.elapsed,
+          error: cancellationToken.isCancelled ? null : error.toString(),
+        ));
+        if (cancellationToken.isCancelled) break;
+      }
+    }
+
+    final assembled = <ChatMessageMap>[
+      ...beforeBase,
+      ...immutableBase.map(_copyMessage),
+    ];
+    final baseConversationIndex = immutableBase.indexWhere(
+      (message) => message['role'] != 'system',
+    );
+    assembled.insertAll(
+      beforeBase.length +
+          (baseConversationIndex < 0
+              ? immutableBase.length
+              : baseConversationIndex),
+      beforeConversation,
+    );
+    assembled.addAll(afterBase);
+
+    final result = ContextAssemblyResult(
+      sessionId: sessionId,
+      baseMessages: immutableBase,
+      messages: assembled,
+      inputTokenBudget: inputBudget,
+      baseEstimatedTokens: baseTokens,
+      estimatedTokens: _pipeline._estimateMessages(assembled),
+      traces: traces,
+      startedAt: startedAt,
+      completedAt: DateTime.now(),
+      cancelled: cancellationToken.isCancelled,
+    );
+    try {
+      _pipeline.onContextAssembled?.call(result);
+    } catch (_) {
+      // Diagnostics must never break chat generation.
+    }
+    return result;
+  }
+
+  Future<LLMResponse> generate(
+    List<ChatMessageMap> messages,
+    ChatGenerationTransport transport,
+  ) async {
+    final startedAt = DateTime.now();
+    final middlewareTraces = <GenerationMiddlewareTrace>[];
+    var request = _request(messages);
+    _lastGenerationRequest = request;
+    final active = await _runBefore(request, middlewareTraces);
+    request = active.request;
+    _lastGenerationRequest = request;
+    LLMResponse response = const LLMResponse(content: '');
+    var recovered = false;
+    Object? terminalError;
+    StackTrace? terminalStackTrace;
+
+    try {
+      if (!cancellationToken.isCancelled) {
+        response = await transport(request);
+      }
+    } catch (error, stackTrace) {
+      if (!cancellationToken.isCancelled) {
+        final recovery = await _recover(
+          active.middlewares,
+          request,
+          error,
+          stackTrace,
+          middlewareTraces,
+        );
+        if (recovery != null) {
+          response = recovery;
+          recovered = true;
+        } else {
+          terminalError = error;
+          terminalStackTrace = stackTrace;
+        }
+      }
+    }
+
+    final outcome = ChatGenerationOutcome(
+      response: response,
+      streaming: false,
+      cancelled: cancellationToken.isCancelled,
+      recovered: recovered,
+      elapsed: DateTime.now().difference(startedAt),
+    );
+    await _runAfter(
+      active.middlewares,
+      request,
+      outcome,
+      middlewareTraces,
+    );
+    _finishTrace(
+      startedAt: startedAt,
+      streaming: false,
+      recovered: recovered,
+      middlewareTraces: middlewareTraces,
+      error: terminalError,
+    );
+    if (terminalError != null) {
+      Error.throwWithStackTrace(terminalError, terminalStackTrace!);
+    }
+    if (cancellationToken.isCancelled) {
+      throw ChatGenerationCancelledException(
+        cancellationToken.reason ?? 'Cancelled',
+      );
+    }
+    return response;
+  }
+
+  Stream<LLMStreamChunk> generateStream(
+    List<ChatMessageMap> messages,
+    ChatGenerationStreamTransport transport,
+  ) async* {
+    final startedAt = DateTime.now();
+    final middlewareTraces = <GenerationMiddlewareTrace>[];
+    var request = _request(messages);
+    _lastGenerationRequest = request;
+    final active = await _runBefore(request, middlewareTraces);
+    request = active.request;
+    _lastGenerationRequest = request;
+    final content = StringBuffer();
+    final reasoning = StringBuffer();
+    var recovered = false;
+    Object? terminalError;
+    StackTrace? terminalStackTrace;
+
+    try {
+      if (!cancellationToken.isCancelled) {
+        await for (final chunk in transport(request)) {
+          if (cancellationToken.isCancelled) break;
+          if (chunk.content != null) content.write(chunk.content);
+          if (chunk.reasoning != null) reasoning.write(chunk.reasoning);
+          yield chunk;
+        }
+      }
+    } catch (error, stackTrace) {
+      if (!cancellationToken.isCancelled) {
+        final recovery = await _recover(
+          active.middlewares,
+          request,
+          error,
+          stackTrace,
+          middlewareTraces,
+        );
+        if (recovery != null) {
+          recovered = true;
+          if (recovery.reasoning?.isNotEmpty == true) {
+            reasoning.write(recovery.reasoning);
+            yield LLMStreamChunk(
+              reasoning: recovery.reasoning,
+              isReasoningChunk: true,
+            );
+          }
+          if (recovery.content.isNotEmpty) {
+            content.write(recovery.content);
+            yield LLMStreamChunk(content: recovery.content);
+          }
+        } else {
+          terminalError = error;
+          terminalStackTrace = stackTrace;
+        }
+      }
+    }
+
+    final response = LLMResponse(
+      content: content.toString(),
+      reasoning: reasoning.isEmpty ? null : reasoning.toString(),
+    );
+    final outcome = ChatGenerationOutcome(
+      response: response,
+      streaming: true,
+      cancelled: cancellationToken.isCancelled,
+      recovered: recovered,
+      elapsed: DateTime.now().difference(startedAt),
+    );
+    await _runAfter(
+      active.middlewares,
+      request,
+      outcome,
+      middlewareTraces,
+    );
+    _finishTrace(
+      startedAt: startedAt,
+      streaming: true,
+      recovered: recovered,
+      middlewareTraces: middlewareTraces,
+      error: terminalError,
+    );
+    if (terminalError != null) {
+      Error.throwWithStackTrace(terminalError, terminalStackTrace!);
+    }
+    if (cancellationToken.isCancelled && content.isEmpty && reasoning.isEmpty) {
+      throw ChatGenerationCancelledException(
+        cancellationToken.reason ?? 'Cancelled',
+      );
+    }
+  }
+
+  Future<void> cancel([String reason = 'Cancelled by user']) async {
+    cancellationToken.cancel(reason);
+    if (_cancellationNotified) return;
+    _cancellationNotified = true;
+
+    final contextRequest = _lastContextRequest;
+    final generationRequest = _lastGenerationRequest;
+    final callbacks = <Future<void>>[];
+    if (contextRequest != null) {
+      for (final contributor in _pipeline.registry.contributors) {
+        callbacks.add(Future.sync(() => contributor.onCancelled(contextRequest))
+            .catchError((_) {}));
+      }
+    }
+    if (generationRequest != null) {
+      for (final middleware in _pipeline.registry.middlewares) {
+        callbacks.add(Future.sync(
+          () => middleware.onCancelled(generationRequest),
+        ).catchError((_) {}));
+      }
+    }
+    await Future.wait(callbacks);
+  }
+
+  void close() {
+    if (_closed) return;
+    _closed = true;
+    _pipeline._remove(this);
+  }
+
+  ChatGenerationRequest _request(List<ChatMessageMap> messages) {
+    return ChatGenerationRequest(
+      sessionId: sessionId,
+      chatId: chatId,
+      characterId: characterId,
+      groupId: groupId,
+      mode: mode,
+      messages: messages,
+      config: config,
+      cancellationToken: cancellationToken,
+      metadata: metadata,
+    );
+  }
+
+  Future<_ActiveMiddlewares> _runBefore(
+    ChatGenerationRequest initialRequest,
+    List<GenerationMiddlewareTrace> traces,
+  ) async {
+    var request = initialRequest;
+    final active = <ChatGenerationMiddleware>[];
+    for (final middleware in _pipeline.registry.middlewares) {
+      final enabledWatch = Stopwatch()..start();
+      try {
+        if (!await middleware.isEnabled(request)) continue;
+      } catch (error) {
+        traces.add(GenerationMiddlewareTrace(
+          middlewareId: middleware.id,
+          order: middleware.order,
+          phase: GenerationMiddlewarePhase.before,
+          elapsed: enabledWatch.elapsed,
+          error: error.toString(),
+        ));
+        continue;
+      }
+      if (cancellationToken.isCancelled) break;
+      final stopwatch = Stopwatch()..start();
+      try {
+        final updatedRequest = await middleware.beforeGeneration(request);
+        if (updatedRequest.sessionId != sessionId ||
+            updatedRequest.chatId != chatId ||
+            updatedRequest.characterId != characterId ||
+            updatedRequest.groupId != groupId ||
+            updatedRequest.mode != mode ||
+            !identical(updatedRequest.cancellationToken, cancellationToken)) {
+          throw StateError(
+            'Middleware ${middleware.id} cannot replace generation scope.',
+          );
+        }
+        request = updatedRequest;
+        active.add(middleware);
+        traces.add(GenerationMiddlewareTrace(
+          middlewareId: middleware.id,
+          order: middleware.order,
+          phase: GenerationMiddlewarePhase.before,
+          elapsed: stopwatch.elapsed,
+        ));
+      } catch (error) {
+        traces.add(GenerationMiddlewareTrace(
+          middlewareId: middleware.id,
+          order: middleware.order,
+          phase: GenerationMiddlewarePhase.before,
+          elapsed: stopwatch.elapsed,
+          error: error.toString(),
+        ));
+      }
+    }
+    return _ActiveMiddlewares(request, active);
+  }
+
+  Future<void> _runAfter(
+    List<ChatGenerationMiddleware> middlewares,
+    ChatGenerationRequest request,
+    ChatGenerationOutcome outcome,
+    List<GenerationMiddlewareTrace> traces,
+  ) async {
+    for (final middleware in middlewares.reversed) {
+      final stopwatch = Stopwatch()..start();
+      try {
+        await middleware.afterGeneration(request, outcome);
+        traces.add(GenerationMiddlewareTrace(
+          middlewareId: middleware.id,
+          order: middleware.order,
+          phase: GenerationMiddlewarePhase.after,
+          elapsed: stopwatch.elapsed,
+        ));
+      } catch (error) {
+        traces.add(GenerationMiddlewareTrace(
+          middlewareId: middleware.id,
+          order: middleware.order,
+          phase: GenerationMiddlewarePhase.after,
+          elapsed: stopwatch.elapsed,
+          error: error.toString(),
+        ));
+      }
+    }
+  }
+
+  Future<LLMResponse?> _recover(
+    List<ChatGenerationMiddleware> middlewares,
+    ChatGenerationRequest request,
+    Object error,
+    StackTrace stackTrace,
+    List<GenerationMiddlewareTrace> traces,
+  ) async {
+    for (final middleware in middlewares.reversed) {
+      final stopwatch = Stopwatch()..start();
+      try {
+        final response =
+            await middleware.recoverFromError(request, error, stackTrace);
+        traces.add(GenerationMiddlewareTrace(
+          middlewareId: middleware.id,
+          order: middleware.order,
+          phase: GenerationMiddlewarePhase.error,
+          elapsed: stopwatch.elapsed,
+          recovered: response != null,
+        ));
+        if (response != null) return response;
+      } catch (recoveryError) {
+        traces.add(GenerationMiddlewareTrace(
+          middlewareId: middleware.id,
+          order: middleware.order,
+          phase: GenerationMiddlewarePhase.error,
+          elapsed: stopwatch.elapsed,
+          error: recoveryError.toString(),
+        ));
+      }
+    }
+    return null;
+  }
+
+  void _finishTrace({
+    required DateTime startedAt,
+    required bool streaming,
+    required bool recovered,
+    required List<GenerationMiddlewareTrace> middlewareTraces,
+    Object? error,
+  }) {
+    try {
+      _pipeline.onGenerationFinished?.call(ChatGenerationTrace(
+        sessionId: sessionId,
+        mode: mode,
+        streaming: streaming,
+        cancelled: cancellationToken.isCancelled,
+        recovered: recovered,
+        middlewareTraces: middlewareTraces,
+        startedAt: startedAt,
+        completedAt: DateTime.now(),
+        error: error?.toString(),
+      ));
+    } catch (_) {
+      // Diagnostics must never break chat generation.
+    }
+  }
+
+  ContextContributionTrace _emptyContributionTrace(
+    ContextContributor contributor,
+    ContextContributionStatus status,
+    Duration elapsed, {
+    String? error,
+  }) {
+    return ContextContributionTrace(
+      contributorId: contributor.id,
+      order: contributor.order,
+      status: status,
+      allocatedTokens: 0,
+      originalTokens: 0,
+      usedTokens: 0,
+      originalMessageCount: 0,
+      truncatedMessageCount: 0,
+      droppedMessageCount: 0,
+      elapsed: elapsed,
+      injectedMessages: const [],
+      error: error,
+    );
+  }
+}
+
+class _FittedContribution {
+  const _FittedContribution({
+    required this.messages,
+    required this.tokens,
+    required this.truncatedMessages,
+    required this.droppedMessages,
+  });
+
+  final List<ChatMessageMap> messages;
+  final int tokens;
+  final int truncatedMessages;
+  final int droppedMessages;
+}
+
+class _ActiveMiddlewares {
+  const _ActiveMiddlewares(this.request, this.middlewares);
+
+  final ChatGenerationRequest request;
+  final List<ChatGenerationMiddleware> middlewares;
+}
+
+List<ChatMessageMap> _immutableMessages(Iterable<ChatMessageMap> messages) =>
+    List<ChatMessageMap>.unmodifiable(messages.map(_copyMessage));
+
+ChatMessageMap _copyMessage(ChatMessageMap message) =>
+    Map<String, dynamic>.unmodifiable(
+      message.map((key, value) => MapEntry(key, _copyValue(value))),
+    );
+
+dynamic _copyValue(dynamic value) {
+  if (value is Map) {
+    return Map<dynamic, dynamic>.unmodifiable(
+      value.map((key, nestedValue) => MapEntry(key, _copyValue(nestedValue))),
+    );
+  }
+  if (value is List) {
+    return List<dynamic>.unmodifiable(value.map(_copyValue));
+  }
+  return value;
+}

--- a/lib/presentation/providers/chat_extension_providers.dart
+++ b/lib/presentation/providers/chat_extension_providers.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:native_tavern/domain/services/chat_generation_pipeline.dart';
+
+final chatExtensionRegistryProvider = Provider<ChatExtensionRegistry>((ref) {
+  final registry = ChatExtensionRegistry();
+  ref.onDispose(registry.clear);
+  return registry;
+});
+
+final lastContextAssemblyProvider =
+    StateProvider<ContextAssemblyResult?>((ref) => null);
+
+final lastChatGenerationTraceProvider =
+    StateProvider<ChatGenerationTrace?>((ref) => null);
+
+final chatGenerationPipelineProvider = Provider<ChatGenerationPipeline>((ref) {
+  final pipeline = ChatGenerationPipeline(
+    registry: ref.watch(chatExtensionRegistryProvider),
+    onContextAssembled: (result) {
+      ref.read(lastContextAssemblyProvider.notifier).state = result;
+    },
+    onGenerationFinished: (trace) {
+      ref.read(lastChatGenerationTraceProvider.notifier).state = trace;
+    },
+  );
+  ref.onDispose(pipeline.dispose);
+  return pipeline;
+});

--- a/lib/presentation/providers/chat_providers.dart
+++ b/lib/presentation/providers/chat_providers.dart
@@ -17,6 +17,8 @@ import 'package:native_tavern/data/repositories/persona_repository.dart';
 import 'package:native_tavern/domain/services/llm_service.dart';
 import 'package:native_tavern/domain/services/macro_service.dart';
 import 'package:native_tavern/domain/services/chat_summarization_service.dart';
+import 'package:native_tavern/domain/services/chat_generation_pipeline.dart';
+import 'package:native_tavern/presentation/providers/chat_extension_providers.dart';
 import 'package:native_tavern/presentation/providers/group_providers.dart';
 import 'package:native_tavern/presentation/providers/persona_providers.dart';
 import 'package:native_tavern/presentation/providers/prompt_manager_providers.dart';
@@ -96,10 +98,12 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
   final LLMService _llmService;
   final WorldInfoMatcher _worldInfoMatcher;
   final ChatSummarizationService _summarizationService;
+  final ChatGenerationPipeline _generationPipeline;
   final Ref _ref;
 
   // Track cancellation flag for stream processing
   bool _isCancelling = false;
+  ChatGenerationSession? _activeGenerationSession;
 
   ActiveChatNotifier({
     required ChatRepository chatRepository,
@@ -108,6 +112,7 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
     required LLMService llmService,
     required WorldInfoMatcher worldInfoMatcher,
     required ChatSummarizationService summarizationService,
+    required ChatGenerationPipeline generationPipeline,
     required Ref ref,
   })  : _chatRepository = chatRepository,
         _characterRepository = characterRepository,
@@ -115,6 +120,7 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
         _llmService = llmService,
         _worldInfoMatcher = worldInfoMatcher,
         _summarizationService = summarizationService,
+        _generationPipeline = generationPipeline,
         _ref = ref,
         super(const ActiveChatState());
 
@@ -173,6 +179,67 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
     ];
   }
 
+  void _startGenerationSession(
+    LLMConfig config,
+    ChatGenerationMode mode, {
+    String? characterId,
+  }) {
+    final previousSession = _activeGenerationSession;
+    if (previousSession != null) {
+      unawaited(previousSession.cancel('Superseded by a new generation'));
+      previousSession.close();
+    }
+    final chat = state.chat;
+    if (chat == null) return;
+    _activeGenerationSession = _generationPipeline.startSession(
+      chatId: chat.id,
+      characterId: characterId ?? state.character?.id,
+      groupId: state.group?.id ?? chat.groupId,
+      mode: mode,
+      config: config,
+      metadata: {
+        'isGroupChat': state.isGroupChat,
+        'messageCount': state.messages.length,
+      },
+    );
+  }
+
+  Future<List<Map<String, dynamic>>> _applyContextContributors(
+    List<Map<String, dynamic>> messages,
+  ) async {
+    final session = _activeGenerationSession;
+    if (session == null) return messages;
+    final result = await session.assemble(messages);
+    if (result.cancelled) {
+      throw ChatGenerationCancelledException(
+        session.cancellationToken.reason ?? 'Cancelled',
+      );
+    }
+    return result.messages;
+  }
+
+  void _closeGenerationSession([ChatGenerationSession? session]) {
+    final target = session ?? _activeGenerationSession;
+    target?.close();
+    if (session == null || identical(session, _activeGenerationSession)) {
+      _activeGenerationSession = null;
+    }
+  }
+
+  void _discardTrailingEmptyAssistantPlaceholder() {
+    final messages = state.messages;
+    if (messages.isEmpty) return;
+    final last = messages.last;
+    if (last.role != MessageRole.assistant ||
+        last.content.isNotEmpty ||
+        last.swipes.any((swipe) => swipe.isNotEmpty)) {
+      return;
+    }
+    state = state.copyWith(
+      messages: messages.sublist(0, messages.length - 1),
+    );
+  }
+
   /// Stream generation with assistant prefill: the prefill text is sent as
   /// a trailing assistant message (native prefill on Claude, continuation
   /// on OpenAI-compatible APIs) and emitted first so it becomes part of
@@ -181,12 +248,31 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
     List<Map<String, dynamic>> context,
     LLMConfig config,
   ) async* {
-    final prefill = state.chat?.startReplyWith ?? '';
-    if (prefill.isNotEmpty) {
-      yield LLMStreamChunk(content: prefill);
+    final session = _activeGenerationSession;
+    if (session == null) {
+      final prefill = state.chat?.startReplyWith ?? '';
+      if (prefill.isNotEmpty) yield LLMStreamChunk(content: prefill);
+      yield* _llmService.generateStreamWithReasoning(
+        _withPrefill(context),
+        config,
+      );
+      return;
     }
-    yield* _llmService.generateStreamWithReasoning(
-        _withPrefill(context), config);
+
+    Stream<LLMStreamChunk> transport(ChatGenerationRequest request) async* {
+      final prefill = state.chat?.startReplyWith ?? '';
+      if (prefill.isNotEmpty) yield LLMStreamChunk(content: prefill);
+      yield* _llmService.generateStreamWithReasoning(
+        _withPrefill(request.messages),
+        request.config,
+      );
+    }
+
+    try {
+      yield* session.generateStream(context, transport);
+    } finally {
+      _closeGenerationSession(session);
+    }
   }
 
   /// Non-streaming generation with assistant prefill
@@ -194,22 +280,65 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
     List<Map<String, dynamic>> context,
     LLMConfig config,
   ) async {
+    final session = _activeGenerationSession;
     final prefill = state.chat?.startReplyWith ?? '';
-    final response =
-        await _llmService.generateWithReasoning(_withPrefill(context), config);
-    if (prefill.isEmpty) return response;
-    return LLMResponse(
-      content: prefill + response.content,
-      reasoning: response.reasoning,
-    );
+    try {
+      if (session == null) {
+        final response = await _llmService.generateWithReasoning(
+          _withPrefill(context),
+          config,
+        );
+        if (prefill.isEmpty) return response;
+        return LLMResponse(
+          content: prefill + response.content,
+          reasoning: response.reasoning,
+        );
+      }
+      return await session.generate(context, (request) async {
+        final response = await _llmService.generateWithReasoning(
+          _withPrefill(request.messages),
+          request.config,
+        );
+        if (prefill.isEmpty) return response;
+        return LLMResponse(
+          content: prefill + response.content,
+          reasoning: response.reasoning,
+        );
+      });
+    } finally {
+      if (session != null) _closeGenerationSession(session);
+    }
+  }
+
+  Future<LLMResponse> _generateWithoutPrefill(
+    List<Map<String, dynamic>> context,
+    LLMConfig config,
+  ) async {
+    final session = _activeGenerationSession;
+    try {
+      if (session == null) {
+        return _llmService.generateWithReasoning(context, config);
+      }
+      return await session.generate(
+        context,
+        (request) => _llmService.generateWithReasoning(
+          request.messages,
+          request.config,
+        ),
+      );
+    } finally {
+      if (session != null) _closeGenerationSession(session);
+    }
   }
 
   /// Cancel current generation
   Future<void> cancelGeneration() async {
     _isCancelling = true;
+    final pipelineCancellation = _generationPipeline.cancelActiveSessions();
     // Abort the HTTP request so server-side generation actually stops
     _llmService.cancelActiveRequest();
     state = state.copyWith(isGenerating: false);
+    await pipelineCancellation;
     // Reset flag after a short delay
     Future.delayed(const Duration(milliseconds: 500), () {
       _isCancelling = false;
@@ -552,10 +681,12 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
     // Check if we need to summarize before generating response
     await _checkAndSummarize(config);
 
-    // Prepare context for LLM
-    final context = await _buildContext();
+    _startGenerationSession(config, ChatGenerationMode.send);
 
     try {
+      // Prepare context for LLM
+      final context = await _buildContext();
+
       // Create placeholder for assistant message
       final assistantMessage = ChatMessage(
         id: _generateId(),
@@ -629,6 +760,12 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
 
       state = state.copyWith(isGenerating: false);
     } catch (e, stackTrace) {
+      _closeGenerationSession();
+      if (e is ChatGenerationCancelledException) {
+        _discardTrailingEmptyAssistantPlaceholder();
+        state = state.copyWith(isGenerating: false);
+        return;
+      }
       debugPrint('❌ ChatProvider sendMessage error: $e\n$stackTrace');
       state = state.copyWith(
         isGenerating: false,
@@ -645,6 +782,7 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
     if (lastMessage.role != MessageRole.assistant) return;
 
     state = state.copyWith(isGenerating: true, error: null);
+    _startGenerationSession(config, ChatGenerationMode.regenerate);
 
     try {
       final context = await _buildContext(excludeLastAssistant: true);
@@ -737,6 +875,11 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
 
       state = state.copyWith(isGenerating: false);
     } catch (e, stackTrace) {
+      _closeGenerationSession();
+      if (e is ChatGenerationCancelledException) {
+        state = state.copyWith(isGenerating: false);
+        return;
+      }
       debugPrint('❌ ChatProvider regenerateLastMessage error: $e\n$stackTrace');
       state = state.copyWith(isGenerating: false, error: e.toString());
     }
@@ -892,6 +1035,7 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
     if (message.role != MessageRole.assistant) return;
 
     state = state.copyWith(isGenerating: true, error: null);
+    _startGenerationSession(config, ChatGenerationMode.regenerate);
 
     try {
       // Build context up to (but not including) this message
@@ -990,6 +1134,11 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
 
       state = state.copyWith(isGenerating: false);
     } catch (e, stackTrace) {
+      _closeGenerationSession();
+      if (e is ChatGenerationCancelledException) {
+        state = state.copyWith(isGenerating: false);
+        return;
+      }
       debugPrint('❌ ChatProvider swipeGenerate error: $e\n$stackTrace');
       state = state.copyWith(isGenerating: false, error: e.toString());
     }
@@ -1064,8 +1213,9 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
     if (state.chat == null) return null;
 
     state = state.copyWith(isGenerating: true, error: null);
+    _startGenerationSession(config, ChatGenerationMode.impersonate);
     try {
-      final context = await _buildContext();
+      final context = [...await _buildContext()];
       context.add({
         'role': 'system',
         'content': '[Write the next reply from the point of view of the user '
@@ -1076,11 +1226,16 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
 
       // Deliberately bypass the assistant prefill - it steers the AI's
       // voice, not the user's
-      final response = await _llmService.generateWithReasoning(context, config);
+      final response = await _generateWithoutPrefill(context, config);
       state = state.copyWith(isGenerating: false);
       final text = response.content.trim();
       return text.isEmpty ? null : text;
     } catch (e) {
+      _closeGenerationSession();
+      if (e is ChatGenerationCancelledException) {
+        state = state.copyWith(isGenerating: false);
+        return null;
+      }
       state = state.copyWith(isGenerating: false, error: e.toString());
       return null;
     }
@@ -1091,6 +1246,7 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
     if (state.chat == null || state.character == null) return;
 
     state = state.copyWith(isGenerating: true, error: null);
+    _startGenerationSession(config, ChatGenerationMode.continueResponse);
 
     try {
       final context = await _buildContext();
@@ -1173,6 +1329,12 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
 
       state = state.copyWith(isGenerating: false);
     } catch (e, stackTrace) {
+      _closeGenerationSession();
+      if (e is ChatGenerationCancelledException) {
+        _discardTrailingEmptyAssistantPlaceholder();
+        state = state.copyWith(isGenerating: false);
+        return;
+      }
       debugPrint(
           '❌ ChatProvider _generateAssistantResponse error: $e\n$stackTrace');
       state = state.copyWith(
@@ -1516,7 +1678,7 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
     }
     print('=== End Context Messages ===');
 
-    return messages;
+    return _applyContextContributors(messages);
   }
 
   /// Build messages for a single prompt section
@@ -2050,7 +2212,7 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
       messages.addAll(sectionMessages);
     }
 
-    return messages;
+    return _applyContextContributors(messages);
   }
 
   /// Find matching World Info entries based on chat context
@@ -2307,7 +2469,7 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
         existingSummaries: chat.summaries,
         config: config,
         characterName: character?.name,
-        userName: persona?.name?.isNotEmpty == true ? persona!.name : 'User',
+        userName: persona?.name.isNotEmpty == true ? persona!.name : 'User',
       );
 
       // Add summary to chat
@@ -2641,6 +2803,11 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
       currentResponderId: characterId,
       error: null,
     );
+    _startGenerationSession(
+      config,
+      ChatGenerationMode.groupResponse,
+      characterId: characterId,
+    );
 
     try {
       final context = await _buildGroupContext(character);
@@ -2728,6 +2895,15 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
         clearCurrentResponder: true,
       );
     } catch (e, stackTrace) {
+      _closeGenerationSession();
+      if (e is ChatGenerationCancelledException) {
+        _discardTrailingEmptyAssistantPlaceholder();
+        state = state.copyWith(
+          isGenerating: false,
+          clearCurrentResponder: true,
+        );
+        return;
+      }
       debugPrint('❌ ChatProvider group response error: $e\n$stackTrace');
       state = state.copyWith(
         isGenerating: false,
@@ -2762,7 +2938,7 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
       }
     }
 
-    return messages;
+    return _applyContextContributors(messages);
   }
 
   /// Build system prompt for group chat
@@ -2893,6 +3069,7 @@ final activeChatProvider =
   final llmService = ref.watch(llmServiceProvider);
   final worldInfoMatcher = ref.watch(worldInfoMatcherProvider);
   final summarizationService = ref.watch(chatSummarizationServiceProvider);
+  final generationPipeline = ref.watch(chatGenerationPipelineProvider);
 
   return ActiveChatNotifier(
     chatRepository: chatRepo,
@@ -2901,6 +3078,7 @@ final activeChatProvider =
     llmService: llmService,
     worldInfoMatcher: worldInfoMatcher,
     summarizationService: summarizationService,
+    generationPipeline: generationPipeline,
     ref: ref,
   );
 });

--- a/test/chat_extension_end_to_end_test.dart
+++ b/test/chat_extension_end_to_end_test.dart
@@ -1,0 +1,284 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:native_tavern/core/services/initialization_service.dart';
+import 'package:native_tavern/data/database/database.dart';
+import 'package:native_tavern/data/models/character.dart' as models;
+import 'package:native_tavern/data/repositories/character_repository.dart';
+import 'package:native_tavern/data/repositories/chat_repository.dart';
+import 'package:native_tavern/domain/services/chat_generation_pipeline.dart';
+import 'package:native_tavern/domain/services/llm_service.dart';
+import 'package:native_tavern/presentation/providers/chat_extension_providers.dart';
+import 'package:native_tavern/presentation/providers/chat_providers.dart';
+import 'package:native_tavern/presentation/providers/settings_providers.dart';
+import 'package:native_tavern/presentation/providers/vector_storage_providers.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late AppDatabase database;
+  late Directory dataDirectory;
+  late ChatRepository chatRepository;
+  late CharacterRepository characterRepository;
+  late _RecordingLLMService llmService;
+  late ProviderContainer container;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    final preferences = await SharedPreferences.getInstance();
+    database = AppDatabase.forTesting(NativeDatabase.memory());
+    dataDirectory = Directory.systemTemp.createTempSync('nt_chat_extension');
+    chatRepository = ChatRepository(database);
+    characterRepository = CharacterRepository(database, dataDirectory.path);
+    llmService = _RecordingLLMService();
+    container = ProviderContainer(overrides: [
+      databaseProvider.overrideWithValue(database),
+      dataPathProvider.overrideWithValue(dataDirectory.path),
+      characterRepositoryProvider.overrideWithValue(characterRepository),
+      chatRepositoryProvider.overrideWithValue(chatRepository),
+      llmServiceProvider.overrideWithValue(llmService),
+      sharedPreferencesProvider.overrideWithValue(preferences),
+      ragContextProvider.overrideWithValue((_) async => null),
+    ]);
+
+    final now = DateTime.now();
+    await characterRepository.createCharacter(models.Character(
+      id: 'character-1',
+      name: 'Extension Tester',
+      description: 'A character used for the chat extension test.',
+      createdAt: now,
+      modifiedAt: now,
+    ));
+  });
+
+  tearDown(() async {
+    container.dispose();
+    await database.close();
+    dataDirectory.deleteSync(recursive: true);
+  });
+
+  test('contributor and middleware run through a persisted chat turn',
+      () async {
+    final registry = container.read(chatExtensionRegistryProvider);
+    registry.registerContributor(_TestContributor());
+    registry.registerMiddleware(_TestMiddleware());
+    final notifier = container.read(activeChatProvider.notifier);
+    final chatId = await notifier.createChat('character-1');
+    expect(chatId, isNotNull);
+
+    await notifier.sendMessage('Where should we go?', _config);
+
+    expect(llmService.requests, hasLength(1));
+    final request = llmService.requests.single;
+    expect(
+      request.any((message) => message['content'] == 'Retrieved memory'),
+      isTrue,
+    );
+    expect(
+      request.any((message) => message['content'] == 'Middleware marker'),
+      isTrue,
+    );
+    expect(
+      request.any((message) => message['content'] == 'Where should we go?'),
+      isTrue,
+    );
+
+    final savedMessages = await chatRepository.getMessages(chatId!);
+    expect(savedMessages.map((message) => message.content), [
+      'Where should we go?',
+      'Take the eastern road.',
+    ]);
+    expect(container.read(activeChatProvider).isGenerating, isFalse);
+    expect(container.read(activeChatProvider).error, isNull);
+
+    final assembly = container.read(lastContextAssemblyProvider);
+    expect(assembly, isNotNull);
+    expect(assembly!.traces.single.contributorId, 'test.memory');
+    expect(
+      assembly.traces.single.status,
+      ContextContributionStatus.applied,
+    );
+    final generation = container.read(lastChatGenerationTraceProvider);
+    expect(generation?.mode, ChatGenerationMode.send);
+    expect(generation?.middlewareTraces, hasLength(2));
+  });
+
+  test('empty registry sends the assembled baseline without pipeline changes',
+      () async {
+    final notifier = container.read(activeChatProvider.notifier);
+    await notifier.createChat('character-1');
+
+    await notifier.sendMessage('Baseline request', _config);
+
+    final assembly = container.read(lastContextAssemblyProvider);
+    expect(assembly, isNotNull);
+    expect(assembly!.traces, isEmpty);
+    expect(llmService.requests.single, assembly.messages);
+    expect(
+      llmService.requests.single
+          .where((message) => message['content'] == 'Baseline request'),
+      hasLength(1),
+    );
+  });
+
+  test('cancelling context assembly does not persist an empty reply', () async {
+    final contributor = _SlowContributor();
+    container
+        .read(chatExtensionRegistryProvider)
+        .registerContributor(contributor);
+    final notifier = container.read(activeChatProvider.notifier);
+    final chatId = await notifier.createChat('character-1');
+
+    final sending = notifier.sendMessage('Stop this request', _config);
+    await contributor.started.future;
+    await notifier.cancelGeneration();
+    await sending;
+
+    final savedMessages = await chatRepository.getMessages(chatId!);
+    expect(savedMessages.map((message) => message.content), [
+      'Stop this request',
+    ]);
+    expect(llmService.requests, isEmpty);
+    expect(container.read(activeChatProvider).isGenerating, isFalse);
+    expect(container.read(activeChatProvider).error, isNull);
+    expect(container.read(lastContextAssemblyProvider)?.cancelled, isTrue);
+  });
+
+  test('cancelling middleware removes its in-memory reply placeholder',
+      () async {
+    final middleware = _SlowMiddleware();
+    container
+        .read(chatExtensionRegistryProvider)
+        .registerMiddleware(middleware);
+    final notifier = container.read(activeChatProvider.notifier);
+    final chatId = await notifier.createChat('character-1');
+
+    final sending = notifier.sendMessage('Cancel before output', _config);
+    await middleware.started.future.timeout(
+      const Duration(seconds: 3),
+      onTimeout: () => throw StateError('middleware did not start'),
+    );
+    await notifier.cancelGeneration().timeout(
+          const Duration(seconds: 3),
+          onTimeout: () => throw StateError('cancelGeneration did not finish'),
+        );
+    await middleware.resumed.future.timeout(
+      const Duration(seconds: 3),
+      onTimeout: () => throw StateError('middleware did not observe cancel'),
+    );
+    await sending.timeout(
+      const Duration(seconds: 3),
+      onTimeout: () => throw StateError('sendMessage did not finish'),
+    );
+
+    final state = container.read(activeChatProvider);
+    expect(state.messages.map((message) => message.content), [
+      'Cancel before output',
+    ]);
+    expect(
+      (await chatRepository.getMessages(chatId!))
+          .map((message) => message.content),
+      ['Cancel before output'],
+    );
+    expect(llmService.requests, isEmpty);
+    expect(state.error, isNull);
+  });
+}
+
+const _config = LLMConfig(
+  provider: LLMProvider.openAICompatible,
+  model: 'test-model',
+  apiKey: '',
+  apiUrl: 'http://localhost',
+  contextLength: 4096,
+  maxTokens: 256,
+  streamEnabled: false,
+  autoSummarizeEnabled: false,
+);
+
+class _RecordingLLMService extends LLMService {
+  final List<List<ChatMessageMap>> requests = [];
+
+  @override
+  Future<LLMResponse> generateWithReasoning(
+    List<Map<String, dynamic>> messages,
+    LLMConfig config,
+  ) async {
+    requests.add(
+      messages.map((message) => Map<String, dynamic>.from(message)).toList(),
+    );
+    return const LLMResponse(content: 'Take the eastern road.');
+  }
+}
+
+class _TestContributor extends ContextContributor {
+  @override
+  String get id => 'test.memory';
+
+  @override
+  int get order => 100;
+
+  @override
+  int get maxTokens => 64;
+
+  @override
+  Future<ContextContribution> contribute(ChatContextRequest request) async {
+    expect(request.chatId, isNotEmpty);
+    expect(request.characterId, 'character-1');
+    expect(request.mode, ChatGenerationMode.send);
+    return ContextContribution(messages: const [
+      {'role': 'system', 'content': 'Retrieved memory'},
+    ]);
+  }
+}
+
+class _TestMiddleware extends ChatGenerationMiddleware {
+  @override
+  String get id => 'test.middleware';
+
+  @override
+  ChatGenerationRequest beforeGeneration(ChatGenerationRequest request) {
+    return request.copyWith(messages: [
+      ...request.messages,
+      {'role': 'system', 'content': 'Middleware marker'},
+    ]);
+  }
+}
+
+class _SlowContributor extends ContextContributor {
+  final Completer<void> started = Completer<void>();
+
+  @override
+  String get id => 'test.slow';
+
+  @override
+  Future<ContextContribution> contribute(ChatContextRequest request) async {
+    started.complete();
+    await request.cancellationToken.whenCancelled;
+    request.cancellationToken.throwIfCancelled();
+    throw StateError('unreachable');
+  }
+}
+
+class _SlowMiddleware extends ChatGenerationMiddleware {
+  final Completer<void> started = Completer<void>();
+  final Completer<void> resumed = Completer<void>();
+
+  @override
+  String get id => 'test.slow-middleware';
+
+  @override
+  Future<ChatGenerationRequest> beforeGeneration(
+    ChatGenerationRequest request,
+  ) async {
+    started.complete();
+    await request.cancellationToken.whenCancelled;
+    resumed.complete();
+    request.cancellationToken.throwIfCancelled();
+    throw StateError('unreachable');
+  }
+}

--- a/test/chat_generation_pipeline_test.dart
+++ b/test/chat_generation_pipeline_test.dart
@@ -1,0 +1,488 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:native_tavern/domain/services/chat_generation_pipeline.dart';
+import 'package:native_tavern/domain/services/llm_service.dart';
+
+void main() {
+  group('context assembly', () {
+    test('preserves the base payload when no extensions are registered',
+        () async {
+      ContextAssemblyResult? observed;
+      final pipeline = ChatGenerationPipeline(
+        registry: ChatExtensionRegistry(),
+        onContextAssembled: (result) => observed = result,
+      );
+      final session = pipeline.startSession(
+        chatId: 'chat-1',
+        mode: ChatGenerationMode.send,
+        config: _config,
+      );
+      final base = <ChatMessageMap>[
+        {'role': 'system', 'content': 'Stay in character.'},
+        {'role': 'user', 'content': 'Hello'},
+      ];
+
+      final result = await session.assemble(base);
+
+      expect(result.messages, base);
+      expect(result.baseMessages, base);
+      expect(result.traces, isEmpty);
+      expect(result.baseEstimatedTokens, result.estimatedTokens);
+      expect(observed, same(result));
+      expect(
+        () => result.messages.add({'role': 'user', 'content': 'mutate'}),
+        throwsUnsupportedError,
+      );
+      session.close();
+    });
+
+    test('orders contributors deterministically and honors placement',
+        () async {
+      final calls = <String>[];
+      final registry = ChatExtensionRegistry();
+      registry.registerContributor(_Contributor(
+        id: 'leading',
+        order: 10,
+        onContribute: (request) async {
+          calls.add('leading');
+          return ContextContribution(
+            placement: ContextContributionPlacement.beforeBase,
+            messages: const [
+              {'role': 'assistant', 'content': 'Leading'},
+            ],
+          );
+        },
+      ));
+      registry.registerContributor(_Contributor(
+        id: 'alpha',
+        order: 20,
+        onContribute: (request) async {
+          calls.add('alpha');
+          return ContextContribution(messages: const [
+            {'role': 'system', 'content': 'Before conversation'},
+          ]);
+        },
+      ));
+      registry.registerContributor(_Contributor(
+        id: 'zeta',
+        order: 20,
+        onContribute: (request) async {
+          calls.add('zeta');
+          return ContextContribution(
+            placement: ContextContributionPlacement.afterBase,
+            messages: const [
+              {'role': 'system', 'content': 'Trailing'},
+            ],
+          );
+        },
+      ));
+      final session = ChatGenerationPipeline(registry: registry).startSession(
+        chatId: 'chat-1',
+        mode: ChatGenerationMode.send,
+        config: _config,
+      );
+
+      final result = await session.assemble(const [
+        {'role': 'system', 'content': 'Base system'},
+        {'role': 'user', 'content': 'Base user'},
+      ]);
+
+      expect(calls, ['leading', 'alpha', 'zeta']);
+      expect(
+        result.messages.map((message) => message['content']),
+        [
+          'Leading',
+          'Base system',
+          'Before conversation',
+          'Base user',
+          'Trailing',
+        ],
+      );
+      expect(
+        result.traces.map((trace) => trace.contributorId),
+        ['leading', 'alpha', 'zeta'],
+      );
+      session.close();
+    });
+
+    test('isolates disabled and failing contributors', () async {
+      final registry = ChatExtensionRegistry();
+      registry.registerContributor(_Contributor(
+        id: 'disabled',
+        order: 1,
+        enabled: false,
+        onContribute: (_) async => throw StateError('must not run'),
+      ));
+      registry.registerContributor(_Contributor(
+        id: 'failing',
+        order: 2,
+        onContribute: (_) async => throw StateError('broken source'),
+      ));
+      registry.registerContributor(_Contributor(
+        id: 'healthy',
+        order: 3,
+        onContribute: (_) async => ContextContribution(messages: const [
+          {'role': 'system', 'content': 'Healthy context'},
+        ]),
+      ));
+      final session = ChatGenerationPipeline(registry: registry).startSession(
+        chatId: 'chat-1',
+        mode: ChatGenerationMode.send,
+        config: _config,
+      );
+
+      final result = await session.assemble(const [
+        {'role': 'user', 'content': 'Hello'},
+      ]);
+
+      expect(result.messages.last['content'], 'Hello');
+      expect(result.messages.first['content'], 'Healthy context');
+      expect(
+        result.traces.map((trace) => trace.status),
+        [
+          ContextContributionStatus.disabled,
+          ContextContributionStatus.failed,
+          ContextContributionStatus.applied,
+        ],
+      );
+      expect(result.traces[1].error, contains('broken source'));
+      session.close();
+    });
+
+    test('enforces contributor token budgets and records trimming', () async {
+      final registry = ChatExtensionRegistry();
+      registry.registerContributor(_Contributor(
+        id: 'bounded',
+        maxTokens: 18,
+        onContribute: (_) async => ContextContribution(messages: [
+          {'role': 'system', 'content': 'x' * 500},
+        ]),
+      ));
+      final session = ChatGenerationPipeline(registry: registry).startSession(
+        chatId: 'chat-1',
+        mode: ChatGenerationMode.send,
+        config: _config.copyWith(contextLength: 256, maxTokens: 64),
+      );
+
+      final result = await session.assemble(const [
+        {'role': 'user', 'content': 'Hello'},
+      ]);
+      final trace = result.traces.single;
+
+      expect(trace.allocatedTokens, 18);
+      expect(trace.usedTokens, lessThanOrEqualTo(18));
+      expect(trace.originalTokens, greaterThan(trace.usedTokens));
+      expect(trace.truncatedMessageCount, 1);
+      expect(trace.injectedMessages.single['content'], contains('[truncated]'));
+      expect(result.wasTrimmed, isTrue);
+      expect(
+        result.estimatedTokens,
+        lessThanOrEqualTo(result.baseEstimatedTokens + 18),
+      );
+      session.close();
+    });
+
+    test('propagates cancellation to a running contributor', () async {
+      final started = Completer<void>();
+      var cancellationCallbackRan = false;
+      final registry = ChatExtensionRegistry();
+      registry.registerContributor(_Contributor(
+        id: 'slow',
+        onContribute: (request) async {
+          started.complete();
+          await request.cancellationToken.whenCancelled;
+          request.cancellationToken.throwIfCancelled();
+          throw StateError('unreachable');
+        },
+        onCancel: (_) => cancellationCallbackRan = true,
+      ));
+      final pipeline = ChatGenerationPipeline(registry: registry);
+      final session = pipeline.startSession(
+        chatId: 'chat-1',
+        mode: ChatGenerationMode.send,
+        config: _config,
+      );
+
+      final assembling = session.assemble(const [
+        {'role': 'user', 'content': 'Hello'},
+      ]);
+      await started.future;
+      await pipeline.cancelActiveSessions();
+      final result = await assembling;
+
+      expect(result.cancelled, isTrue);
+      expect(result.messages.single['content'], 'Hello');
+      expect(result.traces.single.status, ContextContributionStatus.cancelled);
+      expect(cancellationCallbackRan, isTrue);
+      session.close();
+    });
+  });
+
+  group('generation middleware', () {
+    test('runs before/after in stack order and recovers transport errors',
+        () async {
+      final events = <String>[];
+      final registry = ChatExtensionRegistry();
+      registry.registerMiddleware(_Middleware(
+        id: 'outer',
+        order: 10,
+        events: events,
+        marker: 'outer marker',
+        recovery: const LLMResponse(content: 'recovered reply'),
+      ));
+      registry.registerMiddleware(_Middleware(
+        id: 'inner',
+        order: 20,
+        events: events,
+        marker: 'inner marker',
+      ));
+      ChatGenerationTrace? observed;
+      final session = ChatGenerationPipeline(
+        registry: registry,
+        onGenerationFinished: (trace) => observed = trace,
+      ).startSession(
+        chatId: 'chat-1',
+        mode: ChatGenerationMode.send,
+        config: _config,
+      );
+
+      final response = await session.generate(
+        const [
+          {'role': 'user', 'content': 'Hello'},
+        ],
+        (request) async {
+          events.add('transport:${request.messages.length}');
+          expect(
+            request.messages.map((message) => message['content']),
+            ['Hello', 'outer marker', 'inner marker'],
+          );
+          throw StateError('provider unavailable');
+        },
+      );
+
+      expect(response.content, 'recovered reply');
+      expect(events, [
+        'before:outer',
+        'before:inner',
+        'transport:3',
+        'recover:inner',
+        'recover:outer',
+        'after:inner:true',
+        'after:outer:true',
+      ]);
+      expect(observed?.recovered, isTrue);
+      expect(observed?.error, isNull);
+      session.close();
+    });
+
+    test('stops a stream and notifies middleware on cancellation', () async {
+      final events = <String>[];
+      final registry = ChatExtensionRegistry();
+      registry.registerMiddleware(_Middleware(
+        id: 'observer',
+        order: 1,
+        events: events,
+      ));
+      ChatGenerationTrace? observed;
+      final pipeline = ChatGenerationPipeline(
+        registry: registry,
+        onGenerationFinished: (trace) => observed = trace,
+      );
+      final session = pipeline.startSession(
+        chatId: 'chat-1',
+        mode: ChatGenerationMode.continueResponse,
+        config: _config,
+      );
+      final firstChunk = Completer<void>();
+      final done = Completer<void>();
+      final chunks = <String>[];
+
+      session.generateStream(
+        const [
+          {'role': 'user', 'content': 'Continue'},
+        ],
+        (request) async* {
+          yield const LLMStreamChunk(content: 'first');
+          await request.cancellationToken.whenCancelled;
+          yield const LLMStreamChunk(content: 'second');
+        },
+      ).listen(
+        (chunk) {
+          chunks.add(chunk.content!);
+          firstChunk.complete();
+        },
+        onDone: done.complete,
+        onError: done.completeError,
+      );
+
+      await firstChunk.future;
+      await pipeline.cancelActiveSessions();
+      await done.future;
+
+      expect(chunks, ['first']);
+      expect(events, contains('cancel:observer'));
+      expect(observed?.cancelled, isTrue);
+      expect(observed?.streaming, isTrue);
+      session.close();
+    });
+
+    test('isolates a middleware that attempts to replace session scope',
+        () async {
+      final registry = ChatExtensionRegistry();
+      registry.registerMiddleware(_ScopeReplacingMiddleware());
+      final session = ChatGenerationPipeline(registry: registry).startSession(
+        chatId: 'chat-1',
+        mode: ChatGenerationMode.send,
+        config: _config,
+      );
+      ChatGenerationRequest? transported;
+
+      await session.generate(
+        const [
+          {'role': 'user', 'content': 'Hello'},
+        ],
+        (request) async {
+          transported = request;
+          return const LLMResponse(content: 'ok');
+        },
+      );
+
+      expect(transported?.chatId, 'chat-1');
+      expect(transported?.messages.single['content'], 'Hello');
+      session.close();
+    });
+  });
+
+  test('registry rejects duplicate extension IDs and supports disposal', () {
+    final registry = ChatExtensionRegistry();
+    final registration = registry.registerContributor(_Contributor(
+      id: 'memory',
+      onContribute: (_) async => ContextContribution(messages: const []),
+    ));
+
+    expect(
+      () => registry.registerContributor(_Contributor(
+        id: 'memory',
+        onContribute: (_) async => ContextContribution(messages: const []),
+      )),
+      throwsStateError,
+    );
+
+    registration.dispose();
+    expect(registry.contributors, isEmpty);
+  });
+}
+
+const LLMConfig _config = LLMConfig(
+  provider: LLMProvider.openAICompatible,
+  model: 'test-model',
+  apiKey: '',
+  apiUrl: 'http://localhost',
+  contextLength: 4096,
+  maxTokens: 512,
+  streamEnabled: false,
+  autoSummarizeEnabled: false,
+);
+
+class _Contributor extends ContextContributor {
+  _Contributor({
+    required this.id,
+    required this.onContribute,
+    this.order = 0,
+    this.maxTokens,
+    this.enabled = true,
+    this.onCancel,
+  });
+
+  @override
+  final String id;
+  @override
+  final int order;
+  @override
+  final int? maxTokens;
+  final bool enabled;
+  final Future<ContextContribution> Function(ChatContextRequest request)
+      onContribute;
+  final void Function(ChatContextRequest request)? onCancel;
+
+  @override
+  bool isEnabled(ChatContextRequest request) => enabled;
+
+  @override
+  Future<ContextContribution> contribute(ChatContextRequest request) =>
+      onContribute(request);
+
+  @override
+  void onCancelled(ChatContextRequest request) => onCancel?.call(request);
+}
+
+class _Middleware extends ChatGenerationMiddleware {
+  _Middleware({
+    required this.id,
+    required this.order,
+    required this.events,
+    this.marker,
+    this.recovery,
+  });
+
+  @override
+  final String id;
+  @override
+  final int order;
+  final List<String> events;
+  final String? marker;
+  final LLMResponse? recovery;
+
+  @override
+  ChatGenerationRequest beforeGeneration(ChatGenerationRequest request) {
+    events.add('before:$id');
+    if (marker == null) return request;
+    return request.copyWith(messages: [
+      ...request.messages,
+      {'role': 'system', 'content': marker},
+    ]);
+  }
+
+  @override
+  void afterGeneration(
+    ChatGenerationRequest request,
+    ChatGenerationOutcome outcome,
+  ) {
+    events.add('after:$id:${outcome.recovered}');
+  }
+
+  @override
+  LLMResponse? recoverFromError(
+    ChatGenerationRequest request,
+    Object error,
+    StackTrace stackTrace,
+  ) {
+    events.add('recover:$id');
+    return recovery;
+  }
+
+  @override
+  void onCancelled(ChatGenerationRequest request) {
+    events.add('cancel:$id');
+  }
+}
+
+class _ScopeReplacingMiddleware extends ChatGenerationMiddleware {
+  @override
+  String get id => 'scope-replacer';
+
+  @override
+  ChatGenerationRequest beforeGeneration(ChatGenerationRequest request) {
+    return ChatGenerationRequest(
+      sessionId: request.sessionId,
+      chatId: 'different-chat',
+      mode: request.mode,
+      messages: const [
+        {'role': 'system', 'content': 'malicious replacement'},
+      ],
+      config: request.config,
+      cancellationToken: request.cancellationToken,
+    );
+  }
+}


### PR DESCRIPTION
## Summary

- add a shared ContextContributor registry with deterministic ordering, enablement, lifecycle ownership, token budgets, truncation, and failure isolation
- add observable context assembly and generation middleware traces with cancellation propagation and error recovery
- integrate the extension boundary across send, regenerate, Swipe, continue, impersonate, and group reply flows while preserving the empty-registry payload
- document the extension contract for B07, C05, F07, and G09

## J02 completion

- [x] Contributor lifecycle, ordering, token budget, enable/disable, and failure isolation
- [x] Observable assembly results covering source, order, trimming, and final injected messages
- [x] Before/after generation middleware, cooperative cancellation, and error recovery boundaries
- [x] Existing summaries, world info, RAG, variables, group chat, Swipe, branching, and empty-registry behavior remain on their existing paths
- [x] Independent provider/registry files for downstream feature registration

## Verification

- `dart format` on all changed Dart files
- targeted analysis: new pipeline/provider/test files have no diagnostics; `chat_providers.dart` retains 11 pre-existing info-level lints
- `flutter test test/chat_generation_pipeline_test.dart test/chat_extension_end_to_end_test.dart` (13 passed)
- `flutter test` on latest `origin/main` (173 passed)
- `git diff --check`

Closes #16