### PR TITLE
feat: add RPG scenario package editor

### DIFF
--- a/lib/domain/services/rpg_scenario_draft_store.dart
+++ b/lib/domain/services/rpg_scenario_draft_store.dart
@@ -1,0 +1,103 @@
+// Draft files are intentionally tiny and user-triggered; asynchronous I/O keeps
+// editor saves off the UI isolate's synchronous filesystem path.
+// ignore_for_file: avoid_slow_async_io
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as path;
+import 'package:path_provider/path_provider.dart';
+
+import 'rpg_scenario_package_service.dart';
+
+class RpgScenarioDraft {
+  final Map<String, dynamic> document;
+  final RpgScenarioPackageFormat format;
+  final DateTime updatedAt;
+
+  const RpgScenarioDraft({
+    required this.document,
+    required this.format,
+    required this.updatedAt,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'document': document,
+        'format': format.name,
+        'updatedAt': updatedAt.toUtc().toIso8601String(),
+      };
+
+  factory RpgScenarioDraft.fromJson(Map<String, dynamic> json) =>
+      RpgScenarioDraft(
+        document: Map<String, dynamic>.from(
+          json['document'] as Map<dynamic, dynamic>,
+        ),
+        format: RpgScenarioPackageFormat.values.firstWhere(
+          (value) => value.name == json['format'],
+          orElse: () => RpgScenarioPackageFormat.json,
+        ),
+        updatedAt: DateTime.parse(json['updatedAt'] as String).toUtc(),
+      );
+}
+
+abstract class RpgScenarioDraftStore {
+  Future<void> save(RpgScenarioDraft draft);
+  Future<RpgScenarioDraft?> load();
+  Future<void> clear();
+}
+
+/// Stores the active editor draft locally using an atomic replace operation.
+class FileRpgScenarioDraftStore implements RpgScenarioDraftStore {
+  final Directory rootDirectory;
+
+  const FileRpgScenarioDraftStore(this.rootDirectory);
+
+  static Future<FileRpgScenarioDraftStore> forApplicationSupport() async {
+    final support = await getApplicationSupportDirectory();
+    return FileRpgScenarioDraftStore(
+      Directory(path.join(support.path, 'rpg_scenario_editor')),
+    );
+  }
+
+  File get _draftFile =>
+      File(path.join(rootDirectory.path, 'active_draft.json'));
+
+  @override
+  Future<void> save(RpgScenarioDraft draft) async {
+    await rootDirectory.create(recursive: true);
+    final target = _draftFile;
+    final temporary = File('${target.path}.tmp');
+    final backup = File('${target.path}.bak');
+    await temporary.writeAsString(jsonEncode(draft.toJson()), flush: true);
+
+    if (await backup.exists()) await backup.delete();
+    if (await target.exists()) await target.rename(backup.path);
+    try {
+      await temporary.rename(target.path);
+      if (await backup.exists()) await backup.delete();
+    } catch (_) {
+      if (await target.exists()) await target.delete();
+      if (await backup.exists()) await backup.rename(target.path);
+      rethrow;
+    } finally {
+      if (await temporary.exists()) await temporary.delete();
+    }
+  }
+
+  @override
+  Future<RpgScenarioDraft?> load() async {
+    final file = _draftFile;
+    if (!await file.exists()) return null;
+    final decoded = jsonDecode(await file.readAsString());
+    if (decoded is! Map<String, dynamic>) {
+      throw const FormatException('RPG scenario draft root must be an object.');
+    }
+    return RpgScenarioDraft.fromJson(decoded);
+  }
+
+  @override
+  Future<void> clear() async {
+    final file = _draftFile;
+    if (await file.exists()) await file.delete();
+  }
+}

--- a/lib/domain/services/rpg_scenario_package_service.dart
+++ b/lib/domain/services/rpg_scenario_package_service.dart
@@ -1,0 +1,912 @@
+import 'dart:convert';
+import 'dart:isolate';
+import 'dart:typed_data';
+
+import 'package:native_tavern/data/models/rpg/rpg.dart';
+import 'package:yaml/yaml.dart';
+
+enum RpgScenarioPackageFormat { json, yaml }
+
+class RpgScenarioPackageLimits {
+  final int maxBytes;
+  final int maxDepth;
+  final int maxNodes;
+  final int maxStringLength;
+  final int maxCollectionLength;
+
+  const RpgScenarioPackageLimits({
+    this.maxBytes = 2 * 1024 * 1024,
+    this.maxDepth = 48,
+    this.maxNodes = 50000,
+    this.maxStringLength = 256 * 1024,
+    this.maxCollectionLength = 5000,
+  });
+}
+
+class RpgScenarioPackageIssue {
+  final String path;
+  final String code;
+  final String message;
+  final int? line;
+  final int? column;
+
+  const RpgScenarioPackageIssue({
+    required this.path,
+    required this.code,
+    required this.message,
+    this.line,
+    this.column,
+  });
+
+  factory RpgScenarioPackageIssue.fromValidation(RpgValidationIssue issue) =>
+      RpgScenarioPackageIssue(
+        path: issue.path,
+        code: issue.code,
+        message: issue.message,
+      );
+
+  @override
+  String toString() {
+    final location = line == null ? '' : ' ($line:${column ?? 1})';
+    return '$path$location [$code]: $message';
+  }
+}
+
+class RpgScenarioPackageResult {
+  final RpgScenario? scenario;
+  final Map<String, dynamic>? document;
+  final RpgScenarioPackageFormat format;
+  final List<RpgScenarioPackageIssue> issues;
+
+  const RpgScenarioPackageResult({
+    required this.format,
+    required this.issues,
+    this.scenario,
+    this.document,
+  });
+
+  bool get isValid => scenario != null && issues.isEmpty;
+}
+
+/// Parses untrusted, declarative RPG packages into the C01 domain contract.
+///
+/// The importer accepts JSON and a deliberately constrained YAML subset. YAML
+/// anchors, aliases, merge keys, and custom tags are rejected before parsing so
+/// a package cannot expand a small document into an unbounded object graph.
+class RpgScenarioPackageService {
+  static const supportedExtensions = <String>['json', 'yaml', 'yml'];
+
+  final RpgScenarioPackageLimits limits;
+  final String engineVersion;
+  final Set<String> availableCapabilities;
+  final RpgScenarioValidator _validator;
+
+  const RpgScenarioPackageService({
+    this.limits = const RpgScenarioPackageLimits(),
+    this.engineVersion = RpgCompatibility.defaultEngineVersion,
+    this.availableCapabilities = const {'core_rules'},
+    RpgScenarioValidator validator = const RpgScenarioValidator(),
+  }) : _validator = validator;
+
+  RpgScenarioPackageResult importBytes(
+    Uint8List bytes, {
+    String? fileName,
+  }) {
+    final format = formatForFileName(fileName);
+    if (bytes.length > limits.maxBytes) {
+      return _failure(
+        format,
+        const RpgScenarioPackageIssue(
+          path: r'$package',
+          code: 'package_too_large',
+          message: 'Scenario package exceeds the configured byte limit.',
+        ),
+      );
+    }
+    try {
+      return importText(
+        utf8.decode(bytes, allowMalformed: false),
+        fileName: fileName,
+        format: format,
+      );
+    } on FormatException catch (error) {
+      return _failure(
+        format,
+        RpgScenarioPackageIssue(
+          path: r'$package',
+          code: 'invalid_encoding',
+          message: error.message,
+        ),
+      );
+    }
+  }
+
+  /// Runs parsing and validation outside the UI isolate for imported files.
+  Future<RpgScenarioPackageResult> importBytesAsync(
+    Uint8List bytes, {
+    String? fileName,
+  }) =>
+      Isolate.run(() => importBytes(bytes, fileName: fileName));
+
+  RpgScenarioPackageResult importText(
+    String source, {
+    String? fileName,
+    RpgScenarioPackageFormat? format,
+  }) {
+    final resolvedFormat = format ?? detectFormat(source, fileName: fileName);
+    if (utf8.encode(source).length > limits.maxBytes) {
+      return _failure(
+        resolvedFormat,
+        const RpgScenarioPackageIssue(
+          path: r'$package',
+          code: 'package_too_large',
+          message: 'Scenario package exceeds the configured byte limit.',
+        ),
+      );
+    }
+
+    Object? decoded;
+    try {
+      if (resolvedFormat == RpgScenarioPackageFormat.json) {
+        decoded = jsonDecode(source);
+      } else {
+        final unsafe = _findUnsafeYamlFeature(source);
+        if (unsafe != null) {
+          return _failure(resolvedFormat, unsafe);
+        }
+        decoded = _yamlToJson(loadYaml(source));
+      }
+    } on YamlException catch (error) {
+      return _failure(
+        resolvedFormat,
+        RpgScenarioPackageIssue(
+          path: r'$package',
+          code: 'invalid_yaml',
+          message: error.message,
+          line: error.span?.start.line == null
+              ? null
+              : error.span!.start.line + 1,
+          column: error.span?.start.column == null
+              ? null
+              : error.span!.start.column + 1,
+        ),
+      );
+    } on FormatException catch (error) {
+      return _failure(
+        resolvedFormat,
+        _syntaxIssue(error, resolvedFormat),
+      );
+    } catch (error) {
+      return _failure(
+        resolvedFormat,
+        RpgScenarioPackageIssue(
+          path: r'$package',
+          code: 'invalid_package',
+          message: 'Could not parse scenario package: $error',
+        ),
+      );
+    }
+
+    if (decoded is! Map<String, dynamic>) {
+      return _failure(
+        resolvedFormat,
+        const RpgScenarioPackageIssue(
+          path: r'$package',
+          code: 'invalid_root',
+          message: 'Scenario package root must be an object.',
+        ),
+      );
+    }
+
+    final resourceIssues = _inspectResources(decoded);
+    final schemaIssues = _schema.validateDocument(decoded);
+    final issues = <RpgScenarioPackageIssue>[
+      ...resourceIssues,
+      ...schemaIssues,
+    ];
+    if (issues.isNotEmpty) {
+      return RpgScenarioPackageResult(
+        format: resolvedFormat,
+        document: decoded,
+        issues: List.unmodifiable(issues),
+      );
+    }
+
+    RpgScenario scenario;
+    try {
+      scenario = RpgScenario.fromJson(decoded);
+    } catch (error) {
+      return RpgScenarioPackageResult(
+        format: resolvedFormat,
+        document: decoded,
+        issues: [
+          RpgScenarioPackageIssue(
+            path: r'$package',
+            code: 'invalid_contract_value',
+            message: 'Package contains an unsupported contract value: $error',
+          ),
+        ],
+      );
+    }
+
+    issues.addAll(
+      _validator
+          .validate(scenario)
+          .issues
+          .map(RpgScenarioPackageIssue.fromValidation),
+    );
+    issues.addAll(_validateCompatibility(scenario));
+
+    return RpgScenarioPackageResult(
+      format: resolvedFormat,
+      scenario: issues.isEmpty ? scenario : null,
+      document: decoded,
+      issues: List.unmodifiable(issues),
+    );
+  }
+
+  String exportScenario(
+    RpgScenario scenario, {
+    RpgScenarioPackageFormat format = RpgScenarioPackageFormat.json,
+  }) {
+    final validationIssues = <RpgScenarioPackageIssue>[
+      ..._validator
+          .validate(scenario)
+          .issues
+          .map(RpgScenarioPackageIssue.fromValidation),
+      ..._validateCompatibility(scenario),
+    ];
+    if (validationIssues.isNotEmpty) {
+      throw RpgScenarioPackageException(validationIssues);
+    }
+    final document = scenario.toJson();
+    return switch (format) {
+      RpgScenarioPackageFormat.json =>
+        const JsonEncoder.withIndent('  ').convert(document),
+      RpgScenarioPackageFormat.yaml => _YamlWriter().write(document),
+    };
+  }
+
+  RpgScenarioPackageFormat detectFormat(
+    String source, {
+    String? fileName,
+  }) {
+    final fromFileName = formatForFileName(fileName);
+    if (fileName != null && fileName.contains('.')) return fromFileName;
+    final trimmed = source.trimLeft();
+    return trimmed.startsWith('{') || trimmed.startsWith('[')
+        ? RpgScenarioPackageFormat.json
+        : RpgScenarioPackageFormat.yaml;
+  }
+
+  RpgScenarioPackageFormat formatForFileName(String? fileName) {
+    final normalized = fileName?.toLowerCase() ?? '';
+    return normalized.endsWith('.yaml') || normalized.endsWith('.yml')
+        ? RpgScenarioPackageFormat.yaml
+        : RpgScenarioPackageFormat.json;
+  }
+
+  RpgScenarioPackageResult _failure(
+    RpgScenarioPackageFormat format,
+    RpgScenarioPackageIssue issue,
+  ) =>
+      RpgScenarioPackageResult(format: format, issues: [issue]);
+
+  RpgScenarioPackageIssue _syntaxIssue(
+    FormatException error,
+    RpgScenarioPackageFormat format,
+  ) {
+    int? line;
+    int? column;
+    if (error.offset case final offset? when error.source is String) {
+      final prefix = (error.source! as String).substring(0, offset);
+      line = '\n'.allMatches(prefix).length + 1;
+      final lastBreak = prefix.lastIndexOf('\n');
+      column = offset - lastBreak;
+    }
+    return RpgScenarioPackageIssue(
+      path: r'$package',
+      code: format == RpgScenarioPackageFormat.json
+          ? 'invalid_json'
+          : 'invalid_yaml',
+      message: error.message,
+      line: line,
+      column: column,
+    );
+  }
+
+  List<RpgScenarioPackageIssue> _inspectResources(Object? root) {
+    final issues = <RpgScenarioPackageIssue>[];
+    var nodes = 0;
+
+    void visit(Object? value, String path, int depth) {
+      if (issues.isNotEmpty) return;
+      nodes++;
+      if (nodes > limits.maxNodes) {
+        issues.add(RpgScenarioPackageIssue(
+          path: path,
+          code: 'too_many_nodes',
+          message: 'Scenario package exceeds the configured node limit.',
+        ));
+        return;
+      }
+      if (depth > limits.maxDepth) {
+        issues.add(RpgScenarioPackageIssue(
+          path: path,
+          code: 'nesting_too_deep',
+          message: 'Scenario package exceeds the configured nesting limit.',
+        ));
+        return;
+      }
+      if (value is String && value.length > limits.maxStringLength) {
+        issues.add(RpgScenarioPackageIssue(
+          path: path,
+          code: 'string_too_long',
+          message: 'Text value exceeds the configured character limit.',
+        ));
+      } else if (value is List<dynamic>) {
+        if (value.length > limits.maxCollectionLength) {
+          issues.add(RpgScenarioPackageIssue(
+            path: path,
+            code: 'collection_too_large',
+            message: 'List exceeds the configured item limit.',
+          ));
+          return;
+        }
+        for (var index = 0; index < value.length; index++) {
+          visit(value[index], '$path[$index]', depth + 1);
+        }
+      } else if (value is Map<String, dynamic>) {
+        if (value.length > limits.maxCollectionLength) {
+          issues.add(RpgScenarioPackageIssue(
+            path: path,
+            code: 'collection_too_large',
+            message: 'Object exceeds the configured property limit.',
+          ));
+          return;
+        }
+        for (final entry in value.entries) {
+          if (_isUnsafeKey(entry.key)) {
+            issues.add(RpgScenarioPackageIssue(
+              path: '$path.${entry.key}',
+              code: 'unsafe_property',
+              message: 'Executable or file-path properties are not allowed.',
+            ));
+            return;
+          }
+          visit(entry.value, '$path.${entry.key}', depth + 1);
+        }
+      } else if (value is num && !value.isFinite) {
+        issues.add(RpgScenarioPackageIssue(
+          path: path,
+          code: 'non_finite_number',
+          message: 'Numbers must be finite.',
+        ));
+      }
+    }
+
+    visit(root, r'$package', 0);
+    return issues;
+  }
+
+  bool _isUnsafeKey(String key) {
+    final normalized = key.toLowerCase().replaceAll(RegExp(r'[^a-z]'), '');
+    return const {
+      'script',
+      'sourcecode',
+      'executable',
+      'command',
+      'shell',
+      'filepath',
+      'absoluteuri',
+    }.contains(normalized);
+  }
+
+  List<RpgScenarioPackageIssue> _validateCompatibility(RpgScenario scenario) {
+    final issues = <RpgScenarioPackageIssue>[];
+    final current = _SemanticVersion.tryParse(engineVersion);
+    final minimum = _SemanticVersion.tryParse(
+      scenario.compatibility.minimumEngineVersion,
+    );
+    final maximum = _SemanticVersion.tryParse(
+      scenario.compatibility.maximumEngineVersion,
+    );
+    if (current != null && minimum != null && current < minimum) {
+      issues.add(RpgScenarioPackageIssue(
+        path: 'compatibility.minimumEngineVersion',
+        code: 'incompatible_engine_version',
+        message:
+            'Package requires engine ${scenario.compatibility.minimumEngineVersion} '
+            'or newer; this app provides $engineVersion.',
+      ));
+    }
+    if (current != null && maximum != null && current > maximum) {
+      issues.add(RpgScenarioPackageIssue(
+        path: 'compatibility.maximumEngineVersion',
+        code: 'incompatible_engine_version',
+        message:
+            'Package supports engine ${scenario.compatibility.maximumEngineVersion} '
+            'or older; this app provides $engineVersion.',
+      ));
+    }
+    for (var index = 0;
+        index < scenario.compatibility.requiredCapabilities.length;
+        index++) {
+      final capability = scenario.compatibility.requiredCapabilities[index];
+      if (!availableCapabilities.contains(capability)) {
+        issues.add(RpgScenarioPackageIssue(
+          path: 'compatibility.requiredCapabilities[$index]',
+          code: 'missing_capability',
+          message: 'Required capability `$capability` is not available.',
+        ));
+      }
+    }
+    return issues;
+  }
+
+  RpgScenarioPackageIssue? _findUnsafeYamlFeature(String source) {
+    final lines = const LineSplitter().convert(source);
+    for (var lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+      final line = _stripYamlComment(lines[lineIndex]);
+      final token = RegExp(
+        r'(^|[\s\[\]{},:?-])(?:&[A-Za-z0-9_-]+|\*[A-Za-z0-9_-]+|![^\s]+|<<\s*:)',
+      ).firstMatch(line);
+      if (token != null) {
+        return RpgScenarioPackageIssue(
+          path: r'$package',
+          code: 'unsafe_yaml_feature',
+          message:
+              'YAML anchors, aliases, merge keys, and custom tags are not supported.',
+          line: lineIndex + 1,
+          column: token.start + 1,
+        );
+      }
+    }
+    return null;
+  }
+
+  String _stripYamlComment(String line) {
+    var singleQuoted = false;
+    var doubleQuoted = false;
+    for (var index = 0; index < line.length; index++) {
+      final char = line[index];
+      if (char == "'" && !doubleQuoted) singleQuoted = !singleQuoted;
+      if (char == '"' &&
+          !singleQuoted &&
+          (index == 0 || line[index - 1] != r'\')) {
+        doubleQuoted = !doubleQuoted;
+      }
+      if (char == '#' && !singleQuoted && !doubleQuoted) {
+        return line.substring(0, index);
+      }
+    }
+    return line;
+  }
+
+  Object? _yamlToJson(Object? value) {
+    if (value is YamlMap) {
+      final result = <String, dynamic>{};
+      for (final entry in value.entries) {
+        if (entry.key is! String) {
+          throw const FormatException('YAML object keys must be strings.');
+        }
+        result[entry.key as String] = _yamlToJson(entry.value);
+      }
+      return result;
+    }
+    if (value is YamlList) {
+      return value.map(_yamlToJson).toList(growable: false);
+    }
+    if (value == null || value is String || value is bool || value is num) {
+      return value;
+    }
+    throw FormatException('Unsupported YAML value `${value.runtimeType}`.');
+  }
+}
+
+class RpgScenarioPackageException implements Exception {
+  final List<RpgScenarioPackageIssue> issues;
+
+  const RpgScenarioPackageException(this.issues);
+
+  @override
+  String toString() => 'Invalid RPG scenario package:\n${issues.join('\n')}';
+}
+
+class _SemanticVersion implements Comparable<_SemanticVersion> {
+  final int major;
+  final int minor;
+  final int patch;
+
+  const _SemanticVersion(this.major, this.minor, this.patch);
+
+  static _SemanticVersion? tryParse(String? value) {
+    if (value == null) return null;
+    final match = RegExp(r'^(\d+)\.(\d+)\.(\d+)').firstMatch(value);
+    if (match == null) return null;
+    return _SemanticVersion(
+      int.parse(match.group(1)!),
+      int.parse(match.group(2)!),
+      int.parse(match.group(3)!),
+    );
+  }
+
+  @override
+  int compareTo(_SemanticVersion other) {
+    final majorComparison = major.compareTo(other.major);
+    if (majorComparison != 0) return majorComparison;
+    final minorComparison = minor.compareTo(other.minor);
+    if (minorComparison != 0) return minorComparison;
+    return patch.compareTo(other.patch);
+  }
+
+  bool operator <(_SemanticVersion other) => compareTo(other) < 0;
+  bool operator >(_SemanticVersion other) => compareTo(other) > 0;
+}
+
+class _YamlWriter {
+  String write(Map<String, dynamic> value) {
+    final buffer = StringBuffer();
+    _writeMap(buffer, value, 0);
+    return buffer.toString();
+  }
+
+  void _writeMap(StringBuffer buffer, Map<String, dynamic> map, int indent) {
+    for (final entry in map.entries) {
+      buffer.write('${' ' * indent}${jsonEncode(entry.key)}:');
+      if (_isScalar(entry.value)) {
+        buffer.writeln(' ${_scalar(entry.value)}');
+      } else if (entry.value is List && (entry.value as List).isEmpty) {
+        buffer.writeln(' []');
+      } else if (entry.value is Map && (entry.value as Map).isEmpty) {
+        buffer.writeln(' {}');
+      } else {
+        buffer.writeln();
+        _writeValue(buffer, entry.value, indent + 2);
+      }
+    }
+  }
+
+  void _writeValue(StringBuffer buffer, Object? value, int indent) {
+    if (value is Map<String, dynamic>) {
+      _writeMap(buffer, value, indent);
+    } else if (value is List<dynamic>) {
+      for (final item in value) {
+        if (_isScalar(item)) {
+          buffer.writeln('${' ' * indent}- ${_scalar(item)}');
+        } else {
+          buffer.writeln('${' ' * indent}-');
+          _writeValue(buffer, item, indent + 2);
+        }
+      }
+    }
+  }
+
+  bool _isScalar(Object? value) =>
+      value == null || value is String || value is bool || value is num;
+
+  String _scalar(Object? value) {
+    if (value == null) return 'null';
+    if (value is String) return jsonEncode(value);
+    return value.toString();
+  }
+}
+
+final _schema = _ObjectSchema(
+  fields: {
+    'schemaVersion': _required(_integer),
+    'metadata': _required(_ObjectSchema(fields: {
+      'id': _required(_string),
+      'name': _required(_string),
+      'version': _required(_string),
+      'description': _optional(_string),
+      'author': _optional(_string),
+      'tags': _optional(_list(_string)),
+    })),
+    'initialSeed': _required(_integer),
+    'compatibility': _optional(_ObjectSchema(fields: {
+      'minimumEngineVersion': _optional(_string),
+      'maximumEngineVersion': _optional(_string),
+      'requiredCapabilities': _optional(_list(_string)),
+    })),
+    'protectedFields': _optional(_list(_string)),
+    'attributes': _optional(_list(_ObjectSchema(fields: {
+      'id': _required(_string),
+      'label': _required(_string),
+      'initialValue': _optional(_number),
+      'minimum': _optional(_number),
+      'maximum': _optional(_number),
+    }))),
+    'items': _optional(_list(_ObjectSchema(fields: {
+      'id': _required(_string),
+      'label': _required(_string),
+      'description': _optional(_string),
+      'stackable': _optional(_boolean),
+    }))),
+    'actors': _optional(_list(_ObjectSchema(fields: {
+      'id': _required(_string),
+      'label': _required(_string),
+    }))),
+    'locations': _optional(_list(_ObjectSchema(fields: {
+      'id': _required(_string),
+      'label': _required(_string),
+      'description': _optional(_string),
+    }))),
+    'quests': _optional(_list(_quest)),
+    'actions': _optional(_list(_action)),
+    'initialState': _required(_runtimeState),
+  },
+);
+
+final _quest = _ObjectSchema(fields: {
+  'id': _required(_string),
+  'label': _required(_string),
+  'stages': _optional(_list(_ObjectSchema(fields: {
+    'id': _required(_string),
+    'label': _required(_string),
+    'objectiveIds': _optional(_list(_string)),
+  }))),
+});
+
+_ObjectSchema _conditionSchema() => _ObjectSchema(fields: {
+      'operator':
+          _required(_enum(RpgConditionOperator.values.map((e) => e.name))),
+      'path': _optional(_string),
+      'value': _optional(_jsonValue),
+      'conditions': _optional(const _ListSchema.lazy(_conditionSchema)),
+    });
+
+final _effect = _ObjectSchema(fields: {
+  'type': _required(_enum(RpgEffectType.values.map((e) => e.name))),
+  'target': _required(_string),
+  'value': _optional(_jsonValue),
+  'amount': _optional(_number),
+});
+
+final _action = _ObjectSchema(fields: {
+  'id': _required(_string),
+  'label': _required(_string),
+  'description': _optional(_string),
+  'availability': _optional(_list(_conditionSchema())),
+  'costs': _optional(_list(_ObjectSchema(fields: {
+    'path': _required(_string),
+    'amount': _required(_number),
+  }))),
+  'check': _optional(_ObjectSchema(fields: {
+    'attributeId': _required(_string),
+    'dice': _required(_ObjectSchema(fields: {
+      'expression': _required(_string),
+    })),
+    'difficulty': _required(_number),
+    'successEffects': _optional(_list(_effect)),
+    'failureEffects': _optional(_list(_effect)),
+  })),
+  'effects': _optional(_list(_effect)),
+});
+
+final _runtimeState = _ObjectSchema(fields: {
+  'scenarioId': _required(_string),
+  'scenarioVersion': _required(_string),
+  'turn': _optional(_integer),
+  'random': _required(_ObjectSchema(fields: {
+    'initialSeed': _required(_integer),
+    'state': _required(_integer),
+    'rollsConsumed': _optional(_integer),
+  })),
+  'attributes': _optional(const _MapSchema(_number)),
+  'variables': _optional(const _MapSchema(_jsonValue)),
+  'inventory': _optional(_list(_ObjectSchema(fields: {
+    'itemId': _required(_string),
+    'quantity': _required(_integer),
+    'metadata': _optional(const _MapSchema(_jsonValue)),
+  }))),
+  'relationships': _optional(_list(_ObjectSchema(fields: {
+    'actorId': _required(_string),
+    'score': _optional(_number),
+    'tags': _optional(_list(_string)),
+  }))),
+  'clock': _optional(_ObjectSchema(fields: {
+    'elapsedMinutes': _optional(_integer),
+    'day': _optional(_integer),
+    'minuteOfDay': _optional(_integer),
+  })),
+  'locationId': _optional(_string),
+  'quests': _optional(_list(_ObjectSchema(fields: {
+    'questId': _required(_string),
+    'status': _optional(_enum(RpgQuestStatus.values.map((e) => e.name))),
+    'stageId': _optional(_string),
+    'objectiveProgress': _optional(const _MapSchema(_integer)),
+  }))),
+  'cooldowns': _optional(const _MapSchema(_integer)),
+  'eventHistory': _optional(_list(_ObjectSchema(fields: {
+    'id': _required(_string),
+    'turn': _required(_integer),
+    'type': _required(_string),
+    'actionId': _optional(_string),
+    'summary': _optional(_string),
+    'data': _optional(const _MapSchema(_jsonValue)),
+  }))),
+});
+
+_SchemaField _required(_ValueSchema schema) => _SchemaField(schema, true);
+_SchemaField _optional(_ValueSchema schema) => _SchemaField(schema, false);
+_ListSchema _list(_ValueSchema schema) => _ListSchema(schema);
+_ScalarSchema _enum(Iterable<String> values) =>
+    _ScalarSchema(_ScalarType.string, values.toSet());
+
+const _string = _ScalarSchema(_ScalarType.string);
+const _number = _ScalarSchema(_ScalarType.number);
+const _integer = _ScalarSchema(_ScalarType.integer);
+const _boolean = _ScalarSchema(_ScalarType.boolean);
+const _jsonValue = _JsonValueSchema();
+
+enum _ScalarType { string, number, integer, boolean }
+
+abstract class _ValueSchema {
+  const _ValueSchema();
+  void validate(
+    Object? value,
+    String path,
+    List<RpgScenarioPackageIssue> issues,
+  );
+}
+
+class _SchemaField {
+  final _ValueSchema schema;
+  final bool required;
+  const _SchemaField(this.schema, this.required);
+}
+
+class _ObjectSchema extends _ValueSchema {
+  final Map<String, _SchemaField> fields;
+  const _ObjectSchema({required this.fields});
+
+  List<RpgScenarioPackageIssue> validateDocument(Map<String, dynamic> value) {
+    final issues = <RpgScenarioPackageIssue>[];
+    validateAt(value, r'$package', issues);
+    return issues;
+  }
+
+  @override
+  void validate(
+          Object? value, String path, List<RpgScenarioPackageIssue> issues) =>
+      validateAt(value, path, issues);
+
+  void validateAt(
+    Object? value,
+    String path,
+    List<RpgScenarioPackageIssue> issues,
+  ) {
+    if (value is! Map<String, dynamic>) {
+      _typeIssue(path, 'object', issues);
+      return;
+    }
+    for (final field in fields.entries) {
+      if (!value.containsKey(field.key)) {
+        if (field.value.required) {
+          issues.add(RpgScenarioPackageIssue(
+            path: '$path.${field.key}',
+            code: 'missing_required_field',
+            message: 'Required field `${field.key}` is missing.',
+          ));
+        }
+        continue;
+      }
+      final child = value[field.key];
+      if (child == null && !field.value.required) continue;
+      field.value.schema.validate(child, '$path.${field.key}', issues);
+    }
+    for (final key in value.keys) {
+      if (!fields.containsKey(key)) {
+        issues.add(RpgScenarioPackageIssue(
+          path: '$path.$key',
+          code: 'unknown_field',
+          message: 'Field `$key` is not part of the RPG scenario schema.',
+        ));
+      }
+    }
+  }
+}
+
+class _ListSchema extends _ValueSchema {
+  final _ValueSchema? item;
+  final _ValueSchema Function()? _itemBuilder;
+  const _ListSchema(this.item) : _itemBuilder = null;
+  const _ListSchema.lazy(this._itemBuilder) : item = null;
+
+  @override
+  void validate(
+      Object? value, String path, List<RpgScenarioPackageIssue> issues) {
+    if (value is! List<dynamic>) {
+      _typeIssue(path, 'list', issues);
+      return;
+    }
+    final itemSchema = item ?? _itemBuilder!();
+    for (var index = 0; index < value.length; index++) {
+      itemSchema.validate(value[index], '$path[$index]', issues);
+    }
+  }
+}
+
+class _MapSchema extends _ValueSchema {
+  final _ValueSchema valueSchema;
+  const _MapSchema(this.valueSchema);
+
+  @override
+  void validate(
+      Object? value, String path, List<RpgScenarioPackageIssue> issues) {
+    if (value is! Map<String, dynamic>) {
+      _typeIssue(path, 'object', issues);
+      return;
+    }
+    for (final entry in value.entries) {
+      valueSchema.validate(entry.value, '$path.${entry.key}', issues);
+    }
+  }
+}
+
+class _ScalarSchema extends _ValueSchema {
+  final _ScalarType type;
+  final Set<String>? values;
+  const _ScalarSchema(this.type, [this.values]);
+
+  @override
+  void validate(
+      Object? value, String path, List<RpgScenarioPackageIssue> issues) {
+    final valid = switch (type) {
+      _ScalarType.string => value is String,
+      _ScalarType.number => value is num,
+      _ScalarType.integer =>
+        value is int || value is num && value == value.toInt(),
+      _ScalarType.boolean => value is bool,
+    };
+    if (!valid) {
+      _typeIssue(path, type.name, issues);
+      return;
+    }
+    if (values != null && !values!.contains(value)) {
+      issues.add(RpgScenarioPackageIssue(
+        path: path,
+        code: 'invalid_enum_value',
+        message: 'Value must be one of: ${values!.join(', ')}.',
+      ));
+    }
+  }
+}
+
+class _JsonValueSchema extends _ValueSchema {
+  const _JsonValueSchema();
+
+  @override
+  void validate(
+      Object? value, String path, List<RpgScenarioPackageIssue> issues) {
+    if (value == null || value is String || value is bool || value is num) {
+      return;
+    }
+    if (value is List<dynamic>) {
+      for (var index = 0; index < value.length; index++) {
+        validate(value[index], '$path[$index]', issues);
+      }
+      return;
+    }
+    if (value is Map<String, dynamic>) {
+      for (final entry in value.entries) {
+        validate(entry.value, '$path.${entry.key}', issues);
+      }
+      return;
+    }
+    _typeIssue(path, 'JSON value', issues);
+  }
+}
+
+void _typeIssue(
+  String path,
+  String expected,
+  List<RpgScenarioPackageIssue> issues,
+) {
+  issues.add(RpgScenarioPackageIssue(
+    path: path,
+    code: 'invalid_field_type',
+    message: 'Expected $expected.',
+  ));
+}

--- a/lib/presentation/controllers/rpg_scenario_editor_controller.dart
+++ b/lib/presentation/controllers/rpg_scenario_editor_controller.dart
@@ -1,0 +1,527 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:native_tavern/data/models/rpg/rpg.dart';
+import 'package:native_tavern/domain/services/rpg_scenario_draft_store.dart';
+import 'package:native_tavern/domain/services/rpg_scenario_package_service.dart';
+
+class RpgEditorPath {
+  final List<Object> segments;
+
+  const RpgEditorPath([this.segments = const []]);
+
+  RpgEditorPath child(Object segment) => RpgEditorPath([...segments, segment]);
+
+  String get key => segments.map((segment) => '/$segment').join();
+
+  String get normalized =>
+      segments.map((segment) => segment is int ? '/*' : '/$segment').join();
+
+  String get display => segments.isEmpty
+      ? r'$package'
+      : segments.fold<String>(r'$package', (path, segment) {
+          return segment is int ? '$path[$segment]' : '$path.$segment';
+        });
+}
+
+class RpgScenarioEditorController extends ChangeNotifier {
+  final RpgScenarioPackageService packageService;
+  RpgScenarioDraftStore? draftStore;
+
+  late Map<String, dynamic> _document;
+  late RpgScenarioPackageResult _validation;
+  RpgScenarioPackageFormat _format;
+  List<RpgScenarioPackageIssue> _importIssues = const [];
+  DateTime? _draftUpdatedAt;
+  bool _dirty = false;
+
+  RpgScenarioEditorController({
+    RpgScenario? initialScenario,
+    this.packageService = const RpgScenarioPackageService(),
+    this.draftStore,
+    RpgScenarioPackageFormat format = RpgScenarioPackageFormat.json,
+  }) : _format = format {
+    _document = _materialize(
+      _deepMap((initialScenario ?? emptyScenario()).toJson()),
+    );
+    _validation = _validateDocument();
+  }
+
+  Map<String, dynamic> get document => _document;
+  RpgScenarioPackageFormat get format => _format;
+  List<RpgScenarioPackageIssue> get issues =>
+      _importIssues.isEmpty ? _validation.issues : _importIssues;
+  RpgScenario? get scenario => _validation.scenario;
+  DateTime? get draftUpdatedAt => _draftUpdatedAt;
+  bool get isValid => _validation.isValid;
+  bool get isDirty => _dirty;
+
+  static RpgScenario emptyScenario() => const RpgScenario(
+        metadata: RpgScenarioMetadata(
+          id: 'new_scenario',
+          name: 'New Scenario',
+          version: '1.0.0',
+        ),
+        initialSeed: 1,
+        initialState: RpgRuntimeState(
+          scenarioId: 'new_scenario',
+          scenarioVersion: '1.0.0',
+          random: RpgRandomState(initialSeed: 1, state: 1),
+        ),
+      );
+
+  RpgScenarioPackageResult importText(
+    String source, {
+    String? fileName,
+  }) {
+    final result = packageService.importText(source, fileName: fileName);
+    _handleImportResult(result);
+    return result;
+  }
+
+  RpgScenarioPackageResult importBytes(
+    Uint8List bytes, {
+    String? fileName,
+  }) {
+    final result = packageService.importBytes(bytes, fileName: fileName);
+    _handleImportResult(result);
+    return result;
+  }
+
+  Future<RpgScenarioPackageResult> importBytesAsync(
+    Uint8List bytes, {
+    String? fileName,
+  }) async {
+    final result = await packageService.importBytesAsync(
+      bytes,
+      fileName: fileName,
+    );
+    _handleImportResult(result);
+    return result;
+  }
+
+  void update(RpgEditorPath path, Object? value) {
+    final previous = valueAt(path);
+    _write(path, _deepValue(value));
+    if (path.key == '/metadata/id' &&
+        valueAt(const RpgEditorPath(['initialState', 'scenarioId'])) ==
+            previous) {
+      _write(const RpgEditorPath(['initialState', 'scenarioId']), value);
+    } else if (path.key == '/metadata/version' &&
+        valueAt(const RpgEditorPath(['initialState', 'scenarioVersion'])) ==
+            previous) {
+      _write(const RpgEditorPath(['initialState', 'scenarioVersion']), value);
+    } else if (path.key == '/initialSeed') {
+      final random = valueAt(
+        const RpgEditorPath(['initialState', 'random']),
+      ) as Map<String, dynamic>;
+      if (random['initialSeed'] == previous) random['initialSeed'] = value;
+      if (random['state'] == previous) random['state'] = value;
+    }
+    _changed();
+  }
+
+  void configureDraftStore(RpgScenarioDraftStore store) {
+    draftStore = store;
+  }
+
+  void initializeOptional(RpgEditorPath path) {
+    update(path, _optionalDefault(path.normalized));
+  }
+
+  void addListItem(RpgEditorPath path) {
+    final list = valueAt(path);
+    if (list is! List<dynamic>) {
+      throw ArgumentError('Path ${path.display} is not a list.');
+    }
+    list.add(_deepValue(_templateFor(path.normalized)));
+    _changed();
+  }
+
+  void removeListItem(RpgEditorPath path, int index) {
+    final list = valueAt(path);
+    if (list is! List<dynamic>) {
+      throw ArgumentError('Path ${path.display} is not a list.');
+    }
+    list.removeAt(index);
+    _changed();
+  }
+
+  void moveListItem(RpgEditorPath path, int oldIndex, int newIndex) {
+    final list = valueAt(path);
+    if (list is! List<dynamic>) {
+      throw ArgumentError('Path ${path.display} is not a list.');
+    }
+    if (newIndex < 0 || newIndex >= list.length || oldIndex == newIndex) return;
+    final item = list.removeAt(oldIndex);
+    list.insert(newIndex, item);
+    _changed();
+  }
+
+  void setMapEntry(RpgEditorPath path, String key, Object? value) {
+    final map = valueAt(path);
+    if (map is! Map<String, dynamic>) {
+      throw ArgumentError('Path ${path.display} is not an object.');
+    }
+    map[key] = _deepValue(value);
+    _changed();
+  }
+
+  void removeMapEntry(RpgEditorPath path, String key) {
+    final map = valueAt(path);
+    if (map is! Map<String, dynamic>) {
+      throw ArgumentError('Path ${path.display} is not an object.');
+    }
+    map.remove(key);
+    _changed();
+  }
+
+  Object? valueAt(RpgEditorPath path) {
+    Object? current = _document;
+    for (final segment in path.segments) {
+      current = segment is int
+          ? (current as List<dynamic>)[segment]
+          : (current as Map<String, dynamic>)[segment];
+    }
+    return current;
+  }
+
+  String preview() => const JsonEncoder.withIndent('  ').convert(_document);
+
+  String export({RpgScenarioPackageFormat? format}) {
+    final currentScenario = scenario;
+    if (currentScenario == null) {
+      throw RpgScenarioPackageException(issues);
+    }
+    return packageService.exportScenario(
+      currentScenario,
+      format: format ?? _format,
+    );
+  }
+
+  Future<void> saveDraft() async {
+    final store = draftStore;
+    if (store == null) {
+      throw StateError('No RPG scenario draft store is configured.');
+    }
+    final updatedAt = DateTime.now().toUtc();
+    await store.save(RpgScenarioDraft(
+      document: _deepMap(_document),
+      format: _format,
+      updatedAt: updatedAt,
+    ));
+    _draftUpdatedAt = updatedAt;
+    _dirty = false;
+    notifyListeners();
+  }
+
+  Future<bool> loadDraft() async {
+    final draft = await draftStore?.load();
+    if (draft == null) return false;
+    _document = _materialize(_deepMap(draft.document));
+    _format = draft.format;
+    _draftUpdatedAt = draft.updatedAt;
+    _dirty = false;
+    _validation = _validateDocument();
+    notifyListeners();
+    return true;
+  }
+
+  void _replaceFromResult(RpgScenarioPackageResult result) {
+    _importIssues = const [];
+    _document = _materialize(
+      _deepMap(result.scenario!.toJson()),
+    );
+    _format = result.format;
+    _validation = _validateDocument();
+    _dirty = true;
+    notifyListeners();
+  }
+
+  void _handleImportResult(RpgScenarioPackageResult result) {
+    if (result.isValid) {
+      _replaceFromResult(result);
+      return;
+    }
+    _importIssues = result.issues;
+    notifyListeners();
+  }
+
+  void _write(RpgEditorPath path, Object? value) {
+    if (path.segments.isEmpty) {
+      if (value is! Map<String, dynamic>) {
+        throw ArgumentError('Document root must be an object.');
+      }
+      _document = value;
+      return;
+    }
+    final parentPath = RpgEditorPath(
+      path.segments.sublist(0, path.segments.length - 1),
+    );
+    final parent = valueAt(parentPath);
+    final segment = path.segments.last;
+    if (segment is int) {
+      (parent as List<dynamic>)[segment] = value;
+    } else {
+      (parent as Map<String, dynamic>)[segment as String] = value;
+    }
+  }
+
+  void _changed() {
+    _importIssues = const [];
+    _dirty = true;
+    _validation = _validateDocument();
+    notifyListeners();
+  }
+
+  RpgScenarioPackageResult _validateDocument() => packageService.importText(
+        jsonEncode(_document),
+        format: RpgScenarioPackageFormat.json,
+      );
+}
+
+Object? _deepValue(Object? value) {
+  if (value is Map<String, dynamic>) return _deepMap(value);
+  if (value is List<dynamic>) return value.map(_deepValue).toList();
+  return value;
+}
+
+Map<String, dynamic> _deepMap(Map<String, dynamic> value) => value.map(
+      (key, item) => MapEntry(key, _deepValue(item)),
+    );
+
+Map<String, dynamic> _materialize(Map<String, dynamic> document) {
+  void defaults(Map<String, dynamic> map, Map<String, dynamic> values) {
+    for (final entry in values.entries) {
+      map.putIfAbsent(entry.key, () => _deepValue(entry.value));
+    }
+  }
+
+  final metadata = document['metadata'] as Map<String, dynamic>;
+  defaults(metadata, {'description': '', 'author': '', 'tags': <dynamic>[]});
+  final compatibility = document['compatibility'] as Map<String, dynamic>;
+  defaults(compatibility, {
+    'minimumEngineVersion': '1.0.0',
+    'maximumEngineVersion': null,
+    'requiredCapabilities': <dynamic>[],
+  });
+  for (final item in document['attributes'] as List<dynamic>) {
+    defaults(item as Map<String, dynamic>, {
+      'initialValue': 0,
+      'minimum': null,
+      'maximum': null,
+    });
+  }
+  for (final item in document['items'] as List<dynamic>) {
+    defaults(item as Map<String, dynamic>, {
+      'description': '',
+      'stackable': true,
+    });
+  }
+  for (final item in document['locations'] as List<dynamic>) {
+    defaults(item as Map<String, dynamic>, {'description': ''});
+  }
+  for (final item in document['quests'] as List<dynamic>) {
+    final quest = item as Map<String, dynamic>;
+    defaults(quest, {'stages': <dynamic>[]});
+    for (final stageItem in quest['stages'] as List<dynamic>) {
+      defaults(stageItem as Map<String, dynamic>, {
+        'objectiveIds': <dynamic>[],
+      });
+    }
+  }
+  for (final item in document['actions'] as List<dynamic>) {
+    _materializeAction(item as Map<String, dynamic>);
+  }
+  final state = document['initialState'] as Map<String, dynamic>;
+  defaults(state, {
+    'turn': 0,
+    'attributes': <String, dynamic>{},
+    'variables': <String, dynamic>{},
+    'inventory': <dynamic>[],
+    'relationships': <dynamic>[],
+    'clock': {'elapsedMinutes': 0, 'day': 1, 'minuteOfDay': 0},
+    'locationId': '',
+    'quests': <dynamic>[],
+    'cooldowns': <String, dynamic>{},
+    'eventHistory': <dynamic>[],
+  });
+  defaults(state['random'] as Map<String, dynamic>, {'rollsConsumed': 0});
+  for (final item in state['inventory'] as List<dynamic>) {
+    defaults(item as Map<String, dynamic>, {'metadata': <String, dynamic>{}});
+  }
+  for (final item in state['relationships'] as List<dynamic>) {
+    defaults(item as Map<String, dynamic>, {
+      'score': 0,
+      'tags': <dynamic>[],
+    });
+  }
+  for (final item in state['quests'] as List<dynamic>) {
+    defaults(item as Map<String, dynamic>, {
+      'status': RpgQuestStatus.inactive.name,
+      'stageId': null,
+      'objectiveProgress': <String, dynamic>{},
+    });
+  }
+  for (final item in state['eventHistory'] as List<dynamic>) {
+    defaults(item as Map<String, dynamic>, {
+      'actionId': null,
+      'summary': '',
+      'data': <String, dynamic>{},
+    });
+  }
+  return document;
+}
+
+void _materializeAction(Map<String, dynamic> action) {
+  action.putIfAbsent('description', () => '');
+  action.putIfAbsent('availability', () => <dynamic>[]);
+  action.putIfAbsent('costs', () => <dynamic>[]);
+  action.putIfAbsent('check', () => null);
+  action.putIfAbsent('effects', () => <dynamic>[]);
+  for (final item in action['availability'] as List<dynamic>) {
+    _materializeCondition(item as Map<String, dynamic>);
+  }
+  for (final item in action['effects'] as List<dynamic>) {
+    _materializeEffect(item as Map<String, dynamic>);
+  }
+  final check = action['check'];
+  if (check is Map<String, dynamic>) {
+    check.putIfAbsent('successEffects', () => <dynamic>[]);
+    check.putIfAbsent('failureEffects', () => <dynamic>[]);
+    for (final key in ['successEffects', 'failureEffects']) {
+      for (final item in check[key] as List<dynamic>) {
+        _materializeEffect(item as Map<String, dynamic>);
+      }
+    }
+  }
+}
+
+void _materializeCondition(Map<String, dynamic> condition) {
+  condition.putIfAbsent('path', () => '');
+  condition.putIfAbsent('value', () => null);
+  condition.putIfAbsent('conditions', () => <dynamic>[]);
+  for (final item in condition['conditions'] as List<dynamic>) {
+    _materializeCondition(item as Map<String, dynamic>);
+  }
+}
+
+void _materializeEffect(Map<String, dynamic> effect) {
+  effect.putIfAbsent('value', () => null);
+  effect.putIfAbsent('amount', () => null);
+}
+
+Object? _templateFor(String path) {
+  if (path == '/metadata/tags' ||
+      path == '/protectedFields' ||
+      path.endsWith('/objectiveIds') ||
+      path.endsWith('/tags')) {
+    return '';
+  }
+  if (path == '/attributes') {
+    return {
+      'id': 'attribute',
+      'label': 'Attribute',
+      'initialValue': 0,
+      'minimum': null,
+      'maximum': null
+    };
+  }
+  if (path == '/items') {
+    return {
+      'id': 'item',
+      'label': 'Item',
+      'description': '',
+      'stackable': true
+    };
+  }
+  if (path == '/actors') return {'id': 'actor', 'label': 'Actor'};
+  if (path == '/locations') {
+    return {'id': 'location', 'label': 'Location', 'description': ''};
+  }
+  if (path == '/quests') {
+    return {'id': 'quest', 'label': 'Quest', 'stages': <dynamic>[]};
+  }
+  if (path.endsWith('/stages')) {
+    return {'id': 'stage', 'label': 'Stage', 'objectiveIds': <dynamic>[]};
+  }
+  if (path == '/actions') {
+    return {
+      'id': 'action',
+      'label': 'Action',
+      'description': '',
+      'availability': <dynamic>[],
+      'costs': <dynamic>[],
+      'check': null,
+      'effects': <dynamic>[],
+    };
+  }
+  if (path.endsWith('/availability') || path.endsWith('/conditions')) {
+    return {
+      'operator': RpgConditionOperator.equals.name,
+      'path': '',
+      'value': null,
+      'conditions': <dynamic>[],
+    };
+  }
+  if (path.endsWith('/costs')) return {'path': '', 'amount': 1};
+  if (path.endsWith('/effects') ||
+      path.endsWith('/successEffects') ||
+      path.endsWith('/failureEffects')) {
+    return {
+      'type': RpgEffectType.setValue.name,
+      'target': '',
+      'value': null,
+      'amount': null
+    };
+  }
+  if (path == '/initialState/inventory') {
+    return {'itemId': '', 'quantity': 1, 'metadata': <String, dynamic>{}};
+  }
+  if (path == '/initialState/relationships') {
+    return {'actorId': '', 'score': 0, 'tags': <dynamic>[]};
+  }
+  if (path == '/initialState/quests') {
+    return {
+      'questId': '',
+      'status': RpgQuestStatus.inactive.name,
+      'stageId': null,
+      'objectiveProgress': <String, dynamic>{}
+    };
+  }
+  if (path == '/initialState/eventHistory') {
+    return {
+      'id': 'event',
+      'turn': 0,
+      'type': 'event',
+      'actionId': null,
+      'summary': '',
+      'data': <String, dynamic>{}
+    };
+  }
+  throw UnsupportedError('No editor template for $path.');
+}
+
+Object? _optionalDefault(String path) {
+  if (path.endsWith('/check')) {
+    return {
+      'attributeId': '',
+      'dice': {'expression': '1d20'},
+      'difficulty': 10,
+      'successEffects': <dynamic>[],
+      'failureEffects': <dynamic>[],
+    };
+  }
+  if (path.endsWith('/amount') ||
+      path.endsWith('/minimum') ||
+      path.endsWith('/maximum')) {
+    return 0;
+  }
+  if (path.endsWith('/value') ||
+      path.endsWith('/stageId') ||
+      path.endsWith('/actionId')) {
+    return '';
+  }
+  if (path.endsWith('/maximumEngineVersion')) return '1.0.0';
+  return '';
+}

--- a/lib/presentation/screens/rpg/rpg_scenario_editor_screen.dart
+++ b/lib/presentation/screens/rpg/rpg_scenario_editor_screen.dart
@@ -1,0 +1,865 @@
+// File selection and exports are user-triggered and intentionally asynchronous.
+// ignore_for_file: avoid_slow_async_io
+
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:native_tavern/data/models/rpg/rpg.dart';
+import 'package:native_tavern/domain/services/rpg_scenario_draft_store.dart';
+import 'package:native_tavern/domain/services/rpg_scenario_package_service.dart';
+import 'package:native_tavern/presentation/controllers/rpg_scenario_editor_controller.dart';
+
+class RpgScenarioFileData {
+  final String name;
+  final Uint8List bytes;
+
+  const RpgScenarioFileData({required this.name, required this.bytes});
+}
+
+abstract class RpgScenarioFileGateway {
+  Future<RpgScenarioFileData?> pickScenario();
+
+  Future<String?> saveScenario({
+    required String suggestedName,
+    required String content,
+    required RpgScenarioPackageFormat format,
+  });
+}
+
+class PlatformRpgScenarioFileGateway implements RpgScenarioFileGateway {
+  const PlatformRpgScenarioFileGateway();
+
+  @override
+  Future<RpgScenarioFileData?> pickScenario() async {
+    final result = await FilePicker.platform.pickFiles(
+      type: FileType.custom,
+      allowedExtensions: RpgScenarioPackageService.supportedExtensions,
+      allowMultiple: false,
+      withData: false,
+    );
+    if (result == null || result.files.isEmpty) return null;
+    final selected = result.files.single;
+    if (selected.size > const RpgScenarioPackageLimits().maxBytes) {
+      throw const FileSystemException(
+        'The selected scenario exceeds the 2 MiB import limit.',
+      );
+    }
+    final bytes = selected.bytes ??
+        (selected.path == null
+            ? null
+            : await File(selected.path!).readAsBytes());
+    if (bytes == null) {
+      throw const FileSystemException(
+          'The selected scenario could not be read.');
+    }
+    return RpgScenarioFileData(name: selected.name, bytes: bytes);
+  }
+
+  @override
+  Future<String?> saveScenario({
+    required String suggestedName,
+    required String content,
+    required RpgScenarioPackageFormat format,
+  }) async {
+    final extension = format == RpgScenarioPackageFormat.json ? 'json' : 'yaml';
+    final result = await FilePicker.platform.saveFile(
+      dialogTitle: 'Export RPG Scenario',
+      fileName: '$suggestedName.$extension',
+      type: FileType.custom,
+      allowedExtensions: [extension],
+    );
+    if (result == null) return null;
+    await File(result).writeAsString(content, flush: true);
+    return result;
+  }
+}
+
+class RpgScenarioEditorScreen extends StatefulWidget {
+  final RpgScenarioEditorController? controller;
+  final RpgScenarioDraftStore? draftStore;
+  final RpgScenarioFileGateway fileGateway;
+
+  const RpgScenarioEditorScreen({
+    super.key,
+    this.controller,
+    this.draftStore,
+    this.fileGateway = const PlatformRpgScenarioFileGateway(),
+  });
+
+  @override
+  State<RpgScenarioEditorScreen> createState() =>
+      _RpgScenarioEditorScreenState();
+}
+
+class _RpgScenarioEditorScreenState extends State<RpgScenarioEditorScreen>
+    with SingleTickerProviderStateMixin {
+  late final RpgScenarioEditorController _controller;
+  late final TabController _tabs;
+  late final bool _ownsController;
+  bool _working = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _ownsController = widget.controller == null;
+    _controller = widget.controller ??
+        RpgScenarioEditorController(draftStore: widget.draftStore);
+    if (widget.draftStore != null) {
+      _controller.configureDraftStore(widget.draftStore!);
+    }
+    _controller.addListener(_refresh);
+    _tabs = TabController(length: 3, vsync: this);
+  }
+
+  @override
+  void dispose() {
+    _tabs.dispose();
+    _controller.removeListener(_refresh);
+    if (_ownsController) _controller.dispose();
+    super.dispose();
+  }
+
+  void _refresh() {
+    if (mounted) setState(() {});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(_controller.isDirty ? 'RPG Scenario *' : 'RPG Scenario'),
+        actions: [
+          IconButton(
+            key: const Key('rpg-import'),
+            tooltip: 'Import scenario',
+            onPressed: _working ? null : _import,
+            icon: const Icon(Icons.file_open_outlined),
+          ),
+          IconButton(
+            key: const Key('rpg-save-draft'),
+            tooltip: 'Save draft',
+            onPressed: _working ? null : _saveDraft,
+            icon: const Icon(Icons.save_outlined),
+          ),
+          IconButton(
+            key: const Key('rpg-load-draft'),
+            tooltip: 'Restore draft',
+            onPressed: _working ? null : _loadDraft,
+            icon: const Icon(Icons.history),
+          ),
+          PopupMenuButton<RpgScenarioPackageFormat>(
+            tooltip: 'Export scenario',
+            icon: const Icon(Icons.file_upload_outlined),
+            enabled: !_working && _controller.isValid,
+            onSelected: _export,
+            itemBuilder: (context) => const [
+              PopupMenuItem(
+                key: Key('rpg-export-json'),
+                value: RpgScenarioPackageFormat.json,
+                child: Text('JSON'),
+              ),
+              PopupMenuItem(
+                key: Key('rpg-export-yaml'),
+                value: RpgScenarioPackageFormat.yaml,
+                child: Text('YAML'),
+              ),
+            ],
+          ),
+        ],
+        bottom: TabBar(
+          controller: _tabs,
+          tabs: [
+            const Tab(key: Key('rpg-tab-edit'), text: 'Edit'),
+            const Tab(key: Key('rpg-tab-preview'), text: 'Preview'),
+            Tab(
+              key: const Key('rpg-tab-issues'),
+              text: _controller.issues.isEmpty
+                  ? 'Issues'
+                  : 'Issues (${_controller.issues.length})',
+            ),
+          ],
+        ),
+      ),
+      body: Stack(
+        children: [
+          TabBarView(
+            controller: _tabs,
+            children: [
+              _DocumentEditor(controller: _controller),
+              _PreviewPane(source: _controller.preview()),
+              _IssuesPane(issues: _controller.issues),
+            ],
+          ),
+          if (_working)
+            const Positioned.fill(
+              child: ColoredBox(
+                color: Color(0x33000000),
+                child: Center(child: CircularProgressIndicator()),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _import() async {
+    await _run(() async {
+      final selected = await widget.fileGateway.pickScenario();
+      if (selected == null) return;
+      final result = await _controller.importBytesAsync(
+        selected.bytes,
+        fileName: selected.name,
+      );
+      if (!result.isValid) {
+        _tabs.animateTo(2);
+        _showMessage('Scenario import failed');
+      } else {
+        _tabs.animateTo(0);
+        _showMessage('Imported ${result.scenario!.metadata.name}');
+      }
+    });
+  }
+
+  Future<void> _saveDraft() async {
+    await _run(() async {
+      await _ensureDraftStore();
+      await _controller.saveDraft();
+      _showMessage('Draft saved');
+    });
+  }
+
+  Future<void> _loadDraft() async {
+    await _run(() async {
+      await _ensureDraftStore();
+      final restored = await _controller.loadDraft();
+      _showMessage(restored ? 'Draft restored' : 'No saved draft');
+      if (restored) _tabs.animateTo(0);
+    });
+  }
+
+  Future<void> _export(RpgScenarioPackageFormat format) async {
+    await _run(() async {
+      final scenario = _controller.scenario!;
+      final result = await widget.fileGateway.saveScenario(
+        suggestedName: scenario.metadata.id,
+        content: _controller.export(format: format),
+        format: format,
+      );
+      if (result != null) _showMessage('Scenario exported');
+    });
+  }
+
+  Future<void> _ensureDraftStore() async {
+    if (_controller.draftStore != null) return;
+    _controller.configureDraftStore(
+      await FileRpgScenarioDraftStore.forApplicationSupport(),
+    );
+  }
+
+  Future<void> _run(Future<void> Function() operation) async {
+    if (_working) return;
+    setState(() => _working = true);
+    try {
+      await operation();
+    } catch (error) {
+      _showMessage(error.toString());
+    } finally {
+      if (mounted) setState(() => _working = false);
+    }
+  }
+
+  void _showMessage(String message) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context)
+      ..hideCurrentSnackBar()
+      ..showSnackBar(SnackBar(content: Text(message)));
+  }
+}
+
+class _DocumentEditor extends StatelessWidget {
+  final RpgScenarioEditorController controller;
+
+  const _DocumentEditor({required this.controller});
+
+  @override
+  Widget build(BuildContext context) {
+    final entries = controller.document.entries.toList();
+    return ListView.separated(
+      key: const PageStorageKey('rpg-document-editor'),
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      itemCount: entries.length,
+      separatorBuilder: (_, __) => const Divider(height: 1),
+      itemBuilder: (context, index) {
+        final entry = entries[index];
+        final path = RpgEditorPath([entry.key]);
+        return _NodeEditor(
+          key: ValueKey(path.key),
+          controller: controller,
+          path: path,
+          label: _labelFor(entry.key),
+          value: entry.value,
+          initiallyExpanded: entry.key == 'metadata',
+        );
+      },
+    );
+  }
+}
+
+class _NodeEditor extends StatelessWidget {
+  final RpgScenarioEditorController controller;
+  final RpgEditorPath path;
+  final String label;
+  final Object? value;
+  final bool initiallyExpanded;
+  final Widget? trailing;
+
+  const _NodeEditor({
+    super.key,
+    required this.controller,
+    required this.path,
+    required this.label,
+    required this.value,
+    this.initiallyExpanded = false,
+    this.trailing,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (value is Map<String, dynamic>) {
+      if (_isOpenMap(path)) {
+        return _OpenMapEditor(
+          controller: controller,
+          path: path,
+          label: label,
+          value: value! as Map<String, dynamic>,
+          initiallyExpanded: initiallyExpanded,
+          trailing: trailing,
+        );
+      }
+      final map = value! as Map<String, dynamic>;
+      return ExpansionTile(
+        key: PageStorageKey(path.key),
+        initiallyExpanded: initiallyExpanded,
+        title: Text(label),
+        subtitle: _objectSubtitle(map),
+        trailing: trailing,
+        children: map.entries.map((entry) {
+          final childPath = path.child(entry.key);
+          return Padding(
+            padding: const EdgeInsets.only(left: 16),
+            child: _NodeEditor(
+              key: ValueKey(childPath.key),
+              controller: controller,
+              path: childPath,
+              label: _labelFor(entry.key),
+              value: entry.value,
+            ),
+          );
+        }).toList(),
+      );
+    }
+    if (value is List<dynamic>) {
+      return _ListEditor(
+        controller: controller,
+        path: path,
+        label: label,
+        value: value! as List<dynamic>,
+        initiallyExpanded: initiallyExpanded,
+        trailing: trailing,
+      );
+    }
+    if (value == null) {
+      return ListTile(
+        title: Text(label),
+        subtitle: _issueText(controller, path),
+        trailing: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            IconButton(
+              key: Key('rpg-set-${path.key}'),
+              tooltip: 'Set value',
+              onPressed: () => controller.initializeOptional(path),
+              icon: const Icon(Icons.add_circle_outline),
+            ),
+            if (trailing != null) trailing!,
+          ],
+        ),
+      );
+    }
+    return _ScalarEditor(
+      controller: controller,
+      path: path,
+      label: label,
+      value: value!,
+      trailing: trailing,
+    );
+  }
+}
+
+class _ListEditor extends StatelessWidget {
+  final RpgScenarioEditorController controller;
+  final RpgEditorPath path;
+  final String label;
+  final List<dynamic> value;
+  final bool initiallyExpanded;
+  final Widget? trailing;
+
+  const _ListEditor({
+    required this.controller,
+    required this.path,
+    required this.label,
+    required this.value,
+    required this.initiallyExpanded,
+    this.trailing,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ExpansionTile(
+      key: PageStorageKey(path.key),
+      initiallyExpanded: initiallyExpanded,
+      title: Text(label),
+      subtitle: Text('${value.length}'),
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          IconButton(
+            key: Key('rpg-add-${path.key}'),
+            tooltip: 'Add ${label.toLowerCase()}',
+            onPressed: () => controller.addListItem(path),
+            icon: const Icon(Icons.add),
+          ),
+          if (trailing != null) trailing!,
+        ],
+      ),
+      children: [
+        for (var index = 0; index < value.length; index++)
+          Padding(
+            padding: const EdgeInsets.only(left: 16),
+            child: _NodeEditor(
+              key: ValueKey('${path.key}/$index'),
+              controller: controller,
+              path: path.child(index),
+              label: _itemLabel(value[index], index),
+              value: value[index],
+              trailing: _ListItemActions(
+                onMoveUp: index == 0
+                    ? null
+                    : () => controller.moveListItem(path, index, index - 1),
+                onMoveDown: index == value.length - 1
+                    ? null
+                    : () => controller.moveListItem(path, index, index + 1),
+                onDelete: () => controller.removeListItem(path, index),
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _ListItemActions extends StatelessWidget {
+  final VoidCallback? onMoveUp;
+  final VoidCallback? onMoveDown;
+  final VoidCallback onDelete;
+
+  const _ListItemActions({
+    this.onMoveUp,
+    this.onMoveDown,
+    required this.onDelete,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return PopupMenuButton<String>(
+      tooltip: 'Item actions',
+      onSelected: (value) {
+        if (value == 'up') onMoveUp?.call();
+        if (value == 'down') onMoveDown?.call();
+        if (value == 'delete') onDelete();
+      },
+      itemBuilder: (context) => [
+        PopupMenuItem(
+            value: 'up',
+            enabled: onMoveUp != null,
+            child: const Text('Move up')),
+        PopupMenuItem(
+            value: 'down',
+            enabled: onMoveDown != null,
+            child: const Text('Move down')),
+        const PopupMenuDivider(),
+        const PopupMenuItem(value: 'delete', child: Text('Delete')),
+      ],
+    );
+  }
+}
+
+class _OpenMapEditor extends StatelessWidget {
+  final RpgScenarioEditorController controller;
+  final RpgEditorPath path;
+  final String label;
+  final Map<String, dynamic> value;
+  final bool initiallyExpanded;
+  final Widget? trailing;
+
+  const _OpenMapEditor({
+    required this.controller,
+    required this.path,
+    required this.label,
+    required this.value,
+    required this.initiallyExpanded,
+    this.trailing,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ExpansionTile(
+      key: PageStorageKey(path.key),
+      initiallyExpanded: initiallyExpanded,
+      title: Text(label),
+      subtitle: Text('${value.length}'),
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          IconButton(
+            key: Key('rpg-add-map-${path.key}'),
+            tooltip: 'Add entry',
+            onPressed: () => _addEntry(context),
+            icon: const Icon(Icons.add),
+          ),
+          if (trailing != null) trailing!,
+        ],
+      ),
+      children: value.entries.map((entry) {
+        final childPath = path.child(entry.key);
+        return Padding(
+          padding: const EdgeInsets.only(left: 16),
+          child: _NodeEditor(
+            key: ValueKey(childPath.key),
+            controller: controller,
+            path: childPath,
+            label: entry.key,
+            value: entry.value,
+            trailing: IconButton(
+              tooltip: 'Delete entry',
+              onPressed: () => controller.removeMapEntry(path, entry.key),
+              icon: const Icon(Icons.delete_outline),
+            ),
+          ),
+        );
+      }).toList(),
+    );
+  }
+
+  Future<void> _addEntry(BuildContext context) async {
+    final keyController = TextEditingController();
+    final valueController = TextEditingController();
+    final result = await showDialog<(String, Object?)>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text('Add $label entry'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            TextField(
+              key: const Key('rpg-map-entry-key'),
+              controller: keyController,
+              autofocus: true,
+              decoration: const InputDecoration(labelText: 'Name'),
+            ),
+            TextField(
+              key: const Key('rpg-map-entry-value'),
+              controller: valueController,
+              decoration: const InputDecoration(labelText: 'Value'),
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () {
+              final key = keyController.text.trim();
+              if (key.isEmpty) return;
+              Navigator.pop(
+                context,
+                (key, _parseLooseValue(valueController.text)),
+              );
+            },
+            child: const Text('Add'),
+          ),
+        ],
+      ),
+    );
+    keyController.dispose();
+    valueController.dispose();
+    if (result != null) controller.setMapEntry(path, result.$1, result.$2);
+  }
+}
+
+class _ScalarEditor extends StatefulWidget {
+  final RpgScenarioEditorController controller;
+  final RpgEditorPath path;
+  final String label;
+  final Object value;
+  final Widget? trailing;
+
+  const _ScalarEditor({
+    required this.controller,
+    required this.path,
+    required this.label,
+    required this.value,
+    this.trailing,
+  });
+
+  @override
+  State<_ScalarEditor> createState() => _ScalarEditorState();
+}
+
+class _ScalarEditorState extends State<_ScalarEditor> {
+  late final TextEditingController _text;
+  late final FocusNode _focus;
+  String? _localError;
+
+  @override
+  void initState() {
+    super.initState();
+    _text = TextEditingController(text: '${widget.value}');
+    _focus = FocusNode();
+  }
+
+  @override
+  void didUpdateWidget(covariant _ScalarEditor oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final next = '${widget.value}';
+    if (!_focus.hasFocus && _text.text != next) _text.text = next;
+  }
+
+  @override
+  void dispose() {
+    _text.dispose();
+    _focus.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final enumValues = _enumValues(widget.path);
+    if (enumValues != null) {
+      return ListTile(
+        title: DropdownButtonFormField<String>(
+          key: Key('rpg-field-${widget.path.key}'),
+          initialValue: widget.value as String,
+          decoration: InputDecoration(
+            labelText: widget.label,
+            errorText: _issueMessage(widget.controller, widget.path),
+          ),
+          items: enumValues
+              .map(
+                  (value) => DropdownMenuItem(value: value, child: Text(value)))
+              .toList(),
+          onChanged: (value) {
+            if (value != null) widget.controller.update(widget.path, value);
+          },
+        ),
+        trailing: widget.trailing,
+      );
+    }
+    if (widget.value is bool) {
+      return SwitchListTile(
+        key: Key('rpg-field-${widget.path.key}'),
+        title: Text(widget.label),
+        subtitle: _issueText(widget.controller, widget.path),
+        value: widget.value as bool,
+        onChanged: (value) => widget.controller.update(widget.path, value),
+        secondary: widget.trailing,
+      );
+    }
+    return ListTile(
+      title: TextField(
+        key: Key('rpg-field-${widget.path.key}'),
+        controller: _text,
+        focusNode: _focus,
+        maxLines: _isLongText(widget.path) ? 3 : 1,
+        keyboardType: widget.value is num
+            ? const TextInputType.numberWithOptions(
+                decimal: true,
+                signed: true,
+              )
+            : TextInputType.text,
+        decoration: InputDecoration(
+          labelText: widget.label,
+          errorText:
+              _localError ?? _issueMessage(widget.controller, widget.path),
+        ),
+        onChanged: _updateText,
+      ),
+      trailing: widget.trailing,
+    );
+  }
+
+  void _updateText(String value) {
+    if (widget.value is int) {
+      final parsed = int.tryParse(value);
+      setState(() => _localError = parsed == null ? 'Enter an integer' : null);
+      if (parsed != null) widget.controller.update(widget.path, parsed);
+    } else if (widget.value is num) {
+      final parsed = num.tryParse(value);
+      setState(() => _localError = parsed == null ? 'Enter a number' : null);
+      if (parsed != null) widget.controller.update(widget.path, parsed);
+    } else {
+      widget.controller.update(widget.path, value);
+    }
+  }
+}
+
+class _PreviewPane extends StatelessWidget {
+  final String source;
+
+  const _PreviewPane({required this.source});
+
+  @override
+  Widget build(BuildContext context) {
+    return SelectionArea(
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Text(
+          source,
+          key: const Key('rpg-preview-source'),
+          style: const TextStyle(fontFamily: 'monospace', fontSize: 13),
+        ),
+      ),
+    );
+  }
+}
+
+class _IssuesPane extends StatelessWidget {
+  final List<RpgScenarioPackageIssue> issues;
+
+  const _IssuesPane({required this.issues});
+
+  @override
+  Widget build(BuildContext context) {
+    if (issues.isEmpty) {
+      return const Center(
+        child: Icon(Icons.check_circle_outline, size: 48, color: Colors.green),
+      );
+    }
+    return ListView.separated(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      itemCount: issues.length,
+      separatorBuilder: (_, __) => const Divider(height: 1),
+      itemBuilder: (context, index) {
+        final issue = issues[index];
+        return ListTile(
+          leading: const Icon(Icons.error_outline, color: Colors.red),
+          title: Text(issue.path),
+          subtitle: Text('${issue.message}\n${issue.code}'),
+          isThreeLine: true,
+        );
+      },
+    );
+  }
+}
+
+bool _isOpenMap(RpgEditorPath path) {
+  const paths = {
+    '/initialState/attributes',
+    '/initialState/variables',
+    '/initialState/cooldowns',
+  };
+  return paths.contains(path.normalized) ||
+      path.normalized.endsWith('/metadata') ||
+      path.normalized.endsWith('/data') ||
+      path.normalized.endsWith('/objectiveProgress');
+}
+
+List<String>? _enumValues(RpgEditorPath path) {
+  final normalized = path.normalized;
+  if (normalized.endsWith('/operator')) {
+    return RpgConditionOperator.values.map((value) => value.name).toList();
+  }
+  if (normalized.contains('Effects/*/type') ||
+      normalized.endsWith('/effects/*/type')) {
+    return RpgEffectType.values.map((value) => value.name).toList();
+  }
+  if (normalized == '/initialState/quests/*/status') {
+    return RpgQuestStatus.values.map((value) => value.name).toList();
+  }
+  return null;
+}
+
+bool _isLongText(RpgEditorPath path) {
+  final field = path.segments.lastOrNull;
+  return field == 'description' || field == 'summary';
+}
+
+Widget? _objectSubtitle(Map<String, dynamic> value) {
+  final text = value['label'] ?? value['name'] ?? value['id'];
+  return text is String && text.isNotEmpty ? Text(text) : null;
+}
+
+String _itemLabel(Object? value, int index) {
+  if (value is Map<String, dynamic>) {
+    final text = value['label'] ?? value['name'] ?? value['id'];
+    if (text is String && text.isNotEmpty) return text;
+  }
+  return 'Item ${index + 1}';
+}
+
+String _labelFor(String key) {
+  const overrides = {
+    'metadata': 'Metadata',
+    'compatibility': 'Compatibility',
+    'initialState': 'Initial State',
+    'initialSeed': 'Initial Seed',
+    'schemaVersion': 'Schema Version',
+    'protectedFields': 'Protected Fields',
+  };
+  if (overrides[key] case final value?) return value;
+  final spaced = key.replaceAllMapped(
+    RegExp(r'([a-z0-9])([A-Z])'),
+    (match) => '${match.group(1)} ${match.group(2)}',
+  );
+  return spaced[0].toUpperCase() + spaced.substring(1);
+}
+
+Object? _parseLooseValue(String input) {
+  final trimmed = input.trim();
+  if (trimmed.isEmpty) return '';
+  try {
+    return jsonDecode(trimmed);
+  } on FormatException {
+    return input;
+  }
+}
+
+Widget? _issueText(
+  RpgScenarioEditorController controller,
+  RpgEditorPath path,
+) {
+  final message = _issueMessage(controller, path);
+  return message == null ? null : Text(message);
+}
+
+String? _issueMessage(
+  RpgScenarioEditorController controller,
+  RpgEditorPath path,
+) {
+  for (final issue in controller.issues) {
+    final issuePath = issue.path.startsWith(r'$package')
+        ? issue.path
+        : r'$package.' + issue.path;
+    if (issuePath == path.display) return issue.message;
+  }
+  return null;
+}
+
+extension<T> on List<T> {
+  T? get lastOrNull => isEmpty ? null : last;
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1522,7 +1522,7 @@ packages:
     source: hosted
     version: "6.6.1"
   yaml:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: yaml
       sha256: b9da305ac7c39faa3f030eccd175340f968459dae4af175130b3fc47e40d76ce

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,6 +51,7 @@ dependencies:
   package_info_plus: ^8.3.1
   collection: ^1.18.0
   equatable: ^2.0.5
+  yaml: ^3.1.3
   
   # UI Components
   cached_network_image: ^3.3.0

--- a/test/rpg_scenario_editor_screen_test.dart
+++ b/test/rpg_scenario_editor_screen_test.dart
@@ -1,0 +1,192 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:native_tavern/domain/services/rpg_scenario_draft_store.dart';
+import 'package:native_tavern/domain/services/rpg_scenario_package_service.dart';
+import 'package:native_tavern/presentation/controllers/rpg_scenario_editor_controller.dart';
+import 'package:native_tavern/presentation/screens/rpg/rpg_scenario_editor_screen.dart';
+
+void main() {
+  for (final size in [const Size(390, 844), const Size(1280, 900)]) {
+    testWidgets('editor lays out without overflow at ${size.width.toInt()}px',
+        (tester) async {
+      tester.view.physicalSize = size;
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(const MaterialApp(
+        home: RpgScenarioEditorScreen(),
+      ));
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+      expect(find.byKey(const Key('rpg-import')), findsOneWidget);
+      expect(find.byKey(const Key('rpg-tab-issues')), findsOneWidget);
+    });
+  }
+
+  testWidgets('imports, edits, drafts, previews, exports, and reimports',
+      (tester) async {
+    tester.view.physicalSize = const Size(1200, 1000);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final draftStore = _MemoryDraftStore();
+    final fileGateway = _FakeFileGateway(_yamlScenario);
+    final controller = RpgScenarioEditorController(
+      draftStore: draftStore,
+      packageService: const _SynchronousPackageService(),
+    );
+    await tester.pumpWidget(MaterialApp(
+      home: RpgScenarioEditorScreen(
+        controller: controller,
+        draftStore: draftStore,
+        fileGateway: fileGateway,
+      ),
+    ));
+
+    await tester.tap(find.byKey(const Key('rpg-import')));
+    await tester.pumpAndSettle();
+    expect(controller.scenario!.metadata.name, 'Imported Scenario');
+
+    final nameField = find.byKey(const Key('rpg-field-/metadata/name'));
+    expect(nameField, findsOneWidget);
+    await tester.enterText(nameField, 'Edited Scenario');
+    await tester.pumpAndSettle();
+
+    final addAttribute = find.byKey(const Key('rpg-add-/attributes'));
+    await Scrollable.ensureVisible(
+      tester.element(addAttribute),
+      alignment: 0.5,
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(addAttribute);
+    await tester.pumpAndSettle();
+    expect(controller.scenario!.attributes, hasLength(1));
+
+    await tester.tap(find.byKey(const Key('rpg-save-draft')));
+    await tester.pumpAndSettle();
+    expect(draftStore.saved, isNotNull);
+    expect(draftStore.saved!.document['metadata'],
+        containsPair('name', 'Edited Scenario'));
+
+    await tester.tap(find.byTooltip('Export scenario'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('rpg-export-json')));
+    await tester.pumpAndSettle();
+    expect(fileGateway.savedContent, isNotNull);
+
+    final reimported = const RpgScenarioPackageService().importText(
+      fileGateway.savedContent!,
+      fileName: 'round-trip.json',
+    );
+    expect(reimported.issues, isEmpty, reason: reimported.issues.join('\n'));
+    expect(reimported.scenario!.metadata.name, 'Edited Scenario');
+
+    await tester.tap(find.byKey(const Key('rpg-tab-preview')));
+    await tester.pumpAndSettle();
+    final preview = tester.widget<Text>(
+      find.byKey(const Key('rpg-preview-source')),
+    );
+    expect(preview.data, contains('Edited Scenario'));
+  });
+
+  testWidgets('invalid import opens field-level issues without replacing draft',
+      (tester) async {
+    final controller = RpgScenarioEditorController(
+      packageService: const _SynchronousPackageService(),
+    );
+    final original = controller.preview();
+    final gateway = _FakeFileGateway('''
+schemaVersion: 1
+metadata:
+  id: broken
+  name: 42
+  version: 1.0.0
+initialSeed: 1
+initialState:
+  scenarioId: broken
+  scenarioVersion: 1.0.0
+  random: {initialSeed: 1, state: 1}
+''');
+    await tester.pumpWidget(MaterialApp(
+      home: RpgScenarioEditorScreen(
+        controller: controller,
+        fileGateway: gateway,
+      ),
+    ));
+
+    await tester.tap(find.byKey(const Key('rpg-import')));
+    await tester.pumpAndSettle();
+
+    expect(controller.preview(), original);
+    expect(find.textContaining(r'$package.metadata.name'), findsOneWidget);
+    expect(find.textContaining('Expected string'), findsOneWidget);
+  });
+}
+
+class _FakeFileGateway implements RpgScenarioFileGateway {
+  final String source;
+  String? savedContent;
+
+  _FakeFileGateway(this.source);
+
+  @override
+  Future<RpgScenarioFileData?> pickScenario() async => RpgScenarioFileData(
+        name: 'scenario.yaml',
+        bytes: utf8.encode(source),
+      );
+
+  @override
+  Future<String?> saveScenario({
+    required String suggestedName,
+    required String content,
+    required RpgScenarioPackageFormat format,
+  }) async {
+    savedContent = content;
+    return '$suggestedName.${format.name}';
+  }
+}
+
+class _SynchronousPackageService extends RpgScenarioPackageService {
+  const _SynchronousPackageService();
+
+  @override
+  Future<RpgScenarioPackageResult> importBytesAsync(
+    Uint8List bytes, {
+    String? fileName,
+  }) async =>
+      importBytes(bytes, fileName: fileName);
+}
+
+class _MemoryDraftStore implements RpgScenarioDraftStore {
+  RpgScenarioDraft? saved;
+
+  @override
+  Future<void> clear() async => saved = null;
+
+  @override
+  Future<RpgScenarioDraft?> load() async => saved;
+
+  @override
+  Future<void> save(RpgScenarioDraft draft) async => saved = draft;
+}
+
+const _yamlScenario = '''
+schemaVersion: 1
+metadata:
+  id: imported_scenario
+  name: Imported Scenario
+  version: 1.0.0
+initialSeed: 11
+initialState:
+  scenarioId: imported_scenario
+  scenarioVersion: 1.0.0
+  random:
+    initialSeed: 11
+    state: 11
+''';

--- a/test/rpg_scenario_package_service_test.dart
+++ b/test/rpg_scenario_package_service_test.dart
@@ -1,0 +1,329 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:native_tavern/domain/services/rpg_scenario_draft_store.dart';
+import 'package:native_tavern/domain/services/rpg_scenario_package_service.dart';
+import 'package:native_tavern/presentation/controllers/rpg_scenario_editor_controller.dart';
+
+void main() {
+  group('RpgScenarioPackageService', () {
+    const service = RpgScenarioPackageService();
+
+    test('imports JSON and YAML through the same production contract', () {
+      final jsonResult = service.importText(
+        jsonEncode(_minimalDocument()),
+        fileName: 'scenario.json',
+      );
+      final yamlResult = service.importText(
+        _minimalYaml,
+        fileName: 'scenario.yaml',
+      );
+
+      expect(jsonResult.issues, isEmpty);
+      expect(yamlResult.issues, isEmpty);
+      expect(yamlResult.scenario!.toJson(), jsonResult.scenario!.toJson());
+      expect(yamlResult.format, RpgScenarioPackageFormat.yaml);
+    });
+
+    test('exports lossless canonical JSON and YAML', () {
+      final scenario = service
+          .importText(jsonEncode(_fullDocument()), fileName: 'full.json')
+          .scenario!;
+
+      for (final format in RpgScenarioPackageFormat.values) {
+        final encoded = service.exportScenario(scenario, format: format);
+        final decoded = service.importText(
+          encoded,
+          fileName: format == RpgScenarioPackageFormat.json
+              ? 'round_trip.json'
+              : 'round_trip.yaml',
+        );
+
+        expect(decoded.issues, isEmpty, reason: decoded.issues.join('\n'));
+        expect(decoded.scenario!.toJson(), scenario.toJson());
+      }
+    });
+
+    test('reports structural errors at the exact field', () {
+      final document = _minimalDocument();
+      (document['metadata'] as Map<String, dynamic>)['name'] = 42;
+
+      final result = service.importText(jsonEncode(document));
+
+      expect(result.isValid, isFalse);
+      expect(
+        result.issues,
+        contains(isA<RpgScenarioPackageIssue>()
+            .having((issue) => issue.path, 'path', r'$package.metadata.name')
+            .having(
+              (issue) => issue.code,
+              'code',
+              'invalid_field_type',
+            )),
+      );
+    });
+
+    test('rejects unsupported versions and missing capabilities', () {
+      final document = _minimalDocument();
+      document['schemaVersion'] = 2;
+      document['compatibility'] = {
+        'minimumEngineVersion': '2.0.0',
+        'requiredCapabilities': ['network_scripts'],
+      };
+
+      final result = service.importText(jsonEncode(document));
+      final codes = result.issues.map((issue) => issue.code).toSet();
+
+      expect(codes, contains('unsupported_schema_version'));
+      expect(codes, contains('incompatible_engine_version'));
+      expect(codes, contains('missing_capability'));
+    });
+
+    test('rejects executable fields and risky YAML features', () {
+      final document = _minimalDocument();
+      document['actions'] = <dynamic>[];
+      (document['actions'] as List<dynamic>).add({
+        'id': 'unsafe',
+        'label': 'Unsafe',
+        'script': 'rm -rf /',
+      });
+
+      final executable = service.importText(jsonEncode(document));
+      final alias = service.importText(
+        '${_minimalYaml}extra: &payload [1, 2]\ncopy: *payload\n',
+        fileName: 'unsafe.yaml',
+      );
+
+      expect(executable.issues.map((issue) => issue.code),
+          contains('unsafe_property'));
+      expect(alias.issues.single.code, 'unsafe_yaml_feature');
+      expect(alias.issues.single.line, isNotNull);
+    });
+
+    test('enforces byte, depth, and collection limits before conversion', () {
+      const limited = RpgScenarioPackageService(
+        limits: RpgScenarioPackageLimits(
+          maxBytes: 200,
+          maxDepth: 3,
+          maxNodes: 20,
+          maxCollectionLength: 2,
+        ),
+      );
+
+      final bytes = limited.importBytes(
+        Uint8List.fromList(List<int>.filled(201, 0x20)),
+      );
+      final depth = const RpgScenarioPackageService(
+        limits: RpgScenarioPackageLimits(maxDepth: 2),
+      ).importText(jsonEncode(_minimalDocument()));
+      final collection = const RpgScenarioPackageService(
+        limits: RpgScenarioPackageLimits(maxCollectionLength: 1),
+      ).importText(jsonEncode(_minimalDocument()));
+
+      expect(bytes.issues.single.code, 'package_too_large');
+      expect(depth.issues.single.code, 'nesting_too_deep');
+      expect(collection.issues.single.code, 'collection_too_large');
+    });
+
+    test('malformed JSON includes a source location', () {
+      final result = service.importText('{"schemaVersion": 1,}');
+
+      expect(result.issues.single.code, 'invalid_json');
+      expect(result.issues.single.line, 1);
+      expect(result.issues.single.column, isNotNull);
+    });
+
+    test('reports invalid references from the production validator', () {
+      final document = _minimalDocument();
+      document['actions'] = [
+        {
+          'id': 'leave',
+          'label': 'Leave',
+          'effects': [
+            {'type': 'moveTo', 'target': 'missing_location'},
+          ],
+        },
+      ];
+
+      final result = service.importText(jsonEncode(document));
+
+      expect(
+        result.issues,
+        contains(isA<RpgScenarioPackageIssue>()
+            .having(
+              (issue) => issue.path,
+              'path',
+              'actions[0].effects[0]',
+            )
+            .having((issue) => issue.code, 'code', 'invalid_reference')),
+      );
+    });
+
+    test('async file import returns the same validated package', () async {
+      final source = '${jsonEncode(_minimalDocument())}${' ' * 512000}';
+
+      final result = await service.importBytesAsync(
+        Uint8List.fromList(utf8.encode(source)),
+        fileName: 'large.json',
+      );
+
+      expect(result.issues, isEmpty);
+      expect(result.scenario!.metadata.id, 'test_scenario');
+    });
+  });
+
+  group('RpgScenarioEditorController', () {
+    test(
+        'edits every document through validation and exports a reimportable pack',
+        () {
+      final controller = RpgScenarioEditorController();
+
+      controller.update(
+        const RpgEditorPath(['metadata', 'id']),
+        'edited_scenario',
+      );
+      controller.addListItem(const RpgEditorPath(['attributes']));
+      controller.update(
+        const RpgEditorPath(['attributes', 0, 'id']),
+        'courage',
+      );
+      controller.update(
+        const RpgEditorPath(['attributes', 0, 'label']),
+        'Courage',
+      );
+      controller.setMapEntry(
+        const RpgEditorPath(['initialState', 'attributes']),
+        'courage',
+        5,
+      );
+      controller.addListItem(const RpgEditorPath(['actions']));
+      controller.update(
+        const RpgEditorPath(['actions', 0, 'id']),
+        'press_on',
+      );
+      controller.update(
+        const RpgEditorPath(['actions', 0, 'label']),
+        'Press On',
+      );
+      controller.initializeOptional(
+        const RpgEditorPath(['actions', 0, 'check']),
+      );
+      controller.update(
+        const RpgEditorPath(['actions', 0, 'check', 'attributeId']),
+        'courage',
+      );
+
+      expect(
+        controller.valueAt(
+          const RpgEditorPath(['initialState', 'scenarioId']),
+        ),
+        'edited_scenario',
+      );
+      expect(controller.issues, isEmpty, reason: controller.issues.join('\n'));
+
+      final exported = controller.export(format: RpgScenarioPackageFormat.yaml);
+      final reimported = const RpgScenarioPackageService().importText(
+        exported,
+        fileName: 'edited.yaml',
+      );
+      expect(reimported.issues, isEmpty, reason: reimported.issues.join('\n'));
+      expect(reimported.scenario!.attributes.single.id, 'courage');
+      expect(reimported.scenario!.actions.single.check!.attributeId, 'courage');
+    });
+
+    test('saves and restores an invalid in-progress draft atomically',
+        () async {
+      final root = await Directory.systemTemp.createTemp('rpg-draft-test-');
+      addTearDown(() => root.delete(recursive: true));
+      final store = FileRpgScenarioDraftStore(root);
+      final original = RpgScenarioEditorController(draftStore: store);
+      original.update(const RpgEditorPath(['metadata', 'name']), 'Draft Name');
+      original.update(const RpgEditorPath(['metadata', 'id']), 'not valid');
+
+      await original.saveDraft();
+      final restored = RpgScenarioEditorController(draftStore: store);
+
+      expect(await restored.loadDraft(), isTrue);
+      expect(
+        restored.valueAt(const RpgEditorPath(['metadata', 'name'])),
+        'Draft Name',
+      );
+      expect(restored.isValid, isFalse);
+      expect(restored.draftUpdatedAt, isNotNull);
+    });
+  });
+}
+
+Map<String, dynamic> _minimalDocument() => {
+      'schemaVersion': 1,
+      'metadata': <String, dynamic>{
+        'id': 'test_scenario',
+        'name': 'Test Scenario',
+        'version': '1.0.0',
+      },
+      'initialSeed': 7,
+      'initialState': <String, dynamic>{
+        'scenarioId': 'test_scenario',
+        'scenarioVersion': '1.0.0',
+        'random': <String, dynamic>{'initialSeed': 7, 'state': 7},
+      },
+    };
+
+Map<String, dynamic> _fullDocument() {
+  final document = _minimalDocument();
+  document['compatibility'] = {
+    'minimumEngineVersion': '1.0.0',
+    'requiredCapabilities': ['core_rules'],
+  };
+  document['attributes'] = [
+    {
+      'id': 'courage',
+      'label': 'Courage',
+      'initialValue': 4,
+      'minimum': 0,
+      'maximum': 10,
+    },
+  ];
+  document['items'] = [
+    {'id': 'torch', 'label': 'Torch'},
+  ];
+  document['locations'] = [
+    {'id': 'gate', 'label': 'Gate'},
+  ];
+  document['actions'] = [
+    {
+      'id': 'advance',
+      'label': 'Advance',
+      'availability': [
+        {'operator': 'greaterThan', 'path': 'attributes.courage', 'value': 0},
+      ],
+      'effects': [
+        {'type': 'moveTo', 'target': 'gate'},
+      ],
+    },
+  ];
+  final state = document['initialState'] as Map<String, dynamic>;
+  state['attributes'] = {'courage': 4};
+  state['inventory'] = [
+    {'itemId': 'torch', 'quantity': 1},
+  ];
+  state['locationId'] = 'gate';
+  return document;
+}
+
+const _minimalYaml = '''
+schemaVersion: 1
+metadata:
+  id: test_scenario
+  name: Test Scenario
+  version: 1.0.0
+initialSeed: 7
+initialState:
+  scenarioId: test_scenario
+  scenarioVersion: 1.0.0
+  random:
+    initialSeed: 7
+    state: 7
+''';


### PR DESCRIPTION
## Summary

- Add a production JSON/YAML RPG scenario package importer with strict schema checks, field-level diagnostics, compatibility gates, resource limits, and isolated parsing.
- Add a schema-driven RPG scenario editor covering metadata, attributes, variables, items, actors, locations, quests, actions, conditions, effects, and initial state.
- Add atomic local drafts, preview, JSON/YAML export, lossless reimport, and responsive desktop/mobile layouts.

## Roadmap tasks

- [x] C04 Scenario package parsing and validation
  - JSON, YAML, schema version, references, compatibility, and capability checks.
  - Byte, nesting, node, string, and collection limits.
  - Executable fields plus YAML anchors, aliases, merge keys, and tags are rejected.
  - Parse and validation errors include precise paths and source locations where available.
- [x] C07 Scenario package editor
  - Structured editing for every current C01 contract node.
  - Draft save/restore, import, preview, JSON/YAML export, reorder/delete, and map entry editing.
  - Editor output is accepted only through the same production validator.
  - Independent Screen only; route/localization integration remains owned by J08.

## Verification

- Targeted flutter analyze on all six added production and test files: no issues.
- Full flutter test: 188 tests passed.
- End-to-end component flow: YAML import to structured edit to draft save to JSON export to production reimport.
- Responsive widget checks at 390x844 and 1280x900.

Closes #27