### PR TITLE
feat: add provider tool calling adapters

### DIFF
--- a/lib/domain/models/tool_calling.dart
+++ b/lib/domain/models/tool_calling.dart
@@ -1,0 +1,564 @@
+import 'dart:convert';
+
+enum ToolChoiceMode { auto, none, required, named }
+
+enum ToolCallStatus { ready, invalidArguments, cancelled }
+
+enum ToolResultStatus { succeeded, failed, cancelled }
+
+final class ToolProtocolException implements Exception {
+  final String code;
+  final String message;
+  final String? slot;
+
+  const ToolProtocolException(this.code, this.message, {this.slot});
+
+  @override
+  String toString() {
+    final location = slot == null ? '' : ' at $slot';
+    return 'Tool protocol error [$code]$location: $message';
+  }
+}
+
+final class ToolDefinition {
+  static final RegExp _validName = RegExp(r'^[A-Za-z0-9_-]{1,64}$');
+
+  final String name;
+  final String description;
+  final Map<String, dynamic> inputSchema;
+
+  factory ToolDefinition({
+    required String name,
+    required String description,
+    required Map<String, dynamic> inputSchema,
+  }) {
+    if (!_validName.hasMatch(name)) {
+      throw const ToolProtocolException(
+        'invalid_tool_name',
+        'Tool names must contain 1-64 letters, digits, underscores, or dashes.',
+      );
+    }
+    if (description.trim().isEmpty) {
+      throw const ToolProtocolException(
+        'invalid_tool_description',
+        'Tool descriptions must not be empty.',
+      );
+    }
+    final schema = copyToolJsonObject(inputSchema);
+    final schemaType = schema['type'];
+    if (schemaType != null && schemaType != 'object') {
+      throw const ToolProtocolException(
+        'invalid_tool_schema',
+        'The root input schema must have type object.',
+      );
+    }
+    return ToolDefinition._(name, description, schema);
+  }
+
+  const ToolDefinition._(this.name, this.description, this.inputSchema);
+}
+
+final class ToolChoice {
+  final ToolChoiceMode mode;
+  final String? toolName;
+
+  const ToolChoice._(this.mode, this.toolName);
+
+  static const auto = ToolChoice._(ToolChoiceMode.auto, null);
+  static const none = ToolChoice._(ToolChoiceMode.none, null);
+  static const required = ToolChoice._(ToolChoiceMode.required, null);
+
+  factory ToolChoice.named(String toolName) {
+    if (!ToolDefinition._validName.hasMatch(toolName)) {
+      throw const ToolProtocolException(
+        'invalid_tool_choice',
+        'A named tool choice must contain a valid tool name.',
+      );
+    }
+    return ToolChoice._(ToolChoiceMode.named, toolName);
+  }
+}
+
+final class ToolCallingConfiguration {
+  final bool enabled;
+  final List<ToolDefinition> tools;
+  final ToolChoice choice;
+  final int maxRecursionDepth;
+
+  const ToolCallingConfiguration.disabled()
+      : enabled = false,
+        tools = const [],
+        choice = ToolChoice.none,
+        maxRecursionDepth = 0;
+
+  factory ToolCallingConfiguration.enabled({
+    required Iterable<ToolDefinition> tools,
+    ToolChoice choice = ToolChoice.auto,
+    int maxRecursionDepth = 8,
+  }) {
+    final definitions = List<ToolDefinition>.unmodifiable(tools);
+    if (definitions.isEmpty) {
+      throw const ToolProtocolException(
+        'missing_tools',
+        'Enabled tool calling requires at least one tool definition.',
+      );
+    }
+    final names = definitions.map((tool) => tool.name).toSet();
+    if (names.length != definitions.length) {
+      throw const ToolProtocolException(
+        'duplicate_tool_name',
+        'Tool names must be unique within a request.',
+      );
+    }
+    if (choice.mode == ToolChoiceMode.named &&
+        !names.contains(choice.toolName)) {
+      throw const ToolProtocolException(
+        'unknown_tool_choice',
+        'The named tool choice must reference a declared tool.',
+      );
+    }
+    if (maxRecursionDepth < 1) {
+      throw const ToolProtocolException(
+        'invalid_recursion_limit',
+        'The recursion limit must be at least one.',
+      );
+    }
+    return ToolCallingConfiguration._(definitions, choice, maxRecursionDepth);
+  }
+
+  const ToolCallingConfiguration._(
+    this.tools,
+    this.choice,
+    this.maxRecursionDepth,
+  ) : enabled = true;
+}
+
+final class ToolCancellationToken {
+  bool _cancelled = false;
+  Object? _reason;
+  final List<void Function(Object?)> _listeners = [];
+
+  ToolCancellationToken._();
+
+  bool get isCancelled => _cancelled;
+  Object? get reason => _reason;
+
+  void throwIfCancelled() {
+    if (_cancelled) {
+      throw ToolProtocolException(
+        'cancelled',
+        _reason?.toString() ?? 'Tool processing was cancelled.',
+      );
+    }
+  }
+
+  void whenCancelled(void Function(Object?) listener) {
+    if (_cancelled) {
+      listener(_reason);
+      return;
+    }
+    _listeners.add(listener);
+  }
+
+  void _cancel(Object? reason) {
+    if (_cancelled) return;
+    _cancelled = true;
+    _reason = reason;
+    final listeners = List<void Function(Object?)>.of(_listeners);
+    _listeners.clear();
+    for (final listener in listeners) {
+      listener(reason);
+    }
+  }
+}
+
+final class ToolCancellationController {
+  final ToolCancellationToken token = ToolCancellationToken._();
+
+  void cancel([Object? reason]) => token._cancel(reason);
+}
+
+final class ToolInvocationContext {
+  final int depth;
+  final int maxDepth;
+  final ToolCancellationToken cancellationToken;
+
+  const ToolInvocationContext({
+    this.depth = 0,
+    required this.maxDepth,
+    required this.cancellationToken,
+  });
+
+  ToolInvocationContext next() {
+    cancellationToken.throwIfCancelled();
+    if (depth >= maxDepth) {
+      throw ToolProtocolException(
+        'recursion_limit',
+        'Tool recursion depth $maxDepth has been reached.',
+      );
+    }
+    return ToolInvocationContext(
+      depth: depth + 1,
+      maxDepth: maxDepth,
+      cancellationToken: cancellationToken,
+    );
+  }
+}
+
+final class ToolCall {
+  final String id;
+  final String name;
+  final Map<String, dynamic> arguments;
+  final String rawArguments;
+  final ToolCallStatus status;
+  final String? error;
+
+  factory ToolCall.ready({
+    required String id,
+    required String name,
+    required Map<String, dynamic> arguments,
+    required String rawArguments,
+  }) {
+    _validateIdentity(id, name);
+    return ToolCall._(
+      id,
+      name,
+      copyToolJsonObject(arguments),
+      rawArguments,
+      ToolCallStatus.ready,
+      null,
+    );
+  }
+
+  factory ToolCall.invalidArguments({
+    required String id,
+    required String name,
+    required String rawArguments,
+    required String error,
+  }) {
+    _validateIdentity(id, name);
+    return ToolCall._(
+      id,
+      name,
+      const {},
+      rawArguments,
+      ToolCallStatus.invalidArguments,
+      error,
+    );
+  }
+
+  factory ToolCall.cancelled({
+    required String id,
+    required String name,
+    required String rawArguments,
+    String? reason,
+  }) {
+    _validateIdentity(id, name);
+    return ToolCall._(
+      id,
+      name,
+      const {},
+      rawArguments,
+      ToolCallStatus.cancelled,
+      reason,
+    );
+  }
+
+  const ToolCall._(
+    this.id,
+    this.name,
+    this.arguments,
+    this.rawArguments,
+    this.status,
+    this.error,
+  );
+
+  static void _validateIdentity(String id, String name) {
+    if (id.trim().isEmpty) {
+      throw const ToolProtocolException(
+        'missing_call_id',
+        'Tool calls require a non-empty ID.',
+      );
+    }
+    if (!ToolDefinition._validName.hasMatch(name)) {
+      throw const ToolProtocolException(
+        'invalid_call_name',
+        'Tool calls require a valid tool name.',
+      );
+    }
+  }
+}
+
+final class ToolResultMessage {
+  final String callId;
+  final String toolName;
+  final Object? output;
+  final ToolResultStatus status;
+
+  factory ToolResultMessage({
+    required String callId,
+    required String toolName,
+    required Object? output,
+    ToolResultStatus status = ToolResultStatus.succeeded,
+  }) {
+    ToolCall._validateIdentity(callId, toolName);
+    return ToolResultMessage._(
+      callId,
+      toolName,
+      copyToolJsonValue(output),
+      status,
+    );
+  }
+
+  const ToolResultMessage._(
+    this.callId,
+    this.toolName,
+    this.output,
+    this.status,
+  );
+
+  bool get isError => status != ToolResultStatus.succeeded;
+}
+
+final class ToolAssistantMessage {
+  final String text;
+  final String? reasoning;
+  final List<ToolCall> toolCalls;
+  final String? finishReason;
+
+  ToolAssistantMessage({
+    this.text = '',
+    this.reasoning,
+    Iterable<ToolCall> toolCalls = const [],
+    this.finishReason,
+  }) : toolCalls = List<ToolCall>.unmodifiable(toolCalls);
+
+  bool get hasToolCalls => toolCalls.isNotEmpty;
+}
+
+final class ToolStreamUpdate {
+  final String textDelta;
+  final String reasoningDelta;
+  final List<ToolCall> completedCalls;
+  final String? finishReason;
+
+  ToolStreamUpdate({
+    this.textDelta = '',
+    this.reasoningDelta = '',
+    Iterable<ToolCall> completedCalls = const [],
+    this.finishReason,
+  }) : completedCalls = List<ToolCall>.unmodifiable(completedCalls);
+
+  bool get isEmpty =>
+      textDelta.isEmpty &&
+      reasoningDelta.isEmpty &&
+      completedCalls.isEmpty &&
+      finishReason == null;
+}
+
+final class ToolCallDelta {
+  final String slot;
+  final String? id;
+  final String? name;
+  final String argumentsFragment;
+  final bool isFinal;
+
+  const ToolCallDelta({
+    required this.slot,
+    this.id,
+    this.name,
+    this.argumentsFragment = '',
+    this.isFinal = false,
+  });
+}
+
+final class ToolCallStreamAccumulator {
+  final Map<String, _PendingToolCall> _pending = {};
+  final Map<String, String> _idSlots = {};
+  final Set<String> _completedSlots = {};
+
+  bool get hasPendingCalls => _pending.isNotEmpty;
+
+  ToolCall? add(ToolCallDelta delta) {
+    if (delta.slot.trim().isEmpty) {
+      throw const ToolProtocolException(
+        'missing_stream_slot',
+        'Streamed tool deltas require a stable slot.',
+      );
+    }
+    if (_completedSlots.contains(delta.slot)) {
+      throw ToolProtocolException(
+        'completed_stream_slot',
+        'A completed tool call cannot accept more deltas.',
+        slot: delta.slot,
+      );
+    }
+    final pending = _pending.putIfAbsent(delta.slot, () => _PendingToolCall());
+
+    if (delta.id != null && delta.id!.isNotEmpty) {
+      final existingSlot = _idSlots[delta.id];
+      if (existingSlot != null && existingSlot != delta.slot) {
+        throw ToolProtocolException(
+          'duplicate_call_id',
+          'Call ID ${delta.id} is already assigned to stream slot $existingSlot.',
+          slot: delta.slot,
+        );
+      }
+      if (pending.id != null && pending.id != delta.id) {
+        throw ToolProtocolException(
+          'changed_call_id',
+          'A stream slot cannot change its call ID.',
+          slot: delta.slot,
+        );
+      }
+      pending.id = delta.id;
+      _idSlots[delta.id!] = delta.slot;
+    }
+
+    if (delta.name != null && delta.name!.isNotEmpty) {
+      if (pending.name != null && pending.name != delta.name) {
+        throw ToolProtocolException(
+          'changed_call_name',
+          'A stream slot cannot change its tool name.',
+          slot: delta.slot,
+        );
+      }
+      pending.name = delta.name;
+    }
+    pending.arguments.write(delta.argumentsFragment);
+
+    return delta.isFinal ? complete(delta.slot) : null;
+  }
+
+  ToolCall complete(String slot) {
+    final pending = _pending.remove(slot);
+    if (pending == null) {
+      throw ToolProtocolException(
+        'unknown_stream_slot',
+        'No pending tool call exists for this stream slot.',
+        slot: slot,
+      );
+    }
+    final id = pending.id;
+    final name = pending.name;
+    if (id == null || id.isEmpty) {
+      throw ToolProtocolException(
+        'missing_call_id',
+        'The streamed tool call completed without an ID.',
+        slot: slot,
+      );
+    }
+    if (name == null || name.isEmpty) {
+      throw ToolProtocolException(
+        'missing_call_name',
+        'The streamed tool call completed without a tool name.',
+        slot: slot,
+      );
+    }
+
+    _completedSlots.add(slot);
+    final raw = pending.arguments.toString();
+    if (raw.trim().isEmpty) {
+      return ToolCall.ready(
+        id: id,
+        name: name,
+        arguments: const {},
+        rawArguments: raw,
+      );
+    }
+
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! Map<String, dynamic>) {
+        return ToolCall.invalidArguments(
+          id: id,
+          name: name,
+          rawArguments: raw,
+          error: 'Tool arguments must decode to a JSON object.',
+        );
+      }
+      return ToolCall.ready(
+        id: id,
+        name: name,
+        arguments: decoded,
+        rawArguments: raw,
+      );
+    } on FormatException catch (error) {
+      return ToolCall.invalidArguments(
+        id: id,
+        name: name,
+        rawArguments: raw,
+        error: error.message,
+      );
+    }
+  }
+
+  List<ToolCall> completeAll() {
+    return [for (final slot in _pending.keys.toList()) complete(slot)];
+  }
+
+  List<ToolCall> cancelAll([String? reason]) {
+    final cancelled = <ToolCall>[];
+    for (final entry in _pending.entries.toList()) {
+      final pending = entry.value;
+      final id = pending.id;
+      final name = pending.name;
+      if (id == null || name == null) {
+        _pending.remove(entry.key);
+        _completedSlots.add(entry.key);
+        continue;
+      }
+      cancelled.add(
+        ToolCall.cancelled(
+          id: id,
+          name: name,
+          rawArguments: pending.arguments.toString(),
+          reason: reason,
+        ),
+      );
+      _pending.remove(entry.key);
+      _completedSlots.add(entry.key);
+    }
+    return cancelled;
+  }
+}
+
+final class _PendingToolCall {
+  String? id;
+  String? name;
+  final StringBuffer arguments = StringBuffer();
+}
+
+Map<String, dynamic> copyToolJsonObject(Map<String, dynamic> value) {
+  return Map<String, dynamic>.unmodifiable({
+    for (final entry in value.entries)
+      entry.key: copyToolJsonValue(entry.value),
+  });
+}
+
+Object? copyToolJsonValue(Object? value) {
+  if (value == null || value is String || value is bool || value is num) {
+    return value;
+  }
+  if (value is List) {
+    return List<Object?>.unmodifiable(value.map(copyToolJsonValue));
+  }
+  if (value is Map) {
+    final result = <String, dynamic>{};
+    for (final entry in value.entries) {
+      final key = entry.key;
+      if (key is! String) {
+        throw const ToolProtocolException(
+          'invalid_json_value',
+          'Tool JSON objects require string keys.',
+        );
+      }
+      result[key] = copyToolJsonValue(entry.value);
+    }
+    return Map<String, dynamic>.unmodifiable(result);
+  }
+  throw ToolProtocolException(
+    'invalid_json_value',
+    'Unsupported tool JSON value of type ${value.runtimeType}.',
+  );
+}

