### PR TITLE
[B02/B03] Add persistent long-term memory FTS retrieval

### DIFF
--- a/lib/data/database/database.dart
+++ b/lib/data/database/database.dart
@@ -670,7 +670,107 @@ class AppDatabase extends _$AppDatabase {
       },
       beforeOpen: (details) async {
         await customStatement('PRAGMA foreign_keys = ON');
+        final searchIndexCreated = await _ensureLongTermMemorySearchIndex();
+        if (searchIndexCreated) {
+          await _rebuildLongTermMemorySearchIndex();
+        }
       },
+    );
+  }
+
+  /// Recreates the derived long-term-memory FTS index from its content table.
+  Future<void> rebuildLongTermMemorySearchIndex() async {
+    await _ensureLongTermMemorySearchIndex();
+    await _rebuildLongTermMemorySearchIndex();
+  }
+
+  Future<bool> _ensureLongTermMemorySearchIndex() async {
+    final existing = await customSelect(
+      'SELECT 1 AS found FROM sqlite_master '
+      "WHERE type = 'table' AND name = 'long_term_memories_fts'",
+    ).getSingleOrNull();
+    final created = existing == null;
+
+    await customStatement('''
+      CREATE VIRTUAL TABLE IF NOT EXISTS long_term_memories_fts USING fts5(
+        id UNINDEXED,
+        content,
+        normalized_identity_key,
+        content = 'long_term_memories',
+        content_rowid = 'rowid',
+        tokenize = 'unicode61 remove_diacritics 2'
+      )
+    ''');
+    await _createLongTermMemorySearchTriggers();
+    return created;
+  }
+
+  Future<void> _createLongTermMemorySearchTriggers() async {
+    const statements = [
+      '''
+        CREATE TRIGGER IF NOT EXISTS long_term_memory_fts_insert
+        AFTER INSERT ON long_term_memories
+        BEGIN
+          INSERT INTO long_term_memories_fts(
+            rowid, id, content, normalized_identity_key
+          ) VALUES (
+            NEW.rowid, NEW.id, NEW.content, NEW.normalized_identity_key
+          );
+        END
+      ''',
+      '''
+        CREATE TRIGGER IF NOT EXISTS long_term_memory_fts_delete
+        AFTER DELETE ON long_term_memories
+        BEGIN
+          INSERT INTO long_term_memories_fts(
+            long_term_memories_fts,
+            rowid,
+            id,
+            content,
+            normalized_identity_key
+          ) VALUES (
+            'delete',
+            OLD.rowid,
+            OLD.id,
+            OLD.content,
+            OLD.normalized_identity_key
+          );
+        END
+      ''',
+      '''
+        CREATE TRIGGER IF NOT EXISTS long_term_memory_fts_update
+        AFTER UPDATE OF content, normalized_identity_key ON long_term_memories
+        BEGIN
+          INSERT INTO long_term_memories_fts(
+            long_term_memories_fts,
+            rowid,
+            id,
+            content,
+            normalized_identity_key
+          ) VALUES (
+            'delete',
+            OLD.rowid,
+            OLD.id,
+            OLD.content,
+            OLD.normalized_identity_key
+          );
+          INSERT INTO long_term_memories_fts(
+            rowid, id, content, normalized_identity_key
+          ) VALUES (
+            NEW.rowid, NEW.id, NEW.content, NEW.normalized_identity_key
+          );
+        END
+      ''',
+    ];
+    for (final statement in statements) {
+      await customStatement(statement);
+    }
+  }
+
+  Future<void> _rebuildLongTermMemorySearchIndex() {
+    return customStatement(
+      'INSERT INTO long_term_memories_fts(long_term_memories_fts) '
+      "VALUES ('rebuild')",
     );
   }
 

--- a/lib/data/repositories/drift_long_term_memory_repository.dart
+++ b/lib/data/repositories/drift_long_term_memory_repository.dart
@@ -104,6 +104,103 @@ class DriftLongTermMemoryRepository implements LongTermMemoryRepository {
   }
 
   @override