--- a/lib/domain/services/tool_calling/claude_tool_calling_adapter.dart
+++ b/lib/domain/services/tool_calling/claude_tool_calling_adapter.dart
@@ -1,0 +1,187 @@
+import 'dart:convert';
+
+import 'package:native_tavern/domain/models/tool_calling.dart';
+import 'package:native_tavern/domain/services/tool_calling/tool_calling_adapter.dart';
+
+final class ClaudeToolCallingAdapter implements ToolCallingAdapter {
+  const ClaudeToolCallingAdapter();
+
+  @override
+  Map<String, dynamic> decorateRequest(
+    Map<String, dynamic> baseRequest,
+    ToolCallingConfiguration configuration,
+  ) {
+    if (!configuration.enabled) return baseRequest;
+
+    return {
+      ...baseRequest,
+      'tools': [
+        for (final tool in configuration.tools)
+          {
+            'name': tool.name,
+            'description': tool.description,
+            'input_schema': tool.inputSchema,
+          },
+      ],
+      'tool_choice': switch (configuration.choice.mode) {
+        ToolChoiceMode.auto => {'type': 'auto'},
+        ToolChoiceMode.none => {'type': 'none'},
+        ToolChoiceMode.required => {'type': 'any'},
+        ToolChoiceMode.named => {
+            'type': 'tool',
+            'name': configuration.choice.toolName,
+          },
+      },
+    };
+  }
+
+  @override
+  ToolAssistantMessage parseResponse(Map<String, dynamic> response) {
+    final text = StringBuffer();
+    final reasoning = StringBuffer();
+    final calls = <ToolCall>[];
+    final accumulator = ToolCallStreamAccumulator();
+    final blocks = toolObjectList(response['content']);
+
+    for (var index = 0; index < blocks.length; index++) {
+      final block = blocks[index];
+      switch (toolString(block['type'])) {
+        case 'text':
+          text.write(toolString(block['text']));
+        case 'thinking':
+          reasoning.write(toolString(block['thinking']));
+        case 'tool_use':
+          final input = block['input'];
+          calls.add(
+            accumulator.add(
+              ToolCallDelta(
+                slot: 'response:$index',
+                id: toolString(block['id']),
+                name: toolString(block['name']),
+                argumentsFragment: input == null ? '' : jsonEncode(input),
+                isFinal: true,
+              ),
+            )!,
+          );
+      }
+    }
+
+    return ToolAssistantMessage(
+      text: text.toString(),
+      reasoning: reasoning.isEmpty ? null : reasoning.toString(),
+      toolCalls: calls,
+      finishReason: _optionalString(response['stop_reason']),
+    );
+  }
+
+  @override
+  ToolCallingStreamParser createStreamParser() => _ClaudeStreamParser();
+
+  @override
+  Map<String, dynamic> encodeResult(ToolResultMessage result) {
+    return {
+      'role': 'user',
+      'content': [
+        {
+          'type': 'tool_result',
+          'tool_use_id': result.callId,
+          'content': toolOutputAsText(result.output),
+          if (result.isError) 'is_error': true,
+        },
+      ],
+    };
+  }
+}
+
+final class _ClaudeStreamParser implements ToolCallingStreamParser {
+  final ToolCallStreamAccumulator _accumulator = ToolCallStreamAccumulator();
+  final Set<String> _toolSlots = {};
+  bool _finished = false;
+
+  @override
+  ToolStreamUpdate addChunk(Map<String, dynamic> chunk) {
+    if (_finished) {
+      throw const ToolProtocolException(
+        'stream_finished',
+        'The Claude tool stream has already finished.',
+      );
+    }
+
+    final type = toolString(chunk['type']);
+    final index = chunk['index'] is int ? chunk['index'] as int : 0;
+    final slot = 'block:$index';
+    final text = StringBuffer();
+    final reasoning = StringBuffer();
+    final completed = <ToolCall>[];
+    String? finishReason;
+
+    switch (type) {
+      case 'content_block_start':
+        final block = toolObject(chunk['content_block']) ?? const {};
+        if (block['type'] == 'tool_use') {
+          final input = toolObject(block['input']);
+          _toolSlots.add(slot);
+          _accumulator.add(
+            ToolCallDelta(
+              slot: slot,
+              id: _optionalString(block['id']),
+              name: _optionalString(block['name']),
+              argumentsFragment:
+                  input == null || input.isEmpty ? '' : jsonEncode(input),
+            ),
+          );
+        }
+      case 'content_block_delta':
+        final delta = toolObject(chunk['delta']) ?? const {};
+        switch (toolString(delta['type'])) {
+          case 'input_json_delta':
+            _toolSlots.add(slot);
+            _accumulator.add(
+              ToolCallDelta(
+                slot: slot,
+                argumentsFragment: toolString(delta['partial_json']),
+              ),
+            );
+          case 'text_delta':
+            text.write(toolString(delta['text']));
+          case 'thinking_delta':
+            reasoning.write(toolString(delta['thinking']));
+        }
+      case 'content_block_stop':
+        if (_toolSlots.remove(slot)) {
+          completed.add(_accumulator.complete(slot));
+        }
+      case 'message_delta':
+        final delta = toolObject(chunk['delta']);
+        finishReason = _optionalString(delta?['stop_reason']);
+      case 'message_stop':
+        _finished = true;
+        if (_accumulator.hasPendingCalls) {
+          completed.addAll(_accumulator.completeAll());
+        }
+    }
+
+    return ToolStreamUpdate(
+      textDelta: text.toString(),
+      reasoningDelta: reasoning.toString(),
+      completedCalls: completed,
+      finishReason: finishReason,
+    );
+  }
+
+  @override
+  ToolStreamUpdate finish({bool cancelled = false, String? reason}) {
+    if (_finished) return ToolStreamUpdate();
+    _finished = true;
+    return ToolStreamUpdate(
+      completedCalls: cancelled
+          ? _accumulator.cancelAll(reason)
+          : _accumulator.completeAll(),
+      finishReason: cancelled ? 'cancelled' : null,
+    );
+  }
+}
+
+String? _optionalString(Object? value) {
+  return value is String && value.isNotEmpty ? value : null;
+}

--- a/lib/domain/services/tool_calling/gemini_tool_calling_adapter.dart
+++ b/lib/domain/services/tool_calling/gemini_tool_calling_adapter.dart
@@ -1,0 +1,217 @@
+import 'dart:convert';
+
+import 'package:native_tavern/domain/models/tool_calling.dart';
+import 'package:native_tavern/domain/services/tool_calling/tool_calling_adapter.dart';
+
+final class GeminiToolCallingAdapter implements ToolCallingAdapter {
+  const GeminiToolCallingAdapter();
+
+  @override
+  Map<String, dynamic> decorateRequest(
+    Map<String, dynamic> baseRequest,
+    ToolCallingConfiguration configuration,
+  ) {
+    if (!configuration.enabled) return baseRequest;
+
+    return {
+      ...baseRequest,
+      'tools': [
+        {
+          'functionDeclarations': [
+            for (final tool in configuration.tools)
+              {
+                'name': tool.name,
+                'description': tool.description,
+                'parameters': tool.inputSchema,
+              },
+          ],
+        },
+      ],
+      'toolConfig': {
+        'functionCallingConfig': switch (configuration.choice.mode) {
+          ToolChoiceMode.auto => {'mode': 'AUTO'},
+          ToolChoiceMode.none => {'mode': 'NONE'},
+          ToolChoiceMode.required => {'mode': 'ANY'},
+          ToolChoiceMode.named => {
+              'mode': 'ANY',
+              'allowedFunctionNames': [configuration.choice.toolName],
+            },
+        },
+      },
+    };
+  }
+
+  @override
+  ToolAssistantMessage parseResponse(Map<String, dynamic> response) {
+    final text = StringBuffer();
+    final reasoning = StringBuffer();
+    final calls = <ToolCall>[];
+    final accumulator = ToolCallStreamAccumulator();
+    String? finishReason;
+    final candidates = toolObjectList(response['candidates']);
+
+    for (var candidateIndex = 0;
+        candidateIndex < candidates.length;
+        candidateIndex++) {
+      final candidate = candidates[candidateIndex];
+      final content = toolObject(candidate['content']) ?? const {};
+      final parts = toolObjectList(content['parts']);
+      for (var partIndex = 0; partIndex < parts.length; partIndex++) {
+        final part = parts[partIndex];
+        _readTextPart(part, text, reasoning);
+        final function = toolObject(part['functionCall']);
+        if (function == null) continue;
+        final name = toolString(function['name']);
+        final arguments = function['args'];
+        calls.add(
+          accumulator.add(
+            ToolCallDelta(
+              slot: 'candidate:$candidateIndex:part:$partIndex',
+              id: _callId(function, candidateIndex, partIndex, name),
+              name: name,
+              argumentsFragment: arguments == null ? '' : jsonEncode(arguments),
+              isFinal: true,
+            ),
+          )!,
+        );
+      }
+      finishReason ??= _optionalString(candidate['finishReason']);
+    }
+
+    return ToolAssistantMessage(
+      text: text.toString(),
+      reasoning: reasoning.isEmpty ? null : reasoning.toString(),
+      toolCalls: calls,
+      finishReason: finishReason,
+    );
+  }
+
+  @override
+  ToolCallingStreamParser createStreamParser() => _GeminiStreamParser();
+
+  @override
+  Map<String, dynamic> encodeResult(ToolResultMessage result) {
+    return {
+      'role': 'user',
+      'parts': [
+        {
+          'functionResponse': {
+            'id': result.callId,
+            'name': result.toolName,
+            'response': toolOutputAsObject(result),
+          },
+        },
+      ],
+    };
+  }
+}
+
+final class _GeminiStreamParser implements ToolCallingStreamParser {
+  final ToolCallStreamAccumulator _accumulator = ToolCallStreamAccumulator();
+  bool _finished = false;
+
+  @override
+  ToolStreamUpdate addChunk(Map<String, dynamic> chunk) {
+    if (_finished) {
+      throw const ToolProtocolException(
+        'stream_finished',
+        'The Gemini tool stream has already finished.',
+      );
+    }
+
+    final text = StringBuffer();
+    final reasoning = StringBuffer();
+    final completed = <ToolCall>[];
+    String? finishReason;
+    final candidates = toolObjectList(chunk['candidates']);
+
+    for (var listIndex = 0; listIndex < candidates.length; listIndex++) {
+      final candidate = candidates[listIndex];
+      final candidateIndex =
+          candidate['index'] is int ? candidate['index'] as int : listIndex;
+      final content = toolObject(candidate['content']) ?? const {};
+      final parts = toolObjectList(content['parts']);
+
+      for (var partIndex = 0; partIndex < parts.length; partIndex++) {
+        final part = parts[partIndex];
+        _readTextPart(part, text, reasoning);
+        final function = toolObject(part['functionCall']);
+        if (function == null) continue;
+
+        final name = toolString(function['name']);
+        final arguments = function['args'];
+        final slot = 'candidate:$candidateIndex:part:$partIndex';
+        final directArguments = arguments is Map;
+        final call = _accumulator.add(
+          ToolCallDelta(
+            slot: slot,
+            id: _callId(function, candidateIndex, partIndex, name),
+            name: name,
+            argumentsFragment:
+                directArguments ? jsonEncode(arguments) : toolString(arguments),
+            isFinal: directArguments,
+          ),
+        );
+        if (call != null) completed.add(call);
+      }
+
+      finishReason ??= _optionalString(candidate['finishReason']);
+    }
+
+    if (finishReason != null) {
+      if (_accumulator.hasPendingCalls) {
+        completed.addAll(_accumulator.completeAll());
+      }
+      _finished = true;
+    }
+
+    return ToolStreamUpdate(
+      textDelta: text.toString(),
+      reasoningDelta: reasoning.toString(),
+      completedCalls: completed,
+      finishReason: finishReason,
+    );
+  }
+
+  @override
+  ToolStreamUpdate finish({bool cancelled = false, String? reason}) {
+    if (_finished) return ToolStreamUpdate();
+    _finished = true;
+    return ToolStreamUpdate(
+      completedCalls: cancelled
+          ? _accumulator.cancelAll(reason)
+          : _accumulator.completeAll(),
+      finishReason: cancelled ? 'cancelled' : null,
+    );
+  }
+}
+
+void _readTextPart(
+  Map<String, dynamic> part,
+  StringBuffer text,
+  StringBuffer reasoning,
+) {
+  final partText = toolString(part['text']);
+  final thought = part['thought'];
+  if (thought == true) {
+    reasoning.write(partText);
+  } else if (thought is String) {
+    reasoning.write(thought);
+  } else {
+    text.write(partText);
+  }
+}
+
+String _callId(
+  Map<String, dynamic> function,
+  int candidateIndex,
+  int partIndex,
+  String name,
+) {
+  return _optionalString(function['id']) ??
+      'gemini-$candidateIndex-$partIndex-$name';
+}
+
+String? _optionalString(Object? value) {
+  return value is String && value.isNotEmpty ? value : null;
+}