+  Future<List<LongTermMemorySearchResult>> search(
+    String query, {
+    required MemoryScope scope,
+    int topK = 20,
+    Set<MemoryState> states = const <MemoryState>{MemoryState.active},
+    bool includeExpired = false,
+    DateTime? at,
+  }) async {
+    if (topK <= 0) {
+      throw RangeError.range(topK, 1, null, 'topK');
+    }
+    final matchQuery = _plainTextFtsQuery(query);
+    if (matchQuery == null) return const [];
+
+    final conditions = <String>[
+      'long_term_memories_fts MATCH ?',
+      'm.scope_kind = ?',
+    ];
+    final variables = <Variable<Object>>[
+      Variable<String>(matchQuery),
+      Variable<String>(scope.kind.name),
+    ];
+    switch (scope.kind) {
+      case MemoryScopeKind.character:
+        conditions.add('m.character_id = ?');
+        variables.add(Variable<String>(scope.characterId!));
+      case MemoryScopeKind.characterPersona:
+        conditions.add('m.character_id = ?');
+        conditions.add('m.persona_id = ?');
+        variables.add(Variable<String>(scope.characterId!));
+        variables.add(Variable<String>(scope.personaId!));
+      case MemoryScopeKind.chat:
+        conditions.add('m.chat_id = ?');
+        variables.add(Variable<String>(scope.chatId!));
+      case MemoryScopeKind.group:
+        conditions.add('m.group_id = ?');
+        variables.add(Variable<String>(scope.groupId!));
+    }
+
+    if (states.isNotEmpty) {
+      final orderedStates = states.toList()
+        ..sort((left, right) => left.index.compareTo(right.index));
+      conditions.add(
+        'm.state IN (${List.filled(orderedStates.length, '?').join(', ')})',
+      );
+      variables.addAll(
+        orderedStates.map((state) => Variable<String>(state.name)),
+      );
+    }
+    if (!includeExpired) {
+      conditions.add('(m.expires_at IS NULL OR m.expires_at > ?)');
+      variables.add(Variable<DateTime>((at ?? _now()).toUtc()));
+    }
+    variables.add(Variable<int>(topK));
+
+    final rows = await _database
+        .customSelect(
+          '''
+        SELECT m.id AS memory_id, bm25(long_term_memories_fts) AS rank
+        FROM long_term_memories_fts
+        JOIN long_term_memories AS m
+          ON m.rowid = long_term_memories_fts.rowid
+        WHERE ${conditions.join(' AND ')}
+        ORDER BY bm25(long_term_memories_fts) ASC,
+                 m.importance DESC,
+                 m.updated_at DESC,
+                 m.id ASC
+        LIMIT ?
+      ''',
+          variables: variables,
+          readsFrom: {_database.longTermMemories},
+        )
+        .get();
+
+    final results = <LongTermMemorySearchResult>[];
+    for (final row in rows) {
+      final memoryId = row.read<String>('memory_id');
+      final memory = await getById(memoryId);
+      if (memory == null) {
+        throw StateError('FTS index references missing memory $memoryId.');
+      }
+      results.add(
+        LongTermMemorySearchResult(
+          memory: memory,
+          rank: row.read<double>('rank'),
+        ),
+      );
+    }
+    return results;
+  }
+
+  @override
+  Future<void> rebuildSearchIndex() {
+    return _database.rebuildLongTermMemorySearchIndex();
+  }
+
+  @override
   Future<void> updateStates({
     required Set<String> memoryIds,
     required MemoryState state,
@@ -242,6 +339,15 @@ class DriftLongTermMemoryRepository implements LongTermMemoryRepository {
       throw StateError('Memory $id does not exist.');
     }
   }
+}
+
+String? _plainTextFtsQuery(String input) {
+  final tokens = RegExp(
+    r'[\p{L}\p{N}]+',
+    unicode: true,
+  ).allMatches(input).map((match) => match.group(0)!).toList();
+  if (tokens.isEmpty) return null;
+  return tokens.map((token) => '"$token"*').join(' AND ');
 }
 
 T _enumByName<T extends Enum>(Iterable<T> values, String name) {

--- a/lib/domain/repositories/long_term_memory_repository.dart
+++ b/lib/domain/repositories/long_term_memory_repository.dart
@@ -1,5 +1,16 @@
 import 'package:native_tavern/data/models/long_term_memory.dart';
 
+/// One full-text match. Lower [rank] values are more relevant BM25 scores.
+final class LongTermMemorySearchResult {
+  const LongTermMemorySearchResult({
+    required this.memory,
+    required this.rank,
+  });
+
+  final LongTermMemory memory;
+  final double rank;
+}
+
 /// Storage-independent operations required by the long-term memory feature.
 abstract interface class LongTermMemoryRepository {
   Future<LongTermMemory?> getById(String id);
@@ -23,6 +34,22 @@ abstract interface class LongTermMemoryRepository {
     required String chatId,
     String? messageId,
   });
+
+  /// Finds the most relevant memories in one exact owner scope.
+  ///
+  /// User input is treated as plain text rather than FTS query syntax. By
+  /// default, only active memories that have not expired are returned.
+  Future<List<LongTermMemorySearchResult>> search(
+    String query, {
+    required MemoryScope scope,
+    int topK = 20,
+    Set<MemoryState> states = const <MemoryState>{MemoryState.active},
+    bool includeExpired = false,
+    DateTime? at,
+  });
+
+  /// Recreates the derived full-text index from canonical memory records.
+  Future<void> rebuildSearchIndex();
 
   /// Applies one lifecycle state to a group of records atomically.
   ///

--- a/test/centralized_persistence_end_to_end_test.dart
+++ b/test/centralized_persistence_end_to_end_test.dart
@@ -63,6 +63,15 @@ void main() {
       ),
       [memory],
     );