--- a/lib/domain/services/tool_calling/openai_tool_calling_adapter.dart
+++ b/lib/domain/services/tool_calling/openai_tool_calling_adapter.dart
@@ -1,0 +1,167 @@
+import 'dart:convert';
+
+import 'package:native_tavern/domain/models/tool_calling.dart';
+import 'package:native_tavern/domain/services/tool_calling/tool_calling_adapter.dart';
+
+final class OpenAiToolCallingAdapter implements ToolCallingAdapter {
+  const OpenAiToolCallingAdapter();
+
+  @override
+  Map<String, dynamic> decorateRequest(
+    Map<String, dynamic> baseRequest,
+    ToolCallingConfiguration configuration,
+  ) {
+    if (!configuration.enabled) return baseRequest;
+
+    return {
+      ...baseRequest,
+      'tools': [
+        for (final tool in configuration.tools)
+          {
+            'type': 'function',
+            'function': {
+              'name': tool.name,
+              'description': tool.description,
+              'parameters': tool.inputSchema,
+            },
+          },
+      ],
+      'tool_choice': switch (configuration.choice.mode) {
+        ToolChoiceMode.auto => 'auto',
+        ToolChoiceMode.none => 'none',
+        ToolChoiceMode.required => 'required',
+        ToolChoiceMode.named => {
+            'type': 'function',
+            'function': {'name': configuration.choice.toolName},
+          },
+      },
+    };
+  }
+
+  @override
+  ToolAssistantMessage parseResponse(Map<String, dynamic> response) {
+    final choices = toolObjectList(response['choices']);
+    if (choices.isEmpty) return ToolAssistantMessage();
+    final choice = choices.first;
+    final message = toolObject(choice['message']) ?? const {};
+    final accumulator = ToolCallStreamAccumulator();
+    final completed = <ToolCall>[];
+    final calls = toolObjectList(message['tool_calls']);
+
+    for (var index = 0; index < calls.length; index++) {
+      final call = calls[index];
+      final function = toolObject(call['function']) ?? const {};
+      final arguments = function['arguments'];
+      completed.add(
+        accumulator.add(
+          ToolCallDelta(
+            slot: 'response:$index',
+            id: toolString(call['id']),
+            name: toolString(function['name']),
+            argumentsFragment: arguments is String
+                ? arguments
+                : arguments == null
+                    ? ''
+                    : jsonEncode(arguments),
+            isFinal: true,
+          ),
+        )!,
+      );
+    }
+
+    return ToolAssistantMessage(
+      text: toolString(message['content']),
+      reasoning: _optionalString(message['reasoning_content']),
+      toolCalls: completed,
+      finishReason: _optionalString(choice['finish_reason']),
+    );
+  }
+
+  @override
+  ToolCallingStreamParser createStreamParser() => _OpenAiStreamParser();
+
+  @override
+  Map<String, dynamic> encodeResult(ToolResultMessage result) {
+    return {
+      'role': 'tool',
+      'tool_call_id': result.callId,
+      'content': toolOutputAsText(result.output),
+    };
+  }
+}
+
+final class _OpenAiStreamParser implements ToolCallingStreamParser {
+  final ToolCallStreamAccumulator _accumulator = ToolCallStreamAccumulator();
+  bool _finished = false;
+
+  @override
+  ToolStreamUpdate addChunk(Map<String, dynamic> chunk) {
+    if (_finished) {
+      throw const ToolProtocolException(
+        'stream_finished',
+        'The OpenAI tool stream has already finished.',
+      );
+    }
+
+    final text = StringBuffer();
+    final reasoning = StringBuffer();
+    final completed = <ToolCall>[];
+    String? finishReason;
+    final choices = toolObjectList(chunk['choices']);
+
+    for (var choiceIndex = 0; choiceIndex < choices.length; choiceIndex++) {
+      final choice = choices[choiceIndex];
+      final delta = toolObject(choice['delta']) ?? const {};
+      text.write(toolString(delta['content']));
+      reasoning.write(toolString(delta['reasoning_content']));
+
+      final calls = toolObjectList(delta['tool_calls']);
+      for (var listIndex = 0; listIndex < calls.length; listIndex++) {
+        final call = calls[listIndex];
+        final function = toolObject(call['function']) ?? const {};
+        final providerIndex =
+            call['index'] is int ? call['index'] as int : listIndex;
+        _accumulator.add(
+          ToolCallDelta(
+            slot: 'choice:$choiceIndex:call:$providerIndex',
+            id: _optionalString(call['id']),
+            name: _optionalString(function['name']),
+            argumentsFragment: toolString(function['arguments']),
+          ),
+        );
+      }
+
+      finishReason ??= _optionalString(choice['finish_reason']);
+    }
+
+    if (finishReason != null) {
+      if (_accumulator.hasPendingCalls) {
+        completed.addAll(_accumulator.completeAll());
+      }
+      _finished = true;
+    }
+
+    return ToolStreamUpdate(
+      textDelta: text.toString(),
+      reasoningDelta: reasoning.toString(),
+      completedCalls: completed,
+      finishReason: finishReason,
+    );
+  }
+
+  @override
+  ToolStreamUpdate finish({bool cancelled = false, String? reason}) {
+    if (_finished) return ToolStreamUpdate();
+    _finished = true;
+    return ToolStreamUpdate(
+      completedCalls: cancelled
+          ? _accumulator.cancelAll(reason)
+          : _accumulator.completeAll(),
+      finishReason: cancelled ? 'cancelled' : null,
+    );
+  }
+}
+
+String? _optionalString(Object? value) {
+  return value is String && value.isNotEmpty ? value : null;
+}

--- a/lib/domain/services/tool_calling/tool_calling_adapter.dart
+++ b/lib/domain/services/tool_calling/tool_calling_adapter.dart
@@ -1,0 +1,53 @@
+import 'dart:convert';
+
+import 'package:native_tavern/domain/models/tool_calling.dart';
+
+abstract interface class ToolCallingAdapter {
+  Map<String, dynamic> decorateRequest(
+    Map<String, dynamic> baseRequest,
+    ToolCallingConfiguration configuration,
+  );
+
+  ToolAssistantMessage parseResponse(Map<String, dynamic> response);
+
+  ToolCallingStreamParser createStreamParser();
+
+  Map<String, dynamic> encodeResult(ToolResultMessage result);
+}
+
+abstract interface class ToolCallingStreamParser {
+  ToolStreamUpdate addChunk(Map<String, dynamic> chunk);
+
+  ToolStreamUpdate finish({bool cancelled = false, String? reason});
+}
+
+String toolOutputAsText(Object? output) {
+  return output is String ? output : jsonEncode(output);
+}
+
+Map<String, dynamic> toolOutputAsObject(ToolResultMessage result) {
+  final output = result.output;
+  if (result.isError) {
+    return {'error': output};
+  }
+  if (output is Map<String, dynamic>) return output;
+  return {'result': output};
+}
+
+Map<String, dynamic>? toolObject(Object? value) {
+  if (value is Map<String, dynamic>) return value;
+  if (value is Map) {
+    return {
+      for (final entry in value.entries)
+        if (entry.key is String) entry.key as String: entry.value,
+    };
+  }
+  return null;
+}
+
+List<Map<String, dynamic>> toolObjectList(Object? value) {
+  if (value is! List) return const [];
+  return value.map(toolObject).whereType<Map<String, dynamic>>().toList();
+}
+
+String toolString(Object? value) => value is String ? value : '';

--- a/test/fixtures/tool_calling/claude_stream.json
+++ b/test/fixtures/tool_calling/claude_stream.json
@@ -1,0 +1,103 @@
+[
+  {
+    "type": "content_block_start",
+    "index": 0,
+    "content_block": {
+      "type": "thinking",
+      "thinking": ""
+    }
+  },
+  {
+    "type": "content_block_delta",
+    "index": 0,
+    "delta": {
+      "type": "thinking_delta",
+      "thinking": "Need both tools. "
+    }
+  },
+  {
+    "type": "content_block_stop",
+    "index": 0
+  },
+  {
+    "type": "content_block_start",
+    "index": 1,
+    "content_block": {
+      "type": "tool_use",
+      "id": "call_weather",
+      "name": "weather",
+      "input": {}
+    }
+  },
+  {
+    "type": "content_block_delta",
+    "index": 1,
+    "delta": {
+      "type": "input_json_delta",
+      "partial_json": "{\"city\":\"Sing"
+    }
+  },
+  {
+    "type": "content_block_delta",
+    "index": 1,
+    "delta": {
+      "type": "input_json_delta",
+      "partial_json": "apore\"}"
+    }
+  },
+  {
+    "type": "content_block_stop",
+    "index": 1
+  },
+  {
+    "type": "content_block_start",
+    "index": 2,
+    "content_block": {
+      "type": "tool_use",
+      "id": "call_time",
+      "name": "time",
+      "input": {}
+    }
+  },
+  {
+    "type": "content_block_delta",
+    "index": 2,
+    "delta": {
+      "type": "input_json_delta",
+      "partial_json": "{\"zone\":\"Asia/Singapore\"}"
+    }
+  },
+  {
+    "type": "content_block_stop",
+    "index": 2
+  },
+  {
+    "type": "content_block_start",
+    "index": 3,
+    "content_block": {
+      "type": "text",
+      "text": ""
+    }
+  },
+  {
+    "type": "content_block_delta",
+    "index": 3,
+    "delta": {
+      "type": "text_delta",
+      "text": "Checking now."
+    }
+  },
+  {
+    "type": "content_block_stop",
+    "index": 3
+  },
+  {
+    "type": "message_delta",
+    "delta": {
+      "stop_reason": "tool_use"
+    }
+  },
+  {
+    "type": "message_stop"
+  }
+]