+    final searchResults = await repository.search(
+      'station',
+      scope: memory.scope,
+    );
+    expect(searchResults.map((result) => result.memory), [memory]);
+    expect(
+      searchResults.single.memory.source.sourceMessageIds,
+      ['message-1', 'message-2'],
+    );
 
     final replacement = LongTermMemory(
       id: 'memory-2',

--- a/test/database_migration_harness_test.dart
+++ b/test/database_migration_harness_test.dart
@@ -1,4 +1,8 @@
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
+import 'package:native_tavern/data/models/long_term_memory.dart';
+import 'package:native_tavern/data/repositories/drift_long_term_memory_repository.dart';
 import 'package:native_tavern/domain/services/database_backup_service.dart';
 
 import 'support/database_migration_harness.dart';
@@ -132,6 +136,29 @@ void main() {
     database = harness.openWithProductionMigrations(file);
     expect(await readSchemaVersion(database), 15);
     expect(await runIntegrityCheck(database), 'ok');
+  });
+
+  test('existing v15 data gains a rebuilt derived memory search index',
+      () async {
+    final file = File('${harness.directory.path}/derived_fts.sqlite');
+    var database = harness.openWithProductionMigrations(file);
+    await seedCurrentRepresentativeData(database);
+    await database.customStatement('DROP TABLE long_term_memories_fts');
+    await harness.close(database);
+
+    database = harness.openWithProductionMigrations(file);
+    final repository = DriftLongTermMemoryRepository(database);
+    final matches = await repository.search(
+      'representative',
+      scope: MemoryScope.characterPersona(
+        characterId: 'character-1',
+        personaId: 'persona-1',
+      ),
+    );
+
+    expect(await readSchemaVersion(database), 15);
+    expect(matches.map((result) => result.memory.id), ['memory-1']);
+    expect(matches.single.memory.source.sourceMessageIds, ['message-1']);
   });
 
   test('failed v15 migration rolls back every new table', () async {

--- a/test/long_term_memory_contract_test.dart
+++ b/test/long_term_memory_contract_test.dart
@@ -357,6 +357,20 @@ class _MemoryRepositoryStub implements LongTermMemoryRepository {
       const [];
 
   @override
+  Future<void> rebuildSearchIndex() async {}
+
+  @override
+  Future<List<LongTermMemorySearchResult>> search(
+    String query, {
+    required MemoryScope scope,
+    int topK = 20,
+    Set<MemoryState> states = const <MemoryState>{MemoryState.active},
+    bool includeExpired = false,
+    DateTime? at,
+  }) async =>
+      const [];
+
+  @override
   Future<LongTermMemory?> getById(String id) async => null;
 
   @override

--- a/test/long_term_memory_end_to_end_test.dart
+++ b/test/long_term_memory_end_to_end_test.dart
@@ -185,6 +185,20 @@ class _JsonMemoryRepository implements LongTermMemoryRepository {
   }
 
   @override
+  Future<void> rebuildSearchIndex() async {}
+
+  @override
+  Future<List<LongTermMemorySearchResult>> search(
+    String query, {
+    required MemoryScope scope,
+    int topK = 20,
+    Set<MemoryState> states = const <MemoryState>{MemoryState.active},
+    bool includeExpired = false,
+    DateTime? at,
+  }) async =>
+      const [];
+
+  @override
   Future<LongTermMemory?> getById(String id) async => _read(id);
 
   @override

--- a/test/long_term_memory_fts_repository_test.dart
+++ b/test/long_term_memory_fts_repository_test.dart
@@ -1,0 +1,419 @@
+import 'package:drift/drift.dart' hide isNull;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:native_tavern/data/database/database.dart';
+import 'package:native_tavern/data/models/long_term_memory.dart';
+import 'package:native_tavern/data/repositories/drift_long_term_memory_repository.dart';
+
+void main() {
+  final now = DateTime.utc(2026, 8, 8, 12);
+  late AppDatabase database;
+  late DriftLongTermMemoryRepository repository;
+
+  setUp(() async {
+    database = AppDatabase.forTesting(NativeDatabase.memory());
+    await database.customSelect('SELECT 1').get();
+    await _seedOwners(database);
+    repository = DriftLongTermMemoryRepository(database, now: () => now);
+  });
+
+  tearDown(() => database.close());
+
+  test('CRUD keeps FTS synchronized and returns complete provenance', () async {
+    final original = _memory(
+      id: 'memory-crud',
+      scope: MemoryScope.characterPersona(
+        characterId: 'character-1',
+        personaId: 'persona-1',
+      ),
+      content: 'Meet at the station.',
+      normalizedIdentityKey: 'commitment:railway',
+      source: MemorySource.generated(
+        sourceChatId: 'chat-1',
+        sourceMessageIds: const ['message-1', 'message-2'],
+        extractedAt: now.subtract(const Duration(minutes: 1)),
+        providerId: 'provider-1',
+        modelId: 'model-1',
+      ),
+    );
+
+    await repository.create(original);
+    var matches = await repository.search('station', scope: original.scope);
+    expect(matches.map((result) => result.memory), [original]);
+    expect(
+      matches.single.memory.source.sourceMessageIds,
+      ['message-1', 'message-2'],
+    );
+    expect(
+      (await repository.search('rail', scope: original.scope)).single.memory.id,
+      original.id,
+    );
+
+    final updated = original.copyWith(
+      content: 'Meet at the library.',
+      updatedAt: now.add(const Duration(minutes: 1)),
+      locked: true,
+    );
+    await repository.update(updated);
+    expect(await repository.search('station', scope: original.scope), isEmpty);
+    matches = await repository.search('library', scope: original.scope);
+    expect(matches.single.memory, updated);
+    expect(matches.single.memory.locked, isTrue);
+
+    await repository.updateStates(
+      memoryIds: {original.id},
+      state: MemoryState.forgotten,
+    );
+    expect(await repository.search('library', scope: original.scope), isEmpty);
+    await repository.updateStates(
+      memoryIds: {original.id},
+      state: MemoryState.active,
+    );
+    expect(
+      (await repository.search('library', scope: original.scope))
+          .single
+          .memory
+          .state,
+      MemoryState.active,
+    );
+
+    await repository.delete(original.id);
+    expect(await repository.search('library', scope: original.scope), isEmpty);
+  });
+
+  test('plain-text normalization contains FTS operators and invalid limits',
+      () async {
+    final scope = MemoryScope.character('character-1');
+    await repository.create(
+      _memory(
+        id: 'memory-normalized-query',
+        scope: scope,
+        content: 'station secret',
+      ),
+    );
+
+    expect(
+      await repository.search('station OR absent', scope: scope),
+      isEmpty,
+    );
+    expect(await repository.search('" ) ( *', scope: scope), isEmpty);
+    await expectLater(
+      repository.search('station', scope: scope, topK: 0),
+      throwsRangeError,
+    );
+  });
+
+  test('scope, lifecycle, and expiry filters prevent incorrect recall',
+      () async {
+    final scopes = <MemoryScope>[
+      MemoryScope.character('character-1'),
+      MemoryScope.characterPersona(
+        characterId: 'character-1',
+        personaId: 'persona-1',
+      ),
+      MemoryScope.chat('chat-1'),
+      MemoryScope.group('group-1'),
+    ];
+    for (final (index, scope) in scopes.indexed) {
+      await repository.create(
+        _memory(
+          id: 'scope-$index',
+          scope: scope,
+          content: 'scope sentinel',
+        ),
+      );
+    }
+
+    for (final (index, scope) in scopes.indexed) {
+      final matches = await repository.search('sentinel', scope: scope);
+      expect(matches.map((result) => result.memory.id), ['scope-$index']);
+    }
+
+    final characterScope = scopes.first;
+    await repository.create(
+      _memory(
+        id: 'candidate',
+        scope: characterScope,
+        content: 'lifecycle sentinel',
+        state: MemoryState.candidate,
+      ),
+    );
+    await repository.create(
+      _memory(
+        id: 'forgotten',
+        scope: characterScope,
+        content: 'lifecycle sentinel',
+        state: MemoryState.forgotten,
+      ),
+    );
+    await repository.create(
+      _memory(
+        id: 'replacement',
+        scope: characterScope,
+        content: 'replacement without the query term',
+      ),
+    );
+    await repository.create(
+      _memory(
+        id: 'superseded',
+        scope: characterScope,
+        content: 'lifecycle sentinel',
+        state: MemoryState.superseded,
+        supersededByMemoryId: 'replacement',
+      ),
+    );
+    await repository.create(
+      _memory(
+        id: 'expired',
+        scope: characterScope,
+        content: 'lifecycle sentinel',
+        createdAt: now.subtract(const Duration(days: 2)),
+        expiresAt: now.subtract(const Duration(hours: 1)),
+      ),
+    );
+
+    expect(
+      await repository.search('lifecycle', scope: characterScope),
+      isEmpty,
+    );
+    expect(
+      (await repository.search(
+        'lifecycle',
+        scope: characterScope,
+        states: const {MemoryState.candidate},
+      ))
+          .single
+          .memory
+          .id,
+      'candidate',
+    );
+    expect(
+      (await repository.search(
+        'lifecycle',
+        scope: characterScope,
+        includeExpired: true,
+      ))
+          .single
+          .memory
+          .id,
+      'expired',
+    );
+  });
+
+  test('BM25 ties use importance, update time, and id deterministically',
+      () async {
+    final scope = MemoryScope.character('character-1');
+    final createdAt = now.subtract(const Duration(days: 2));
+    final fixtures = [
+      _memory(
+        id: 'rank-important',
+        scope: scope,
+        content: 'shared ranking token',
+        normalizedIdentityKey: 'same-key',
+        importance: 0.9,
+        createdAt: createdAt,
+      ),
+      _memory(
+        id: 'rank-newer',
+        scope: scope,
+        content: 'shared ranking token',
+        normalizedIdentityKey: 'same-key',
+        updatedAt: now,
+        createdAt: createdAt,
+      ),
+      _memory(
+        id: 'rank-b',
+        scope: scope,
+        content: 'shared ranking token',
+        normalizedIdentityKey: 'same-key',
+        createdAt: createdAt,
+      ),
+      _memory(
+        id: 'rank-a',
+        scope: scope,
+        content: 'shared ranking token',
+        normalizedIdentityKey: 'same-key',
+        createdAt: createdAt,
+      ),
+    ];
+    for (final fixture in fixtures) {
+      await repository.create(fixture);
+    }
+
+    final ids = (await repository.search('shared', scope: scope))
+        .map((result) => result.memory.id)
+        .toList();
+    expect(
+      ids,
+      ['rank-important', 'rank-newer', 'rank-a', 'rank-b'],
+    );
+  });
+
+  test('BM25 relevance is applied before memory importance', () async {
+    final scope = MemoryScope.character('character-1');
+    await repository.create(
+      _memory(
+        id: 'bm25-concise',
+        scope: scope,
+        content: 'orchid',
+        normalizedIdentityKey: 'same-key',
+        importance: 0,
+      ),
+    );
+    await repository.create(
+      _memory(
+        id: 'bm25-verbose',
+        scope: scope,
+        content:
+            'orchid with many unrelated filler words that dilute relevance',
+        normalizedIdentityKey: 'same-key',
+        importance: 1,
+      ),
+    );
+
+    final matches = await repository.search('orchid', scope: scope);
+
+    expect(
+      matches.map((result) => result.memory.id),
+      ['bm25-concise', 'bm25-verbose'],
+    );
+    expect(matches.first.rank, lessThan(matches.last.rank));
+  });
+
+  test('rebuild recovers a missing derived index', () async {
+    final scope = MemoryScope.character('character-1');
+    await repository.create(
+      _memory(
+        id: 'memory-rebuild',
+        scope: scope,
+        content: 'recoverable archive',
+      ),
+    );
+    await database.customStatement('DROP TABLE long_term_memories_fts');
+
+    await repository.rebuildSearchIndex();
+
+    expect(
+      (await repository.search('recoverable', scope: scope)).single.memory.id,
+      'memory-rebuild',
+    );
+  });
+
+  test('failed repository transaction rolls back the FTS write', () async {
+    final scope = MemoryScope.character('character-1');
+    final memory = _memory(
+      id: 'memory-rollback',
+      scope: scope,
+      content: 'transaction sentinel',
+      source: MemorySource.generated(
+        sourceChatId: 'chat-1',
+        sourceMessageIds: const ['missing-message'],
+        extractedAt: now.subtract(const Duration(minutes: 1)),
+        providerId: 'provider-1',
+        modelId: 'model-1',
+      ),
+    );
+
+    await expectLater(repository.create(memory), throwsA(anything));
+
+    expect(await repository.getById(memory.id), isNull);
+    expect(await repository.search('transaction', scope: scope), isEmpty);
+  });
+
+  test('1001-memory fixture has repeatable Top-K performance', () async {
+    final createdAt = now.subtract(const Duration(days: 1));
+    final fixtures = List.generate(
+      1001,
+      (index) => LongTermMemoriesCompanion.insert(
+        id: 'bulk-${index.toString().padLeft(4, '0')}',
+        kind: MemoryKind.other.name,
+        scopeKind: MemoryScopeKind.character.name,
+        characterId: const Value('character-1'),
+        state: MemoryState.active.name,
+        content: index == 777
+            ? 'performance needle target'
+            : 'repeatable ordinary fixture $index',
+        sourceOrigin: MemoryOrigin.manual.name,
+        importance: 0.5,
+        confidence: 0.5,
+        createdAt: createdAt,
+        updatedAt: createdAt,
+        normalizedIdentityKey: 'bulk-key-$index',
+      ),
+    );
+    await database.batch(
+      (batch) => batch.insertAll(database.longTermMemories, fixtures),
+    );
+
+    final stopwatch = Stopwatch()..start();
+    final first = await repository.search(
+      'needle',
+      scope: MemoryScope.character('character-1'),
+      topK: 5,
+    );
+    final second = await repository.search(
+      'needle',
+      scope: MemoryScope.character('character-1'),
+      topK: 5,
+    );
+    stopwatch.stop();
+
+    expect(first.map((result) => result.memory.id), ['bulk-0777']);
+    expect(
+      second.map((result) => result.memory.id),
+      first.map((result) => result.memory.id),
+    );
+    expect(stopwatch.elapsed, lessThan(const Duration(seconds: 2)));
+  });
+}
+
+LongTermMemory _memory({
+  required String id,
+  required MemoryScope scope,
+  required String content,
+  MemoryState state = MemoryState.active,
+  MemorySource? source,
+  double importance = 0.5,
+  DateTime? createdAt,
+  DateTime? updatedAt,
+  DateTime? expiresAt,
+  String? normalizedIdentityKey,
+  String? supersededByMemoryId,
+}) {
+  final effectiveCreatedAt = createdAt ?? DateTime.utc(2026, 8, 8, 12);
+  return LongTermMemory(
+    id: id,
+    kind: MemoryKind.other,
+    scope: scope,
+    state: state,
+    content: content,
+    source: source,
+    importance: importance,
+    confidence: 0.9,
+    createdAt: effectiveCreatedAt,
+    updatedAt: updatedAt ?? effectiveCreatedAt,
+    expiresAt: expiresAt,
+    normalizedIdentityKey: normalizedIdentityKey ?? id,
+    supersededByMemoryId: supersededByMemoryId,
+  );
+}
+
+Future<void> _seedOwners(AppDatabase database) async {
+  const statements = [
+    'INSERT INTO characters (id, name, created_at, modified_at) '
+        "VALUES ('character-1', 'Character', 1, 1)",
+    'INSERT INTO personas (id, name, created_at, updated_at) '
+        "VALUES ('persona-1', 'Persona', 1, 1)",
+    'INSERT INTO groups (id, name, created_at, modified_at) '
+        "VALUES ('group-1', 'Group', 1, 1)",
+    'INSERT INTO chats (id, character_id, created_at, updated_at) '
+        "VALUES ('chat-1', 'character-1', 1, 1)",
+    'INSERT INTO messages (id, chat_id, role, content, timestamp) '
+        "VALUES ('message-1', 'chat-1', 'user', 'First', 1)",
+    'INSERT INTO messages (id, chat_id, role, content, timestamp) '
+        "VALUES ('message-2', 'chat-1', 'assistant', 'Second', 2)",
+  ];
+  for (final statement in statements) {
+    await database.customStatement(statement);
+  }
+}


### PR DESCRIPTION
## Summary\n\n- B02: complete the production Drift long-term memory repository contract with searchable results that retain the full memory record and source-message provenance.\n- B03: add an FTS5 external-content index, transactional insert/update/delete triggers, plain-text query normalization, exact scope and lifecycle filtering, Top-K BM25 retrieval, deterministic tie-breaking, and explicit index rebuild.\n- Keep schemaVersion at 15 because the FTS index is derived; existing v15 databases gain and rebuild it during beforeOpen.\n\n## Validation\n\n- flutter test: 213/213 passed\n- focused long-term-memory FTS suite: 8/8 passed\n- focused analyze for all changed files: no issues\n- full flutter analyze: no errors; 1175 existing warning/info diagnostics\n- repeatable 1001-memory fixture: two Top-K searches complete within the 2-second test baseline\n\nCloses #23