--- a/test/fixtures/tool_calling/gemini_stream.json
+++ b/test/fixtures/tool_calling/gemini_stream.json
@@ -1,0 +1,52 @@
+[
+  {
+    "candidates": [
+      {
+        "index": 0,
+        "content": {
+          "role": "model",
+          "parts": [
+            {
+              "thought": true,
+              "text": "Need both tools. "
+            },
+            {
+              "text": "Checking now."
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "candidates": [
+      {
+        "index": 0,
+        "content": {
+          "role": "model",
+          "parts": [
+            {
+              "functionCall": {
+                "id": "call_weather",
+                "name": "weather",
+                "args": {
+                  "city": "Singapore"
+                }
+              }
+            },
+            {
+              "functionCall": {
+                "id": "call_time",
+                "name": "time",
+                "args": {
+                  "zone": "Asia/Singapore"
+                }
+              }
+            }
+          ]
+        },
+        "finishReason": "STOP"
+      }
+    ]
+  }
+]

--- a/test/fixtures/tool_calling/openai_malformed_stream.json
+++ b/test/fixtures/tool_calling/openai_malformed_stream.json
@@ -1,0 +1,32 @@
+[
+  {
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "tool_calls": [
+            {
+              "index": 0,
+              "id": "call_broken",
+              "type": "function",
+              "function": {
+                "name": "weather",
+                "arguments": "{\"city\":"
+              }
+            }
+          ]
+        },
+        "finish_reason": null
+      }
+    ]
+  },
+  {
+    "choices": [
+      {
+        "index": 0,
+        "delta": {},
+        "finish_reason": "tool_calls"
+      }
+    ]
+  }
+]

--- a/test/fixtures/tool_calling/openai_stream.json
+++ b/test/fixtures/tool_calling/openai_stream.json
@@ -1,0 +1,66 @@
+[
+  {
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "content": "Let me check. ",
+          "tool_calls": [
+            {
+              "index": 0,
+              "id": "call_weather",
+              "type": "function",
+              "function": {
+                "name": "weather",
+                "arguments": "{\"city\":\""
+              }
+            },
+            {
+              "index": 1,
+              "id": "call_time",
+              "type": "function",
+              "function": {
+                "name": "time",
+                "arguments": "{\"zone\":\""
+              }
+            }
+          ]
+        },
+        "finish_reason": null
+      }
+    ]
+  },
+  {
+    "choices": [
+      {
+        "index": 0,
+        "delta": {
+          "tool_calls": [
+            {
+              "index": 0,
+              "function": {
+                "arguments": "Singapore\"}"
+              }
+            },
+            {
+              "index": 1,
+              "function": {
+                "arguments": "Asia/Singapore\"}"
+              }
+            }
+          ]
+        },
+        "finish_reason": null
+      }
+    ]
+  },
+  {
+    "choices": [
+      {
+        "index": 0,
+        "delta": {},
+        "finish_reason": "tool_calls"
+      }
+    ]
+  }
+]

--- a/test/tool_calling_adapters_end_to_end_test.dart
+++ b/test/tool_calling_adapters_end_to_end_test.dart
@@ -1,0 +1,119 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:native_tavern/domain/models/tool_calling.dart';
+import 'package:native_tavern/domain/services/tool_calling/claude_tool_calling_adapter.dart';
+import 'package:native_tavern/domain/services/tool_calling/gemini_tool_calling_adapter.dart';
+import 'package:native_tavern/domain/services/tool_calling/openai_tool_calling_adapter.dart';
+import 'package:native_tavern/domain/services/tool_calling/tool_calling_adapter.dart';
+
+void main() {
+  test('all providers round-trip one request through calls and results', () {
+    final configuration = ToolCallingConfiguration.enabled(
+      tools: [
+        ToolDefinition(
+          name: 'weather',
+          description: 'Read weather for a city.',
+          inputSchema: const {
+            'type': 'object',
+            'properties': {
+              'city': {'type': 'string'},
+            },
+            'required': ['city'],
+          },
+        ),
+        ToolDefinition(
+          name: 'time',
+          description: 'Read time in a time zone.',
+          inputSchema: const {
+            'type': 'object',
+            'properties': {
+              'zone': {'type': 'string'},
+            },
+            'required': ['zone'],
+          },
+        ),
+      ],
+      choice: ToolChoice.required,
+    );
+    const cases = [
+      (
+        adapter: OpenAiToolCallingAdapter() as ToolCallingAdapter,
+        fixture: 'test/fixtures/tool_calling/openai_stream.json',
+      ),
+      (
+        adapter: ClaudeToolCallingAdapter() as ToolCallingAdapter,
+        fixture: 'test/fixtures/tool_calling/claude_stream.json',
+      ),
+      (
+        adapter: GeminiToolCallingAdapter() as ToolCallingAdapter,
+        fixture: 'test/fixtures/tool_calling/gemini_stream.json',
+      ),
+    ];
+
+    for (final testCase in cases) {
+      final request = testCase.adapter.decorateRequest(
+        {
+          'model': 'fixture-model',
+          'messages': const [
+            {'role': 'user', 'content': 'Weather and time in Singapore?'},
+          ],
+        },
+        configuration,
+      );
+      final parser = testCase.adapter.createStreamParser();
+      final calls = <ToolCall>[];
+      for (final chunk in _fixture(testCase.fixture)) {
+        calls.addAll(parser.addChunk(chunk).completedCalls);
+      }
+      calls.addAll(parser.finish().completedCalls);
+
+      expect(request, contains('tools'));
+      expect(calls.map((call) => call.name), ['weather', 'time']);
+      expect(
+          calls.every((call) => call.status == ToolCallStatus.ready), isTrue);
+      expect(calls[0].arguments, {'city': 'Singapore'});
+      expect(calls[1].arguments, {'zone': 'Asia/Singapore'});
+
+      for (final call in calls) {
+        final encoded = testCase.adapter.encodeResult(ToolResultMessage(
+          callId: call.id,
+          toolName: call.name,
+          output: {'ok': true, 'tool': call.name},
+        ));
+        final wireJson = jsonEncode(encoded);
+        expect(wireJson, contains(call.id));
+        expect(wireJson, contains(call.name));
+      }
+    }
+  });
+
+  test('cancelling a partial stream produces cancelled calls only', () {
+    const adapter = OpenAiToolCallingAdapter();
+    final parser = adapter.createStreamParser();
+    final firstChunk = _fixture(
+      'test/fixtures/tool_calling/openai_stream.json',
+    ).first;
+
+    expect(parser.addChunk(firstChunk).completedCalls, isEmpty);
+    final cancelled = parser.finish(
+      cancelled: true,
+      reason: 'user stopped generation',
+    );
+
+    expect(cancelled.finishReason, 'cancelled');
+    expect(cancelled.completedCalls, hasLength(2));
+    expect(
+      cancelled.completedCalls.every(
+        (call) => call.status == ToolCallStatus.cancelled,
+      ),
+      isTrue,
+    );
+  });
+}
+
+List<Map<String, dynamic>> _fixture(String path) {
+  final decoded = jsonDecode(File(path).readAsStringSync()) as List<dynamic>;
+  return decoded.cast<Map<String, dynamic>>();
+}

--- a/test/tool_calling_adapters_test.dart
+++ b/test/tool_calling_adapters_test.dart
@@ -1,0 +1,291 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:native_tavern/domain/models/tool_calling.dart';
+import 'package:native_tavern/domain/services/tool_calling/claude_tool_calling_adapter.dart';
+import 'package:native_tavern/domain/services/tool_calling/gemini_tool_calling_adapter.dart';
+import 'package:native_tavern/domain/services/tool_calling/openai_tool_calling_adapter.dart';
+import 'package:native_tavern/domain/services/tool_calling/tool_calling_adapter.dart';
+
+void main() {
+  final tools = _tools();
+  final enabled = ToolCallingConfiguration.enabled(
+    tools: tools,
+    choice: ToolChoice.named('weather'),
+  );
+
+  group('request mapping', () {
+    test('disabled tools preserve the exact ordinary request object', () {
+      final baseline = <String, dynamic>{
+        'model': 'baseline-model',
+        'messages': const [
+          {'role': 'user', 'content': 'Hello'},
+        ],
+      };
+      const adapters = <ToolCallingAdapter>[
+        OpenAiToolCallingAdapter(),
+        ClaudeToolCallingAdapter(),
+        GeminiToolCallingAdapter(),
+      ];
+
+      for (final adapter in adapters) {
+        final result = adapter.decorateRequest(
+          baseline,
+          const ToolCallingConfiguration.disabled(),
+        );
+        expect(identical(result, baseline), isTrue);
+        expect(result, baseline);
+      }
+    });
+
+    test('maps definitions and named choices to native request fields', () {
+      final openAi = const OpenAiToolCallingAdapter().decorateRequest(
+        {'model': 'gpt'},
+        enabled,
+      );
+      final claude = const ClaudeToolCallingAdapter().decorateRequest(
+        {'model': 'claude'},
+        enabled,
+      );
+      final gemini = const GeminiToolCallingAdapter().decorateRequest(
+        {'model': 'gemini'},
+        enabled,
+      );
+
+      expect((openAi['tools'] as List), hasLength(2));
+      expect(
+        ((openAi['tool_choice'] as Map)['function'] as Map)['name'],
+        'weather',
+      );
+      expect((claude['tools'] as List).first, contains('input_schema'));
+      expect((claude['tool_choice'] as Map)['type'], 'tool');
+      final geminiConfig = (gemini['toolConfig']
+          as Map)['functionCallingConfig'] as Map<String, dynamic>;
+      expect(geminiConfig['mode'], 'ANY');
+      expect(geminiConfig['allowedFunctionNames'], ['weather']);
+    });
+  });
+
+  group('OpenAI-compatible adapter', () {
+    test('parses non-streaming calls and encodes associated results', () {
+      const adapter = OpenAiToolCallingAdapter();
+      final message = adapter.parseResponse({
+        'choices': [
+          {
+            'message': {
+              'content': null,
+              'tool_calls': [
+                {
+                  'id': 'call_weather',
+                  'type': 'function',
+                  'function': {
+                    'name': 'weather',
+                    'arguments': '{"city":"Singapore"}',
+                  },
+                },
+              ],
+            },
+            'finish_reason': 'tool_calls',
+          },
+        ],
+      });
+
+      expect(message.toolCalls.single.arguments['city'], 'Singapore');
+      expect(message.finishReason, 'tool_calls');
+      expect(
+        adapter.encodeResult(ToolResultMessage(
+          callId: message.toolCalls.single.id,
+          toolName: 'weather',
+          output: const {'temperature': 30},
+        )),
+        {
+          'role': 'tool',
+          'tool_call_id': 'call_weather',
+          'content': '{"temperature":30}',
+        },
+      );
+    });
+
+    test('fixture accumulates parallel fragments and flags malformed JSON', () {
+      const adapter = OpenAiToolCallingAdapter();
+      final calls = _parseFixture(
+        adapter,
+        'test/fixtures/tool_calling/openai_stream.json',
+      );
+      final malformed = _parseFixture(
+        adapter,
+        'test/fixtures/tool_calling/openai_malformed_stream.json',
+      );
+
+      expect(calls, hasLength(2));
+      expect(calls[0].arguments, {'city': 'Singapore'});
+      expect(calls[1].arguments, {'zone': 'Asia/Singapore'});
+      expect(malformed.single.status, ToolCallStatus.invalidArguments);
+    });
+
+    test('a text-only finish closes its request-scoped parser', () {
+      final parser = const OpenAiToolCallingAdapter().createStreamParser();
+      final update = parser.addChunk({
+        'choices': [
+          {
+            'delta': {'content': 'Done'},
+            'finish_reason': 'stop',
+          },
+        ],
+      });
+
+      expect(update.textDelta, 'Done');
+      expect(update.finishReason, 'stop');
+      expect(
+        () => parser.addChunk(const <String, dynamic>{
+          'choices': <dynamic>[],
+        }),
+        throwsA(isA<ToolProtocolException>()),
+      );
+    });
+  });
+
+  group('Claude adapter', () {
+    test('maps text, thinking, tool_use, and tool_result blocks', () {
+      const adapter = ClaudeToolCallingAdapter();
+      final message = adapter.parseResponse({
+        'content': [
+          {'type': 'thinking', 'thinking': 'Need weather.'},
+          {
+            'type': 'tool_use',
+            'id': 'call_weather',
+            'name': 'weather',
+            'input': {'city': 'Singapore'},
+          },
+          {'type': 'text', 'text': 'Checking.'},
+        ],
+        'stop_reason': 'tool_use',
+      });
+
+      expect(message.reasoning, 'Need weather.');
+      expect(message.text, 'Checking.');
+      expect(message.toolCalls.single.arguments['city'], 'Singapore');
+      final result = adapter.encodeResult(ToolResultMessage(
+        callId: 'call_weather',
+        toolName: 'weather',
+        output: 'service unavailable',
+        status: ToolResultStatus.failed,
+      ));
+      final block = (result['content'] as List).single as Map;
+      expect(block['tool_use_id'], 'call_weather');
+      expect(block['is_error'], isTrue);
+    });
+
+    test('fixture preserves interleaved thinking, text, and tool blocks', () {
+      const adapter = ClaudeToolCallingAdapter();
+      final parser = adapter.createStreamParser();
+      final calls = <ToolCall>[];
+      final text = StringBuffer();
+      final reasoning = StringBuffer();
+      for (final chunk in _fixture(
+        'test/fixtures/tool_calling/claude_stream.json',
+      )) {
+        final update = parser.addChunk(chunk);
+        calls.addAll(update.completedCalls);
+        text.write(update.textDelta);
+        reasoning.write(update.reasoningDelta);
+      }
+
+      expect(text.toString(), 'Checking now.');
+      expect(reasoning.toString(), 'Need both tools. ');
+      expect(calls.map((call) => call.name), ['weather', 'time']);
+      expect(calls[0].arguments['city'], 'Singapore');
+    });
+  });
+
+  group('Gemini adapter', () {
+    test('maps functionCall and functionResponse parts', () {
+      const adapter = GeminiToolCallingAdapter();
+      final message = adapter.parseResponse({
+        'candidates': [
+          {
+            'content': {
+              'parts': [
+                {'thought': true, 'text': 'Need weather.'},
+                {
+                  'functionCall': {
+                    'id': 'call_weather',
+                    'name': 'weather',
+                    'args': {'city': 'Singapore'},
+                  },
+                },
+              ],
+            },
+            'finishReason': 'STOP',
+          },
+        ],
+      });
+
+      expect(message.reasoning, 'Need weather.');
+      expect(message.toolCalls.single.id, 'call_weather');
+      final result = adapter.encodeResult(ToolResultMessage(
+        callId: 'call_weather',
+        toolName: 'weather',
+        output: const {'temperature': 30},
+      ));
+      final part = (result['parts'] as List).single as Map;
+      final response = part['functionResponse'] as Map;
+      expect(response['id'], 'call_weather');
+      expect(response['response'], {'temperature': 30});
+    });
+
+    test('fixture emits structured parallel calls without shared state', () {
+      const adapter = GeminiToolCallingAdapter();
+      final calls = _parseFixture(
+        adapter,
+        'test/fixtures/tool_calling/gemini_stream.json',
+      );
+
+      expect(calls.map((call) => call.id), ['call_weather', 'call_time']);
+      expect(calls[1].arguments['zone'], 'Asia/Singapore');
+    });
+  });
+}
+
+List<ToolDefinition> _tools() {
+  return [
+    ToolDefinition(
+      name: 'weather',
+      description: 'Read weather for a city.',
+      inputSchema: const {
+        'type': 'object',
+        'properties': {
+          'city': {'type': 'string'},
+        },
+        'required': ['city'],
+      },
+    ),
+    ToolDefinition(
+      name: 'time',
+      description: 'Read time in a time zone.',
+      inputSchema: const {
+        'type': 'object',
+        'properties': {
+          'zone': {'type': 'string'},
+        },
+        'required': ['zone'],
+      },
+    ),
+  ];
+}
+
+List<ToolCall> _parseFixture(ToolCallingAdapter adapter, String path) {
+  final parser = adapter.createStreamParser();
+  final calls = <ToolCall>[];
+  for (final chunk in _fixture(path)) {
+    calls.addAll(parser.addChunk(chunk).completedCalls);
+  }
+  calls.addAll(parser.finish().completedCalls);
+  return calls;
+}
+
+List<Map<String, dynamic>> _fixture(String path) {
+  final decoded = jsonDecode(File(path).readAsStringSync()) as List<dynamic>;
+  return decoded.cast<Map<String, dynamic>>();
+}

--- a/test/tool_calling_domain_test.dart
+++ b/test/tool_calling_domain_test.dart
@@ -1,0 +1,152 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:native_tavern/domain/models/tool_calling.dart';
+
+void main() {
+  group('ToolDefinition and configuration', () {
+    test('validates schemas, names, choices, and recursion limits', () {
+      final weather = _weatherTool();
+      final configuration = ToolCallingConfiguration.enabled(
+        tools: [weather],
+        choice: ToolChoice.named('weather'),
+        maxRecursionDepth: 3,
+      );
+
+      expect(configuration.enabled, isTrue);
+      expect(configuration.choice.toolName, 'weather');
+      expect(configuration.maxRecursionDepth, 3);
+      expect(
+        () => ToolDefinition(
+          name: 'bad name',
+          description: 'Invalid',
+          inputSchema: const {'type': 'object'},
+        ),
+        _protocolError('invalid_tool_name'),
+      );
+      expect(
+        () => ToolCallingConfiguration.enabled(
+          tools: [weather, weather],
+        ),
+        _protocolError('duplicate_tool_name'),
+      );
+      expect(
+        () => ToolCallingConfiguration.enabled(
+          tools: [weather],
+          choice: ToolChoice.named('missing'),
+        ),
+        _protocolError('unknown_tool_choice'),
+      );
+    });
+  });
+
+  group('ToolCallStreamAccumulator', () {
+    test('accumulates fragmented parallel calls without crossing slots', () {
+      final accumulator = ToolCallStreamAccumulator();
+      accumulator.add(const ToolCallDelta(
+        slot: '0',
+        id: 'call_weather',
+        name: 'weather',
+        argumentsFragment: '{"city":"',
+      ));
+      accumulator.add(const ToolCallDelta(
+        slot: '1',
+        id: 'call_time',
+        name: 'time',
+        argumentsFragment: '{"zone":"',
+      ));
+      accumulator.add(const ToolCallDelta(
+        slot: '0',
+        argumentsFragment: 'Singapore"}',
+      ));
+      accumulator.add(const ToolCallDelta(
+        slot: '1',
+        argumentsFragment: 'Asia/Singapore"}',
+      ));
+
+      final calls = accumulator.completeAll();
+
+      expect(calls, hasLength(2));
+      expect(calls[0].arguments, {'city': 'Singapore'});
+      expect(calls[1].arguments, {'zone': 'Asia/Singapore'});
+      expect(
+          calls.every((call) => call.status == ToolCallStatus.ready), isTrue);
+    });
+
+    test('preserves malformed JSON as an explicit invalid call', () {
+      final accumulator = ToolCallStreamAccumulator();
+      final call = accumulator.add(const ToolCallDelta(
+        slot: '0',
+        id: 'call_broken',
+        name: 'weather',
+        argumentsFragment: '{"city":',
+        isFinal: true,
+      ));
+
+      expect(call?.status, ToolCallStatus.invalidArguments);
+      expect(call?.rawArguments, '{"city":');
+      expect(call?.error, isNotEmpty);
+    });
+
+    test('rejects duplicate IDs across parallel stream slots', () {
+      final accumulator = ToolCallStreamAccumulator();
+      accumulator.add(const ToolCallDelta(
+        slot: '0',
+        id: 'duplicate',
+        name: 'weather',
+      ));
+
+      expect(
+        () => accumulator.add(const ToolCallDelta(
+          slot: '1',
+          id: 'duplicate',
+          name: 'time',
+        )),
+        _protocolError('duplicate_call_id'),
+      );
+    });
+  });
+
+  test('recursion contexts honor cancellation and depth limits', () {
+    final controller = ToolCancellationController();
+    var cancellationReason = '';
+    controller.token.whenCancelled((reason) {
+      cancellationReason = reason.toString();
+    });
+    final root = ToolInvocationContext(
+      maxDepth: 2,
+      cancellationToken: controller.token,
+    );
+    final depthTwo = root.next().next();
+
+    expect(depthTwo.depth, 2);
+    expect(() => depthTwo.next(), _protocolError('recursion_limit'));
+
+    controller.cancel('user stopped');
+    expect(cancellationReason, 'user stopped');
+    expect(controller.token.isCancelled, isTrue);
+    expect(() => root.next(), _protocolError('cancelled'));
+  });
+}
+
+ToolDefinition _weatherTool() {
+  return ToolDefinition(
+    name: 'weather',
+    description: 'Read the weather for a city.',
+    inputSchema: const {
+      'type': 'object',
+      'properties': {
+        'city': {'type': 'string'},
+      },
+      'required': ['city'],
+    },
+  );
+}
+
+Matcher _protocolError(String code) {
+  return throwsA(
+    isA<ToolProtocolException>().having(
+      (error) => error.code,
+      'code',
+      code,
+    ),
+  );
+}


### PR DESCRIPTION
## 完成内容

- G01 通用工具协议：新增工具定义与 JSON Schema、选择策略、调用/结果消息、显式状态、递归深度与取消令牌；流式累积器支持参数分片、并行调用、重复 ID 拒绝、畸形 JSON 状态和结果关联。
- G02 OpenAI-compatible 适配：支持 tools、tool_choice、普通及流式 tool_calls，并编码 role=tool 的关联结果消息。
- G03 Claude 适配：支持 tools/input_schema、tool_choice、tool_use/tool_result，以及 thinking、text、input_json_delta 交错流。
- G04 Gemini 适配：支持 functionDeclarations、functionCallingConfig、functionCall/functionResponse parts 与结构化流式响应。
- 三个 Provider 适配器均在独立文件中维护请求级解析状态；当前聊天生成循环未改动，工具关闭时返回原始普通请求对象，网络 payload 保持兼容。

## 测试

- flutter test --no-pub test/tool_calling_domain_test.dart test/tool_calling_adapters_test.dart test/tool_calling_adapters_end_to_end_test.dart（16/16 通过）
- flutter test --no-pub（204/204 通过，基于最新 main）
- flutter analyze --no-pub --no-fatal-infos --no-fatal-warnings（无 error；仓库既有 1175 条 warning/info）
- 新增文件定向 analyze：零问题
- git diff --check

Closes #32