### PR TITLE
feat(data-bank): add local document ingestion pipeline

### DIFF
--- a/lib/domain/services/data_bank_ingestion_service.dart
+++ b/lib/domain/services/data_bank_ingestion_service.dart
@@ -1,0 +1,1388 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:archive/archive.dart';
+import 'package:charset/charset.dart' as charset;
+import 'package:crypto/crypto.dart';
+import 'package:html/dom.dart' as html_dom;
+import 'package:html/parser.dart' as html_parser;
+import 'package:markdown/markdown.dart' as markdown;
+import 'package:path/path.dart' as path;
+import 'package:pdfrx/pdfrx.dart';
+import 'package:xml/xml.dart';
+
+import '../../data/models/data_bank.dart';
+
+enum DataBankDocumentFormat { plainText, markdown, html, pdf, epub }
+
+enum DataBankChunkingStrategy { fixedLength, paragraph, chapter }
+
+enum DataBankIngestionPhase { staging, parsing, chunking, completed }
+
+enum DataBankIngestionFailureCode {
+  sourceNotFound,
+  unsupportedFormat,
+  invalidEncoding,
+  encryptedDocument,
+  corruptDocument,
+  emptyDocument,
+  cancelled,
+  ioFailure,
+}
+
+enum DataBankContentComparison { identical, changed }
+
+final class DataBankIngestionException implements Exception {
+  final DataBankIngestionFailureCode code;
+  final String message;
+  final Object? cause;
+
+  const DataBankIngestionException(this.code, this.message, {this.cause});
+
+  @override
+  String toString() => 'DataBankIngestionException(${code.name}): $message';
+}
+
+final class DataBankCancellationToken {
+  bool _cancelled = false;
+
+  bool get isCancelled => _cancelled;
+
+  void cancel() {
+    _cancelled = true;
+  }
+
+  void throwIfCancelled() {
+    if (_cancelled) {
+      throw const DataBankIngestionException(
+        DataBankIngestionFailureCode.cancelled,
+        'Document ingestion was cancelled.',
+      );
+    }
+  }
+}
+
+final class DataBankIngestionProgress {
+  final DataBankIngestionPhase phase;
+  final int completedUnits;
+  final int totalUnits;
+
+  const DataBankIngestionProgress({
+    required this.phase,
+    required this.completedUnits,
+    required this.totalUnits,
+  });
+
+  double get fraction {
+    if (totalUnits <= 0) return 0;
+    return (completedUnits / totalUnits).clamp(0, 1).toDouble();
+  }
+}
+
+typedef DataBankProgressCallback = void Function(
+  DataBankIngestionProgress progress,
+);
+
+final class DataBankChunkingOptions {
+  final DataBankChunkingStrategy strategy;
+  final int maxCharacters;
+
+  factory DataBankChunkingOptions({
+    DataBankChunkingStrategy strategy = DataBankChunkingStrategy.paragraph,
+    int maxCharacters = 1200,
+  }) {
+    if (maxCharacters < 1) {
+      throw ArgumentError.value(
+        maxCharacters,
+        'maxCharacters',
+        'must be at least 1',
+      );
+    }
+    return DataBankChunkingOptions._(strategy, maxCharacters);
+  }
+
+  const DataBankChunkingOptions._(this.strategy, this.maxCharacters);
+}
+
+final class DataBankIngestionRequest {
+  final File sourceFile;
+  final String documentVersionId;
+  final String? mediaType;
+  final DataBankChunkingOptions chunking;
+  final DataBankCancellationToken cancellationToken;
+  final DataBankProgressCallback? onProgress;
+
+  DataBankIngestionRequest({
+    required this.sourceFile,
+    required this.documentVersionId,
+    this.mediaType,
+    DataBankChunkingOptions? chunking,
+    DataBankCancellationToken? cancellationToken,
+    this.onProgress,
+  })  : chunking = chunking ?? DataBankChunkingOptions(),
+        cancellationToken = cancellationToken ?? DataBankCancellationToken() {
+    if (documentVersionId.trim().isEmpty) {
+      throw ArgumentError.value(
+        documentVersionId,
+        'documentVersionId',
+        'must not be blank',
+      );
+    }
+  }
+}
+
+final class DataBankIngestionResult {
+  final String originalFileName;
+  final String mediaType;
+  final int byteSize;
+  final DataBankContentHash contentHash;
+  final String normalizedText;
+  final String? detectedEncoding;
+  final List<DataBankSection> sections;
+  final List<DataBankTextChunk> chunks;
+
+  const DataBankIngestionResult({
+    required this.originalFileName,
+    required this.mediaType,
+    required this.byteSize,
+    required this.contentHash,
+    required this.normalizedText,
+    required this.detectedEncoding,
+    required this.sections,
+    required this.chunks,
+  });
+
+  DataBankContentComparison compareContent(
+    DataBankContentHash previousContentHash,
+  ) {
+    return previousContentHash.algorithm == contentHash.algorithm &&
+            previousContentHash.digest == contentHash.digest
+        ? DataBankContentComparison.identical
+        : DataBankContentComparison.changed;
+  }
+}
+
+final class DataBankPdfPage {
+  final int pageNumber;
+  final String text;
+
+  const DataBankPdfPage({required this.pageNumber, required this.text});
+}
+
+abstract interface class DataBankPdfTextExtractor {
+  Future<List<DataBankPdfPage>> extractPages(
+    File file, {
+    required DataBankCancellationToken cancellationToken,
+    required void Function(int completedPages, int totalPages) onProgress,
+  });
+}
+
+final class PdfrxDataBankPdfTextExtractor implements DataBankPdfTextExtractor {
+  const PdfrxDataBankPdfTextExtractor();
+
+  @override
+  Future<List<DataBankPdfPage>> extractPages(
+    File file, {
+    required DataBankCancellationToken cancellationToken,
+    required void Function(int completedPages, int totalPages) onProgress,
+  }) async {
+    PdfDocument? document;
+    try {
+      cancellationToken.throwIfCancelled();
+      document = await PdfDocument.openFile(file.path);
+      if (document.isEncrypted) {
+        throw const DataBankIngestionException(
+          DataBankIngestionFailureCode.encryptedDocument,
+          'Encrypted PDF documents are not supported.',
+        );
+      }
+
+      final pages = <DataBankPdfPage>[];
+      final totalPages = document.pages.length;
+      for (var index = 0; index < totalPages; index++) {
+        cancellationToken.throwIfCancelled();
+        final pageText = await document.pages[index].loadText();
+        cancellationToken.throwIfCancelled();
+        pages.add(
+          DataBankPdfPage(
+            pageNumber: index + 1,
+            text: pageText.fullText,
+          ),
+        );
+        onProgress(index + 1, totalPages);
+      }
+      return pages;
+    } on PdfPasswordException catch (error) {
+      throw DataBankIngestionException(
+        DataBankIngestionFailureCode.encryptedDocument,
+        'The PDF requires a password.',
+        cause: error,
+      );
+    } on PdfException catch (error) {
+      throw DataBankIngestionException(
+        DataBankIngestionFailureCode.corruptDocument,
+        'The PDF could not be parsed.',
+        cause: error,
+      );
+    } finally {
+      await document?.dispose();
+    }
+  }
+}
+
+typedef DataBankStagingDirectoryProvider = Future<Directory> Function();
+
+final class DataBankIngestionService {
+  final DataBankPdfTextExtractor _pdfTextExtractor;
+  final DataBankStagingDirectoryProvider _createStagingDirectory;
+
+  DataBankIngestionService({
+    DataBankPdfTextExtractor pdfTextExtractor =
+        const PdfrxDataBankPdfTextExtractor(),
+    DataBankStagingDirectoryProvider? createStagingDirectory,
+  })  : _pdfTextExtractor = pdfTextExtractor,
+        _createStagingDirectory = createStagingDirectory ??
+            (() => Directory.systemTemp.createTemp(
+                  'native_tavern_data_bank_',
+                ));
+
+  Future<DataBankIngestionResult> ingest(
+    DataBankIngestionRequest request,
+  ) async {
+    request.cancellationToken.throwIfCancelled();
+    if (!request.sourceFile.existsSync()) {
+      throw DataBankIngestionException(
+        DataBankIngestionFailureCode.sourceNotFound,
+        'Source file does not exist: ${request.sourceFile.path}',
+      );
+    }
+
+    final sourceType = _resolveSourceType(
+      request.sourceFile.path,
+      request.mediaType,
+    );
+    Directory? stagingDirectory;
+    try {
+      stagingDirectory = await _createStagingDirectory();
+      final stagedFile = File(
+        path.join(
+          stagingDirectory.path,
+          'source${path.extension(request.sourceFile.path)}',
+        ),
+      );
+      final staged = await _stageAndHash(request, stagedFile);
+      request.cancellationToken.throwIfCancelled();
+
+      final parsed = await _parse(
+        stagedFile,
+        sourceType,
+        request,
+      );
+      request.cancellationToken.throwIfCancelled();
+      final resolved = _resolveSegments(parsed.segments);
+      if (resolved.isEmpty) {
+        throw const DataBankIngestionException(
+          DataBankIngestionFailureCode.emptyDocument,
+          'The document contains no importable text.',
+        );
+      }
+
+      final sections = _buildSections(
+        request.documentVersionId,
+        resolved,
+      );
+      final chunks = _buildChunks(
+        request.documentVersionId,
+        resolved,
+        request.chunking,
+        request,
+      );
+      if (chunks.isEmpty) {
+        throw const DataBankIngestionException(
+          DataBankIngestionFailureCode.emptyDocument,
+          'The document contains no importable text.',
+        );
+      }
+
+      _report(
+        request,
+        const DataBankIngestionProgress(
+          phase: DataBankIngestionPhase.completed,
+          completedUnits: 1,
+          totalUnits: 1,
+        ),
+      );
+      request.cancellationToken.throwIfCancelled();
+      return DataBankIngestionResult(
+        originalFileName: path.basename(request.sourceFile.path),
+        mediaType: sourceType.mediaType,
+        byteSize: staged.byteSize,
+        contentHash: DataBankContentHash(
+          algorithm: DataBankHashAlgorithm.sha256,
+          digest: staged.digest,
+        ),
+        normalizedText: resolved.map((segment) => segment.text).join('\n\n'),
+        detectedEncoding: parsed.detectedEncoding,
+        sections: List.unmodifiable(sections),
+        chunks: List.unmodifiable(chunks),
+      );
+    } on DataBankIngestionException {
+      rethrow;
+    } on FileSystemException catch (error) {
+      throw DataBankIngestionException(
+        DataBankIngestionFailureCode.ioFailure,
+        'The document could not be read.',
+        cause: error,
+      );
+    } on FormatException catch (error) {
+      throw DataBankIngestionException(
+        DataBankIngestionFailureCode.corruptDocument,
+        'The document structure is invalid.',
+        cause: error,
+      );
+    } catch (error) {
+      throw DataBankIngestionException(
+        DataBankIngestionFailureCode.corruptDocument,
+        'The document could not be parsed.',
+        cause: error,
+      );
+    } finally {
+      if (stagingDirectory != null && stagingDirectory.existsSync()) {
+        try {
+          await stagingDirectory.delete(recursive: true);
+        } on FileSystemException catch (error) {
+          throw DataBankIngestionException(
+            DataBankIngestionFailureCode.ioFailure,
+            'Temporary document files could not be removed.',
+            cause: error,
+          );
+        }
+      }
+    }
+  }
+
+  Future<_StagedSource> _stageAndHash(
+    DataBankIngestionRequest request,
+    File stagedFile,
+  ) async {
+    final byteSize = await request.sourceFile.length();
+    final digestCompleter = Completer<Digest>();
+    final digestSink = sha256.startChunkedConversion(
+      ChunkedConversionSink.withCallback(
+        (digests) => digestCompleter.complete(digests.single),
+      ),
+    );
+    final output = stagedFile.openWrite();
+    var copiedBytes = 0;
+    var digestClosed = false;
+    var outputClosed = false;
+    try {
+      await for (final bytes in request.sourceFile.openRead()) {
+        request.cancellationToken.throwIfCancelled();
+        digestSink.add(bytes);
+        output.add(bytes);
+        copiedBytes += bytes.length;
+        _report(
+          request,
+          DataBankIngestionProgress(
+            phase: DataBankIngestionPhase.staging,
+            completedUnits: copiedBytes,
+            totalUnits: byteSize,
+          ),
+        );
+        request.cancellationToken.throwIfCancelled();
+      }
+      digestSink.close();
+      digestClosed = true;
+      await output.flush();
+      await output.close();
+      outputClosed = true;
+      return _StagedSource(
+        byteSize: copiedBytes,
+        digest: (await digestCompleter.future).toString(),
+      );
+    } catch (_) {
+      if (!digestClosed) {
+        try {
+          digestSink.close();
+        } catch (_) {
+          // Preserve the original staging error.
+        }
+      }
+      if (!outputClosed) {
+        try {
+          await output.close();
+        } catch (_) {
+          // Preserve the original staging error.
+        }
+      }
+      rethrow;
+    }
+  }
+
+  Future<_ParsedDocument> _parse(
+    File stagedFile,
+    _SourceType sourceType,
+    DataBankIngestionRequest request,
+  ) async {
+    switch (sourceType.format) {
+      case DataBankDocumentFormat.plainText:
+        return _parsePlainText(await stagedFile.readAsBytes(), request);
+      case DataBankDocumentFormat.markdown:
+        return _parseMarkdown(await stagedFile.readAsBytes(), request);
+      case DataBankDocumentFormat.html:
+        return _parseHtml(await stagedFile.readAsBytes(), request);
+      case DataBankDocumentFormat.pdf:
+        return _parsePdf(stagedFile, request);
+      case DataBankDocumentFormat.epub:
+        return _parseEpub(await stagedFile.readAsBytes(), request);
+    }
+  }
+
+  _ParsedDocument _parsePlainText(
+    Uint8List bytes,
+    DataBankIngestionRequest request,
+  ) {
+    final decoded = _decodeText(bytes);
+    _reportParseUnit(request, 1, 1);
+    return _ParsedDocument(
+      segments: [
+        _SourceSegment(
+          kind: DataBankSectionKind.section,
+          text: decoded.text,
+        ),
+      ],
+      detectedEncoding: decoded.encodingName,
+    );
+  }
+
+  _ParsedDocument _parseMarkdown(
+    Uint8List bytes,
+    DataBankIngestionRequest request,
+  ) {
+    final decoded = _decodeText(bytes);
+    final rendered = markdown.markdownToHtml(
+      decoded.text,
+      extensionSet: markdown.ExtensionSet.gitHubFlavored,
+    );
+    final parts = _parseStructuredHtml(rendered);
+    _reportParseUnit(request, 1, 1);
+    return _ParsedDocument(
+      segments: parts
+          .map(
+            (part) => _SourceSegment(
+              kind: DataBankSectionKind.section,
+              title: part.title,
+              text: part.text,
+            ),
+          )
+          .toList(growable: false),
+      detectedEncoding: decoded.encodingName,
+    );
+  }
+
+  _ParsedDocument _parseHtml(
+    Uint8List bytes,
+    DataBankIngestionRequest request,
+  ) {
+    final decoded = _decodeText(bytes, inspectHtmlCharset: true);
+    final parts = _parseStructuredHtml(decoded.text);
+    _reportParseUnit(request, 1, 1);
+    return _ParsedDocument(
+      segments: parts
+          .map(
+            (part) => _SourceSegment(
+              kind: DataBankSectionKind.section,
+              title: part.title,
+              text: part.text,
+            ),
+          )
+          .toList(growable: false),
+      detectedEncoding: decoded.encodingName,
+    );
+  }
+
+  Future<_ParsedDocument> _parsePdf(
+    File file,
+    DataBankIngestionRequest request,
+  ) async {
+    final pages = await _pdfTextExtractor.extractPages(
+      file,
+      cancellationToken: request.cancellationToken,
+      onProgress: (completed, total) {
+        _reportParseUnit(request, completed, total);
+      },
+    );
+    return _ParsedDocument(
+      segments: pages
+          .map(
+            (page) => _SourceSegment(
+              kind: DataBankSectionKind.section,
+              pageStart: page.pageNumber,
+              pageEnd: page.pageNumber,
+              text: page.text,
+            ),
+          )
+          .toList(growable: false),
+    );
+  }
+
+  _ParsedDocument _parseEpub(
+    Uint8List bytes,
+    DataBankIngestionRequest request,
+  ) {
+    request.cancellationToken.throwIfCancelled();
+    final Archive archive;
+    try {
+      archive = ZipDecoder().decodeBytes(bytes, verify: true);
+    } catch (error) {
+      throw DataBankIngestionException(
+        DataBankIngestionFailureCode.corruptDocument,
+        'The EPUB archive is damaged.',
+        cause: error,
+      );
+    }
+
+    final entries = <String, ArchiveFile>{
+      for (final entry in archive.files)
+        if (entry.isFile) path.posix.normalize(entry.name): entry,
+    };
+    final container = _readArchiveText(
+      entries,
+      'META-INF/container.xml',
+      description: 'EPUB container',
+    );
+    final containerXml = XmlDocument.parse(container);
+    final rootFile = containerXml.descendants
+        .whereType<XmlElement>()
+        .where((element) => element.name.local == 'rootfile')
+        .firstOrNull;
+    final packagePath = rootFile?.getAttribute('full-path');
+    if (packagePath == null || packagePath.trim().isEmpty) {
+      throw const DataBankIngestionException(
+        DataBankIngestionFailureCode.corruptDocument,
+        'The EPUB does not declare a package document.',
+      );
+    }
+
+    final normalizedPackagePath = path.posix.normalize(packagePath);
+    final packageDirectory = path.posix.dirname(normalizedPackagePath);
+    final packageXml = XmlDocument.parse(
+      _readArchiveText(
+        entries,
+        normalizedPackagePath,
+        description: 'EPUB package',
+      ),
+    );
+    final manifest = <String, _EpubManifestItem>{};
+    for (final item in packageXml.descendants
+        .whereType<XmlElement>()
+        .where((element) => element.name.local == 'item')) {
+      final id = item.getAttribute('id');
+      final href = item.getAttribute('href');
+      if (id == null || href == null) continue;
+      manifest[id] = _EpubManifestItem(
+        id: id,
+        archivePath: _resolveEpubPath(packageDirectory, href),
+        mediaType: item.getAttribute('media-type') ?? '',
+        properties: (item.getAttribute('properties') ?? '')
+            .split(RegExp(r'\s+'))
+            .where((value) => value.isNotEmpty)
+            .toSet(),
+      );
+    }
+
+    final spine = packageXml.descendants
+        .whereType<XmlElement>()
+        .where((element) => element.name.local == 'itemref')
+        .map((element) => element.getAttribute('idref'))
+        .whereType<String>()
+        .map((id) => manifest[id])
+        .whereType<_EpubManifestItem>()
+        .toList(growable: false);
+    if (spine.isEmpty) {
+      throw const DataBankIngestionException(
+        DataBankIngestionFailureCode.corruptDocument,
+        'The EPUB reading order is empty.',
+      );
+    }
+
+    final encryptedPaths = _readEncryptedEpubPaths(entries);
+    if (spine.any((item) => encryptedPaths.contains(item.archivePath))) {
+      throw const DataBankIngestionException(
+        DataBankIngestionFailureCode.encryptedDocument,
+        'The EPUB chapter content is encrypted.',
+      );
+    }
+
+    final titlesByPath = _readEpubNavigationTitles(entries, manifest);
+    final segments = <_SourceSegment>[];
+    for (var spineIndex = 0; spineIndex < spine.length; spineIndex++) {
+      request.cancellationToken.throwIfCancelled();
+      final item = spine[spineIndex];
+      if (item.mediaType != 'application/xhtml+xml' &&
+          item.mediaType != 'text/html') {
+        continue;
+      }
+      final chapterHtml = _readArchiveText(
+        entries,
+        item.archivePath,
+        description: 'EPUB chapter',
+      );
+      final parts = _parseStructuredHtml(chapterHtml);
+      final navigationTitle = titlesByPath[item.archivePath];
+      for (var partIndex = 0; partIndex < parts.length; partIndex++) {
+        final part = parts[partIndex];
+        final title = _normalizeInlineText(
+          part.title ??
+              (partIndex == 0 ? navigationTitle : null) ??
+              'Chapter ${spineIndex + 1}',
+        );
+        segments.add(
+          _SourceSegment(
+            kind: DataBankSectionKind.chapter,
+            title: title,
+            chapter: title,
+            text: part.text,
+          ),
+        );
+      }
+      _reportParseUnit(request, spineIndex + 1, spine.length);
+      request.cancellationToken.throwIfCancelled();
+    }
+    return _ParsedDocument(segments: segments);
+  }
+
+  List<DataBankSection> _buildSections(
+    String versionId,
+    List<_ResolvedSegment> segments,
+  ) {
+    return [
+      for (final segment in segments)
+        DataBankSection(
+          id: '$versionId-section-${segment.ordinal + 1}',
+          documentVersionId: versionId,
+          kind: segment.source.kind,
+          title: segment.source.title,
+          ordinal: segment.ordinal,
+          locator: DataBankSourceLocator(
+            documentVersionId: versionId,
+            sectionId: '$versionId-section-${segment.ordinal + 1}',
+            pageStart: segment.source.pageStart,
+            pageEnd: segment.source.pageEnd,
+            chapter: segment.source.chapter,
+            startOffset: segment.startOffset,
+            endOffset: segment.endOffset,
+          ),
+        ),
+    ];
+  }
+
+  List<DataBankTextChunk> _buildChunks(
+    String versionId,
+    List<_ResolvedSegment> segments,
+    DataBankChunkingOptions options,
+    DataBankIngestionRequest request,
+  ) {
+    final spans = <_ChunkSpan>[];
+    for (var index = 0; index < segments.length; index++) {
+      request.cancellationToken.throwIfCancelled();
+      final segment = segments[index];
+      switch (options.strategy) {
+        case DataBankChunkingStrategy.fixedLength:
+          spans.addAll(
+            _fixedLengthSpans(
+              segment,
+              segment.startOffset,
+              segment.endOffset,
+              options.maxCharacters,
+            ),
+          );
+        case DataBankChunkingStrategy.paragraph:
+          spans.addAll(_paragraphSpans(segment, options.maxCharacters));
+        case DataBankChunkingStrategy.chapter:
+          spans.add(
+            _ChunkSpan(
+              segment: segment,
+              startOffset: segment.startOffset,
+              endOffset: segment.endOffset,
+            ),
+          );
+      }
+      _report(
+        request,
+        DataBankIngestionProgress(
+          phase: DataBankIngestionPhase.chunking,
+          completedUnits: index + 1,
+          totalUnits: segments.length,
+        ),
+      );
+    }
+
+    return [
+      for (var index = 0; index < spans.length; index++)
+        DataBankTextChunk(
+          id: '$versionId-chunk-${index + 1}',
+          documentVersionId: versionId,
+          sectionId: '$versionId-section-${spans[index].segment.ordinal + 1}',
+          ordinal: index,
+          text: spans[index].segment.documentText.substring(
+                spans[index].startOffset,
+                spans[index].endOffset,
+              ),
+          locator: DataBankSourceLocator(
+            documentVersionId: versionId,
+            sectionId: '$versionId-section-${spans[index].segment.ordinal + 1}',
+            pageStart: spans[index].segment.source.pageStart,
+            pageEnd: spans[index].segment.source.pageEnd,
+            chapter: spans[index].segment.source.chapter,
+            startOffset: spans[index].startOffset,
+            endOffset: spans[index].endOffset,
+          ),
+        ),
+    ];
+  }
+
+  List<_ChunkSpan> _paragraphSpans(
+    _ResolvedSegment segment,
+    int maxCharacters,
+  ) {
+    final spans = <_ChunkSpan>[];
+    var cursor = segment.startOffset;
+    while (cursor < segment.endOffset) {
+      cursor = _skipWhitespace(
+        segment.documentText,
+        cursor,
+        segment.endOffset,
+      );
+      if (cursor >= segment.endOffset) break;
+      final delimiter = segment.documentText.indexOf('\n\n', cursor);
+      final paragraphLimit = delimiter == -1 || delimiter >= segment.endOffset
+          ? segment.endOffset
+          : delimiter;
+      final paragraphEnd = _trimEndWhitespace(
+        segment.documentText,
+        cursor,
+        paragraphLimit,
+      );
+      if (paragraphEnd > cursor) {
+        spans.addAll(
+          _fixedLengthSpans(
+            segment,
+            cursor,
+            paragraphEnd,
+            maxCharacters,
+          ),
+        );
+      }
+      cursor = delimiter == -1 ? segment.endOffset : delimiter + 2;
+    }
+    return spans;
+  }
+
+  List<_ChunkSpan> _fixedLengthSpans(
+    _ResolvedSegment segment,
+    int rangeStart,
+    int rangeEnd,
+    int maxCharacters,
+  ) {
+    final spans = <_ChunkSpan>[];
+    var cursor = rangeStart;
+    while (cursor < rangeEnd) {
+      cursor = _skipWhitespace(segment.documentText, cursor, rangeEnd);
+      if (cursor >= rangeEnd) break;
+      var chunkEnd = (cursor + maxCharacters).clamp(cursor + 1, rangeEnd);
+      if (chunkEnd < rangeEnd &&
+          !_isWhitespace(segment.documentText.codeUnitAt(chunkEnd))) {
+        final candidate = segment.documentText.lastIndexOf(
+          RegExp(r'\s'),
+          chunkEnd,
+        );
+        if (candidate > cursor) chunkEnd = candidate;
+      }
+      chunkEnd = _trimEndWhitespace(
+        segment.documentText,
+        cursor,
+        chunkEnd,
+      );
+      if (chunkEnd <= cursor) {
+        chunkEnd = (cursor + maxCharacters).clamp(cursor + 1, rangeEnd);
+      }
+      spans.add(
+        _ChunkSpan(
+          segment: segment,
+          startOffset: cursor,
+          endOffset: chunkEnd,
+        ),
+      );
+      cursor = chunkEnd;
+    }
+    return spans;
+  }
+
+  void _reportParseUnit(
+    DataBankIngestionRequest request,
+    int completed,
+    int total,
+  ) {
+    _report(
+      request,
+      DataBankIngestionProgress(
+        phase: DataBankIngestionPhase.parsing,
+        completedUnits: completed,
+        totalUnits: total,
+      ),
+    );
+    request.cancellationToken.throwIfCancelled();
+  }
+
+  void _report(
+    DataBankIngestionRequest request,
+    DataBankIngestionProgress progress,
+  ) {
+    try {
+      request.onProgress?.call(progress);
+    } catch (_) {
+      // A progress observer cannot invalidate an otherwise valid import.
+    }
+  }
+}
+
+_SourceType _resolveSourceType(String filePath, String? requestedMediaType) {
+  final mediaType = requestedMediaType?.split(';').first.trim().toLowerCase();
+  final byMediaType = switch (mediaType) {
+    'text/plain' => const _SourceType(
+        DataBankDocumentFormat.plainText,
+        'text/plain',
+      ),
+    'text/markdown' || 'text/x-markdown' => const _SourceType(
+        DataBankDocumentFormat.markdown,
+        'text/markdown',
+      ),
+    'text/html' || 'application/xhtml+xml' => const _SourceType(
+        DataBankDocumentFormat.html,
+        'text/html',
+      ),
+    'application/pdf' => const _SourceType(
+        DataBankDocumentFormat.pdf,
+        'application/pdf',
+      ),
+    'application/epub+zip' => const _SourceType(
+        DataBankDocumentFormat.epub,
+        'application/epub+zip',
+      ),
+    null || '' => null,
+    _ => throw DataBankIngestionException(
+        DataBankIngestionFailureCode.unsupportedFormat,
+        'Unsupported media type: $requestedMediaType',
+      ),
+  };
+  if (byMediaType != null) return byMediaType;
+
+  return switch (path.extension(filePath).toLowerCase()) {
+    '.txt' => const _SourceType(
+        DataBankDocumentFormat.plainText,
+        'text/plain',
+      ),
+    '.md' || '.markdown' => const _SourceType(
+        DataBankDocumentFormat.markdown,
+        'text/markdown',
+      ),
+    '.html' || '.htm' => const _SourceType(
+        DataBankDocumentFormat.html,
+        'text/html',
+      ),
+    '.pdf' => const _SourceType(
+        DataBankDocumentFormat.pdf,
+        'application/pdf',
+      ),
+    '.epub' => const _SourceType(
+        DataBankDocumentFormat.epub,
+        'application/epub+zip',
+      ),
+    _ => throw DataBankIngestionException(
+        DataBankIngestionFailureCode.unsupportedFormat,
+        'Unsupported document extension: ${path.extension(filePath)}',
+      ),
+  };
+}
+
+_DecodedText _decodeText(
+  Uint8List bytes, {
+  bool inspectHtmlCharset = false,
+}) {
+  if (bytes.isEmpty) return const _DecodedText('', 'UTF-8');
+
+  try {
+    if (_startsWith(bytes, const [0xef, 0xbb, 0xbf])) {
+      return _validatedDecodedText(
+        utf8.decode(bytes.sublist(3), allowMalformed: false),
+        'UTF-8',
+      );
+    }
+    if (_startsWith(bytes, const [0xff, 0xfe, 0x00, 0x00]) ||
+        _startsWith(bytes, const [0x00, 0x00, 0xfe, 0xff])) {
+      return _validatedDecodedText(charset.utf32.decode(bytes), 'UTF-32');
+    }
+    if (_startsWith(bytes, const [0xff, 0xfe]) ||
+        _startsWith(bytes, const [0xfe, 0xff])) {
+      return _validatedDecodedText(charset.utf16.decode(bytes), 'UTF-16');
+    }
+
+    if (inspectHtmlCharset) {
+      final declared = _declaredHtmlEncoding(bytes);
+      if (declared != null) {
+        return _validatedDecodedText(declared.decode(bytes), declared.name);
+      }
+    }
+
+    try {
+      return _validatedDecodedText(
+        utf8.decode(bytes, allowMalformed: false),
+        'UTF-8',
+      );
+    } on FormatException {
+      final detected = charset.Charset.detect(
+        bytes,
+        orders: [
+          charset.gbk,
+          charset.shiftJis,
+          charset.windows1252,
+          latin1,
+        ],
+      );
+      if (detected != null) {
+        return _validatedDecodedText(detected.decode(bytes), detected.name);
+      }
+      rethrow;
+    }
+  } on FormatException catch (error) {
+    throw DataBankIngestionException(
+      DataBankIngestionFailureCode.invalidEncoding,
+      'The text encoding could not be detected.',
+      cause: error,
+    );
+  } on ArgumentError catch (error) {
+    throw DataBankIngestionException(
+      DataBankIngestionFailureCode.invalidEncoding,
+      'The text encoding could not be decoded.',
+      cause: error,
+    );
+  }
+}
+
+_DecodedText _validatedDecodedText(String text, String encodingName) {
+  final normalized = text.startsWith('\ufeff') ? text.substring(1) : text;
+  var disallowedControls = 0;
+  for (final codePoint in normalized.runes) {
+    if ((codePoint >= 0 && codePoint < 0x09) ||
+        codePoint == 0x0b ||
+        codePoint == 0x0c ||
+        (codePoint > 0x0d && codePoint < 0x20)) {
+      disallowedControls++;
+    }
+  }
+  final toleratedControls =
+      normalized.length < 200 ? 0 : normalized.length ~/ 100;
+  if (normalized.contains('\ufffd') || disallowedControls > toleratedControls) {
+    throw const DataBankIngestionException(
+      DataBankIngestionFailureCode.invalidEncoding,
+      'The source contains invalid text or binary control characters.',
+    );
+  }
+  return _DecodedText(normalized, encodingName);
+}
+
+Encoding? _declaredHtmlEncoding(Uint8List bytes) {
+  final prefix = latin1.decode(bytes.take(4096).toList());
+  final match = RegExp(
+    r'''<meta[^>]+charset\s*=\s*["']?\s*([^\s"'/>;]+)''',
+    caseSensitive: false,
+  ).firstMatch(prefix);
+  return match == null ? null : charset.Charset.getByName(match.group(1)!);
+}
+
+List<_StructuredHtmlPart> _parseStructuredHtml(String source) {
+  final document = html_parser.parse(source);
+  document
+      .querySelectorAll('script,style,noscript,template,svg,canvas')
+      .forEach((element) => element.remove());
+  document.querySelectorAll('br').forEach(
+        (element) => element.replaceWith(html_dom.Text('\n')),
+      );
+  final root = document.body ?? document.documentElement;
+  if (root == null) return const [];
+
+  const headings = {'h1', 'h2', 'h3', 'h4', 'h5', 'h6'};
+  const blocks = {
+    ...headings,
+    'p',
+    'li',
+    'blockquote',
+    'pre',
+    'td',
+    'th',
+    'dt',
+    'dd',
+  };
+  final parts = <_StructuredHtmlPart>[];
+  final content = <String>[];
+  String? currentTitle = _nonBlank(document.querySelector('title')?.text);
+  var currentTitleIsHeading = false;
+
+  void finishPart() {
+    if (content.isEmpty && !currentTitleIsHeading) return;
+    final blockText = content.where((value) => value.isNotEmpty).join('\n\n');
+    final text = _normalizeDocumentText(
+      [if (currentTitle != null) currentTitle, blockText]
+          .where((value) => value.isNotEmpty)
+          .join('\n\n'),
+    );
+    if (text.isNotEmpty) {
+      parts.add(_StructuredHtmlPart(title: currentTitle, text: text));
+    }
+    content.clear();
+  }
+
+  for (final element in root.querySelectorAll(blocks.join(','))) {
+    if (_isHiddenHtmlElement(element, root)) {
+      continue;
+    }
+    final name = element.localName;
+    if (name == null) continue;
+    final text = _normalizeDocumentText(element.text);
+    if (text.isEmpty) continue;
+    if (headings.contains(name)) {
+      finishPart();
+      currentTitle = _normalizeInlineText(text);
+      currentTitleIsHeading = true;
+      continue;
+    }
+    if (_hasSelectedBlockAncestor(element, root, blocks)) continue;
+    content.add(text);
+  }
+
+  if (content.isEmpty && parts.isEmpty) {
+    final fallback = _normalizeDocumentText(root.text);
+    if (fallback.isNotEmpty) content.add(fallback);
+  }
+  finishPart();
+  return parts;
+}
+
+bool _isHiddenHtmlElement(
+  html_dom.Element element,
+  html_dom.Element root,
+) {
+  html_dom.Element? candidate = element;
+  while (candidate != null) {
+    if (candidate.attributes.containsKey('hidden') ||
+        candidate.attributes['aria-hidden']?.toLowerCase() == 'true') {
+      return true;
+    }
+    if (candidate == root) break;
+    candidate = candidate.parent;
+  }
+  return false;
+}
+
+bool _hasSelectedBlockAncestor(
+  html_dom.Element element,
+  html_dom.Element root,
+  Set<String> blockNames,
+) {
+  html_dom.Element? ancestor = element.parent;
+  while (ancestor != null && ancestor != root) {
+    if (blockNames.contains(ancestor.localName)) return true;
+    ancestor = ancestor.parent;
+  }
+  return false;
+}
+
+Set<String> _readEncryptedEpubPaths(Map<String, ArchiveFile> entries) {
+  final entry = entries['META-INF/encryption.xml'];
+  if (entry == null) return const {};
+  final document = XmlDocument.parse(_archiveEntryText(entry));
+  return document.descendants
+      .whereType<XmlElement>()
+      .where((element) => element.name.local == 'CipherReference')
+      .map((element) => element.getAttribute('URI'))
+      .whereType<String>()
+      .map((value) => path.posix.normalize(Uri.decodeComponent(value)))
+      .toSet();
+}
+
+Map<String, String> _readEpubNavigationTitles(
+  Map<String, ArchiveFile> entries,
+  Map<String, _EpubManifestItem> manifest,
+) {
+  final titles = <String, String>{};
+  for (final item in manifest.values) {
+    if (item.properties.contains('nav')) {
+      final nav = entries[item.archivePath];
+      if (nav == null) continue;
+      final document = html_parser.parse(_archiveEntryText(nav));
+      for (final anchor in document.querySelectorAll('a[href]')) {
+        final href = anchor.attributes['href'];
+        final title = _nonBlank(_normalizeInlineText(anchor.text));
+        if (href == null || title == null) continue;
+        titles[_resolveEpubPath(path.posix.dirname(item.archivePath), href)] =
+            title;
+      }
+    }
+    if (item.mediaType == 'application/x-dtbncx+xml') {
+      final ncx = entries[item.archivePath];
+      if (ncx == null) continue;
+      final document = XmlDocument.parse(_archiveEntryText(ncx));
+      for (final point in document.descendants
+          .whereType<XmlElement>()
+          .where((element) => element.name.local == 'navPoint')) {
+        final source = point.descendants
+            .whereType<XmlElement>()
+            .where((element) => element.name.local == 'content')
+            .firstOrNull
+            ?.getAttribute('src');
+        final title = point.descendants
+            .whereType<XmlElement>()
+            .where((element) => element.name.local == 'navLabel')
+            .firstOrNull
+            ?.innerText;
+        final normalizedTitle = _nonBlank(_normalizeInlineText(title ?? ''));
+        if (source == null || normalizedTitle == null) continue;
+        titles[_resolveEpubPath(
+          path.posix.dirname(item.archivePath),
+          source,
+        )] = normalizedTitle;
+      }
+    }
+  }
+  return titles;
+}
+
+String _readArchiveText(
+  Map<String, ArchiveFile> entries,
+  String archivePath, {
+  required String description,
+}) {
+  final entry = entries[path.posix.normalize(archivePath)];
+  if (entry == null) {
+    throw DataBankIngestionException(
+      DataBankIngestionFailureCode.corruptDocument,
+      'The $description is missing.',
+    );
+  }
+  return _archiveEntryText(entry);
+}
+
+String _archiveEntryText(ArchiveFile entry) {
+  final content = entry.content;
+  if (content is! List<int>) {
+    throw const DataBankIngestionException(
+      DataBankIngestionFailureCode.corruptDocument,
+      'An EPUB entry could not be decoded.',
+    );
+  }
+  return utf8.decode(content, allowMalformed: false);
+}
+
+String _resolveEpubPath(String baseDirectory, String reference) {
+  final withoutFragment = reference.split('#').first;
+  return path.posix.normalize(
+    path.posix.join(baseDirectory, Uri.decodeComponent(withoutFragment)),
+  );
+}
+
+List<_ResolvedSegment> _resolveSegments(List<_SourceSegment> sourceSegments) {
+  final document = StringBuffer();
+  final resolved = <_ResolvedSegment>[];
+  for (final source in sourceSegments) {
+    final text = _normalizeDocumentText(source.text);
+    if (text.isEmpty) continue;
+    if (document.isNotEmpty) document.write('\n\n');
+    final start = document.length;
+    document.write(text);
+    final end = document.length;
+    resolved.add(
+      _ResolvedSegment(
+        source: source,
+        ordinal: resolved.length,
+        startOffset: start,
+        endOffset: end,
+        text: text,
+        documentText: '',
+      ),
+    );
+  }
+  final documentText = document.toString();
+  return resolved
+      .map((segment) => segment.withDocumentText(documentText))
+      .toList(growable: false);
+}
+
+String _normalizeDocumentText(String value) {
+  final lines = value
+      .replaceAll('\r\n', '\n')
+      .replaceAll('\r', '\n')
+      .replaceAll('\u00a0', ' ')
+      .replaceAll('\u0000', '')
+      .split('\n')
+      .map((line) => line.replaceAll(RegExp(r'[\t ]+'), ' ').trim())
+      .toList();
+  while (lines.isNotEmpty && lines.first.isEmpty) {
+    lines.removeAt(0);
+  }
+  while (lines.isNotEmpty && lines.last.isEmpty) {
+    lines.removeLast();
+  }
+  return lines.join('\n').replaceAll(RegExp(r'\n{3,}'), '\n\n');
+}
+
+String _normalizeInlineText(String value) {
+  return value.replaceAll(RegExp(r'\s+'), ' ').trim();
+}
+
+String? _nonBlank(String? value) {
+  if (value == null || value.trim().isEmpty) return null;
+  return value.trim();
+}
+
+bool _startsWith(Uint8List bytes, List<int> prefix) {
+  if (bytes.length < prefix.length) return false;
+  for (var index = 0; index < prefix.length; index++) {
+    if (bytes[index] != prefix[index]) return false;
+  }
+  return true;
+}
+
+int _skipWhitespace(String text, int start, int end) {
+  var cursor = start;
+  while (cursor < end && _isWhitespace(text.codeUnitAt(cursor))) {
+    cursor++;
+  }
+  return cursor;
+}
+
+int _trimEndWhitespace(String text, int start, int end) {
+  var cursor = end;
+  while (cursor > start && _isWhitespace(text.codeUnitAt(cursor - 1))) {
+    cursor--;
+  }
+  return cursor;
+}
+
+bool _isWhitespace(int codeUnit) {
+  return codeUnit == 0x20 ||
+      codeUnit == 0x09 ||
+      codeUnit == 0x0a ||
+      codeUnit == 0x0d;
+}
+
+final class _SourceType {
+  final DataBankDocumentFormat format;
+  final String mediaType;
+
+  const _SourceType(this.format, this.mediaType);
+}
+
+final class _StagedSource {
+  final int byteSize;
+  final String digest;
+
+  const _StagedSource({required this.byteSize, required this.digest});
+}
+
+final class _DecodedText {
+  final String text;
+  final String encodingName;
+
+  const _DecodedText(this.text, this.encodingName);
+}
+
+final class _ParsedDocument {
+  final List<_SourceSegment> segments;
+  final String? detectedEncoding;
+
+  const _ParsedDocument({required this.segments, this.detectedEncoding});
+}
+
+final class _SourceSegment {
+  final DataBankSectionKind kind;
+  final String? title;
+  final int? pageStart;
+  final int? pageEnd;
+  final String? chapter;
+  final String text;
+
+  const _SourceSegment({
+    required this.kind,
+    this.title,
+    this.pageStart,
+    this.pageEnd,
+    this.chapter,
+    required this.text,
+  });
+}
+
+final class _ResolvedSegment {
+  final _SourceSegment source;
+  final int ordinal;
+  final int startOffset;
+  final int endOffset;
+  final String text;
+  final String documentText;
+
+  const _ResolvedSegment({
+    required this.source,
+    required this.ordinal,
+    required this.startOffset,
+    required this.endOffset,
+    required this.text,
+    required this.documentText,
+  });
+
+  _ResolvedSegment withDocumentText(String value) {
+    return _ResolvedSegment(
+      source: source,
+      ordinal: ordinal,
+      startOffset: startOffset,
+      endOffset: endOffset,
+      text: text,
+      documentText: value,
+    );
+  }
+}
+
+final class _ChunkSpan {
+  final _ResolvedSegment segment;
+  final int startOffset;
+  final int endOffset;
+
+  const _ChunkSpan({
+    required this.segment,
+    required this.startOffset,
+    required this.endOffset,
+  });
+}
+
+final class _StructuredHtmlPart {
+  final String? title;
+  final String text;
+
+  const _StructuredHtmlPart({required this.title, required this.text});
+}
+
+final class _EpubManifestItem {
+  final String id;
+  final String archivePath;
+  final String mediaType;
+  final Set<String> properties;
+
+  const _EpubManifestItem({
+    required this.id,
+    required this.archivePath,
+    required this.mediaType,
+    required this.properties,
+  });
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -177,6 +177,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  charset:
+    dependency: "direct main"
+    description:
+      name: charset
+      sha256: "27802032a581e01ac565904ece8c8962564b1070690794f0072f6865958ce8b9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -234,13 +242,21 @@ packages:
     source: hosted
     version: "0.3.5+1"
   crypto:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: crypto
       sha256: c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf
       url: "https://pub.dev"
     source: hosted
     version: "3.0.7"
+  csslib:
+    dependency: transitive
+    description:
+      name: csslib
+      sha256: "09bad715f418841f976c77db72d5398dc1253c21fb9c0c7f0b0b985860b2d58e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.2"
   custom_lint_core:
     dependency: transitive
     description:
@@ -257,6 +273,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0+7.7.0"
+  dart_pubspec_licenses:
+    dependency: transitive
+    description:
+      name: dart_pubspec_licenses
+      sha256: fafb90d50c182dd3d4f441c6aea75baff1e5311aab2f6430d3f40f6e3a1f5885
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.12"
   dart_style:
     dependency: transitive
     description:
@@ -653,6 +677,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
+  html:
+    dependency: "direct main"
+    description:
+      name: html
+      sha256: "6d1264f2dffa1b1101c25a91dff0dc2daee4c18e87cd8538729773c073dbf602"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.15.6"
   http:
     dependency: transitive
     description:
@@ -854,7 +886,7 @@ packages:
     source: hosted
     version: "1.3.0"
   markdown:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: markdown
       sha256: "935e23e1ff3bc02d390bad4d4be001208ee92cc217cb5b5a6c19bc14aaa318c1"
@@ -988,6 +1020,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  pdfrx:
+    dependency: "direct main"
+    description:
+      name: pdfrx
+      sha256: "94c865686e7e15e93f2a5e3c0255f7d6c2ac39b2e5e82d62a0d278cb4b7d0d3b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.5"
   petitparser:
     dependency: transitive
     description:
@@ -1514,7 +1554,7 @@ packages:
     source: hosted
     version: "1.1.0"
   xml:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: xml
       sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.1.9+23
 
 environment:
   sdk: '>=3.2.0 <4.0.0'
-  flutter: '>=3.16.0'
+  flutter: '>=3.29.0'
 
 dependencies:
   flutter:
@@ -40,6 +40,14 @@ dependencies:
   
   # Archive Handling
   archive: ^3.4.9
+
+  # Local Document Parsing
+  charset: ^2.0.1
+  crypto: ^3.0.7
+  html: ^0.15.6
+  markdown: ^7.3.0
+  pdfrx: 1.3.5
+  xml: ^6.5.0
   
   # Code Generation (Runtime)
   freezed_annotation: ^2.4.1

--- a/test/data_bank_ingestion_end_to_end_test.dart
+++ b/test/data_bank_ingestion_end_to_end_test.dart
@@ -1,0 +1,493 @@
+import 'dart:io';
+
+import 'package:charset/charset.dart' as charset;
+import 'package:crypto/crypto.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:native_tavern/data/models/data_bank.dart';
+import 'package:native_tavern/domain/services/data_bank_ingestion_service.dart';
+import 'package:path/path.dart' as path;
+
+import 'support/data_bank_document_fixtures.dart';
+
+void main() {
+  late Directory sandbox;
+  late Directory inputDirectory;
+  late Directory stagingRoot;
+  late int stagingSequence;
+
+  setUp(() {
+    sandbox = Directory.systemTemp.createTempSync('data_bank_ingestion_test_');
+    inputDirectory = Directory(path.join(sandbox.path, 'input'))..createSync();
+    stagingRoot = Directory(path.join(sandbox.path, 'staging'))..createSync();
+    stagingSequence = 0;
+  });
+
+  tearDown(() {
+    if (sandbox.existsSync()) sandbox.deleteSync(recursive: true);
+  });
+
+  DataBankIngestionService createService({
+    DataBankPdfTextExtractor? pdfTextExtractor,
+  }) {
+    return DataBankIngestionService(
+      pdfTextExtractor: pdfTextExtractor ?? _FixturePdfTextExtractor(),
+      createStagingDirectory: () async {
+        final directory = Directory(
+          path.join(stagingRoot.path, 'stage-${stagingSequence++}'),
+        );
+        await directory.create();
+        return directory;
+      },
+    );
+  }
+
+  group('lightweight text ingestion', () {
+    test('detects GBK, hashes exact bytes, chunks paragraphs, and cleans up',
+        () async {
+      final sourceBytes = charset.gbk.encode(
+        '第一段包含中文。\r\n\r\n第二段也能正确解析。',
+      );
+      final source = File(path.join(inputDirectory.path, 'notes.txt'))
+        ..writeAsBytesSync(sourceBytes);
+      final progress = <DataBankIngestionProgress>[];
+
+      final result = await createService().ingest(
+        DataBankIngestionRequest(
+          sourceFile: source,
+          documentVersionId: 'version-gbk',
+          onProgress: progress.add,
+        ),
+      );
+
+      expect(result.detectedEncoding?.toLowerCase(), contains('gb'));
+      expect(result.normalizedText, '第一段包含中文。\n\n第二段也能正确解析。');
+      expect(result.contentHash.digest, sha256.convert(sourceBytes).toString());
+      expect(result.sections, hasLength(1));
+      expect(result.chunks, hasLength(2));
+      expect(
+        progress.map((event) => event.phase),
+        containsAllInOrder([
+          DataBankIngestionPhase.staging,
+          DataBankIngestionPhase.parsing,
+          DataBankIngestionPhase.chunking,
+          DataBankIngestionPhase.completed,
+        ]),
+      );
+      _expectExactProvenance(result);
+      _expectNoStagingArtifacts(stagingRoot);
+    });
+
+    test('decodes UTF-16 BOM content without leaking the marker', () async {
+      const text = 'UTF-16 notes';
+      final bytes = <int>[
+        0xff,
+        0xfe,
+        for (final codeUnit in text.codeUnits) ...[
+          codeUnit & 0xff,
+          codeUnit >> 8,
+        ],
+      ];
+      final source = File(path.join(inputDirectory.path, 'utf16.txt'))
+        ..writeAsBytesSync(bytes);
+
+      final result = await createService().ingest(
+        DataBankIngestionRequest(
+          sourceFile: source,
+          documentVersionId: 'version-utf16',
+        ),
+      );
+
+      expect(result.detectedEncoding, 'UTF-16');
+      expect(result.normalizedText, text);
+      expect(result.normalizedText, isNot(startsWith('\ufeff')));
+      _expectExactProvenance(result);
+      _expectNoStagingArtifacts(stagingRoot);
+    });
+
+    test('preserves Markdown headings while removing formatting markup',
+        () async {
+      final source = File(path.join(inputDirectory.path, 'guide.md'))
+        ..writeAsStringSync('''
+# Arrival
+
+The **train** arrived before dawn.
+
+## Safe Harbor
+
+Ships enter from the [eastern channel](https://example.test).
+''');
+
+      final result = await createService().ingest(
+        DataBankIngestionRequest(
+          sourceFile: source,
+          documentVersionId: 'version-markdown',
+          chunking: DataBankChunkingOptions(
+            strategy: DataBankChunkingStrategy.chapter,
+          ),
+        ),
+      );
+
+      expect(
+        result.sections.map((section) => section.title),
+        ['Arrival', 'Safe Harbor'],
+      );
+      expect(result.normalizedText, contains('The train arrived before dawn.'));
+      expect(result.normalizedText, isNot(contains('**')));
+      expect(result.normalizedText, isNot(contains('https://')));
+      expect(result.chunks, hasLength(2));
+      _expectExactProvenance(result);
+      _expectNoStagingArtifacts(stagingRoot);
+    });
+
+    test('uses declared HTML encoding and drops non-content elements',
+        () async {
+      const html = '''
+<!doctype html><html><head>
+<meta charset="windows-1252"><title>Price Guide</title>
+<style>.hidden { display: none; }</style></head><body>
+<h1>Visible offers</h1><p>Entry price: €10 &amp; tax.</p>
+<script>secretPrompt()</script>
+<div hidden><p>ancestorSecret()</p></div>
+<h2>Terms</h2><p>No hidden fees.</p>
+</body></html>
+''';
+      final source = File(path.join(inputDirectory.path, 'prices.html'))
+        ..writeAsBytesSync(charset.windows1252.encode(html));
+
+      final result = await createService().ingest(
+        DataBankIngestionRequest(
+          sourceFile: source,
+          documentVersionId: 'version-html',
+        ),
+      );
+
+      expect(result.detectedEncoding?.toLowerCase(), contains('1252'));
+      expect(result.sections.map((section) => section.title), [
+        'Visible offers',
+        'Terms',
+      ]);
+      expect(result.normalizedText, contains('Entry price: €10 & tax.'));
+      expect(result.normalizedText, isNot(contains('secretPrompt')));
+      expect(result.normalizedText, isNot(contains('ancestorSecret')));
+      expect(result.normalizedText, isNot(contains('.hidden')));
+      _expectExactProvenance(result);
+      _expectNoStagingArtifacts(stagingRoot);
+    });
+  });
+
+  group('PDF and EPUB ingestion', () {
+    test('preserves PDF page numbers through the complete ingestion pipeline',
+        () async {
+      final pdfBytes = buildPdfFixture(['First PDF page', 'Second PDF page']);
+      final extractor = _FixturePdfTextExtractor(
+        expectedBytes: pdfBytes,
+        pages: const [
+          DataBankPdfPage(pageNumber: 1, text: 'First PDF page'),
+          DataBankPdfPage(pageNumber: 2, text: 'Second PDF page'),
+        ],
+      );
+      final source = File(path.join(inputDirectory.path, 'field-guide.pdf'))
+        ..writeAsBytesSync(pdfBytes);
+
+      final result = await createService(pdfTextExtractor: extractor).ingest(
+        DataBankIngestionRequest(
+          sourceFile: source,
+          documentVersionId: 'version-pdf',
+          chunking: DataBankChunkingOptions(
+            strategy: DataBankChunkingStrategy.fixedLength,
+            maxCharacters: 8,
+          ),
+        ),
+      );
+
+      expect(extractor.called, isTrue);
+      expect(result.mediaType, 'application/pdf');
+      expect(
+          result.sections.map((section) => section.locator.pageStart), [1, 2]);
+      expect(
+        result.chunks.where((chunk) => chunk.locator.pageStart == 1),
+        isNotEmpty,
+      );
+      expect(result.chunks.every((chunk) => chunk.text.length <= 8), isTrue);
+      _expectExactProvenance(result);
+      _expectNoStagingArtifacts(stagingRoot);
+    });
+
+    test('imports EPUB spine order as chapter provenance', () async {
+      final bytes = buildEpubFixture();
+      final source = File(path.join(inputDirectory.path, 'fixture.epub'))
+        ..writeAsBytesSync(bytes);
+
+      final result = await createService().ingest(
+        DataBankIngestionRequest(
+          sourceFile: source,
+          documentVersionId: 'version-epub',
+          chunking: DataBankChunkingOptions(
+            strategy: DataBankChunkingStrategy.chapter,
+          ),
+        ),
+      );
+
+      expect(result.mediaType, 'application/epub+zip');
+      expect(result.sections.map((section) => section.kind), [
+        DataBankSectionKind.chapter,
+        DataBankSectionKind.chapter,
+      ]);
+      expect(result.sections.map((section) => section.title), [
+        'Arrival',
+        'Safe Harbor',
+      ]);
+      expect(result.chunks.map((chunk) => chunk.locator.chapter), [
+        'Arrival',
+        'Safe Harbor',
+      ]);
+      expect(result.normalizedText, contains('eastern channel'));
+      _expectExactProvenance(result);
+      _expectNoStagingArtifacts(stagingRoot);
+    });
+  });
+
+  group('identity and failure behavior', () {
+    test('stable SHA256 distinguishes duplicate content from a new version',
+        () async {
+      final firstFile = File(path.join(inputDirectory.path, 'first.txt'))
+        ..writeAsStringSync('Stable content');
+      final duplicateFile =
+          File(path.join(inputDirectory.path, 'duplicate.txt'))
+            ..writeAsStringSync('Stable content');
+      final changedFile = File(path.join(inputDirectory.path, 'changed.txt'))
+        ..writeAsStringSync('Changed content');
+      final service = createService();
+
+      final first = await service.ingest(
+        DataBankIngestionRequest(
+          sourceFile: firstFile,
+          documentVersionId: 'version-1',
+        ),
+      );
+      final duplicate = await service.ingest(
+        DataBankIngestionRequest(
+          sourceFile: duplicateFile,
+          documentVersionId: 'version-2',
+        ),
+      );
+      final changed = await service.ingest(
+        DataBankIngestionRequest(
+          sourceFile: changedFile,
+          documentVersionId: 'version-3',
+        ),
+      );
+
+      expect(
+        duplicate.compareContent(first.contentHash),
+        DataBankContentComparison.identical,
+      );
+      expect(
+        changed.compareContent(first.contentHash),
+        DataBankContentComparison.changed,
+      );
+      _expectNoStagingArtifacts(stagingRoot);
+    });
+
+    test(
+        'empty, damaged, encrypted, and unsupported inputs return typed errors',
+        () async {
+      final empty = File(path.join(inputDirectory.path, 'empty.txt'))
+        ..writeAsStringSync(' \r\n\t');
+      final damaged = File(path.join(inputDirectory.path, 'damaged.epub'))
+        ..writeAsBytesSync([0x50, 0x4b, 0x03]);
+      final encrypted = File(path.join(inputDirectory.path, 'encrypted.epub'))
+        ..writeAsBytesSync(buildEpubFixture(encryptSecondChapter: true));
+      final unsupported = File(path.join(inputDirectory.path, 'unknown.bin'))
+        ..writeAsBytesSync([1, 2, 3]);
+      final binaryText = File(path.join(inputDirectory.path, 'binary.txt'))
+        ..writeAsBytesSync([0, 1, 2, 3, 0xff]);
+      final service = createService();
+
+      await _expectFailure(
+        service.ingest(
+          DataBankIngestionRequest(
+            sourceFile: binaryText,
+            documentVersionId: 'version-binary',
+          ),
+        ),
+        DataBankIngestionFailureCode.invalidEncoding,
+      );
+      await _expectFailure(
+        service.ingest(
+          DataBankIngestionRequest(
+            sourceFile: empty,
+            documentVersionId: 'version-empty',
+          ),
+        ),
+        DataBankIngestionFailureCode.emptyDocument,
+      );
+      await _expectFailure(
+        service.ingest(
+          DataBankIngestionRequest(
+            sourceFile: damaged,
+            documentVersionId: 'version-damaged',
+          ),
+        ),
+        DataBankIngestionFailureCode.corruptDocument,
+      );
+      await _expectFailure(
+        service.ingest(
+          DataBankIngestionRequest(
+            sourceFile: encrypted,
+            documentVersionId: 'version-encrypted',
+          ),
+        ),
+        DataBankIngestionFailureCode.encryptedDocument,
+      );
+      await _expectFailure(
+        service.ingest(
+          DataBankIngestionRequest(
+            sourceFile: unsupported,
+            documentVersionId: 'version-unsupported',
+          ),
+        ),
+        DataBankIngestionFailureCode.unsupportedFormat,
+      );
+      _expectNoStagingArtifacts(stagingRoot);
+    });
+
+    test('PDF password failures retain the encrypted-document error code',
+        () async {
+      final source = File(path.join(inputDirectory.path, 'locked.pdf'))
+        ..writeAsBytesSync(buildPdfFixture(['Locked']));
+
+      await _expectFailure(
+        createService(
+          pdfTextExtractor: const _ThrowingPdfTextExtractor(
+            DataBankIngestionFailureCode.encryptedDocument,
+          ),
+        ).ingest(
+          DataBankIngestionRequest(
+            sourceFile: source,
+            documentVersionId: 'version-locked-pdf',
+          ),
+        ),
+        DataBankIngestionFailureCode.encryptedDocument,
+      );
+      _expectNoStagingArtifacts(stagingRoot);
+    });
+
+    test('large-file cancellation returns no result and removes staging files',
+        () async {
+      final source = File(path.join(inputDirectory.path, 'large.txt'))
+        ..writeAsBytesSync(List<int>.filled(1024 * 1024, 0x61));
+      final token = DataBankCancellationToken();
+
+      await _expectFailure(
+        createService().ingest(
+          DataBankIngestionRequest(
+            sourceFile: source,
+            documentVersionId: 'version-cancelled',
+            cancellationToken: token,
+            onProgress: (progress) {
+              if (progress.phase == DataBankIngestionPhase.staging &&
+                  progress.completedUnits > 0) {
+                token.cancel();
+              }
+            },
+          ),
+        ),
+        DataBankIngestionFailureCode.cancelled,
+      );
+      _expectNoStagingArtifacts(stagingRoot);
+    });
+  });
+}
+
+void _expectExactProvenance(DataBankIngestionResult result) {
+  final sectionIds = result.sections.map((section) => section.id).toSet();
+  for (final section in result.sections) {
+    final locator = section.locator;
+    expect(locator.documentVersionId, section.documentVersionId);
+    expect(locator.sectionId, section.id);
+    expect(
+      result.normalizedText.substring(
+        locator.startOffset!,
+        locator.endOffset!,
+      ),
+      isNotEmpty,
+    );
+  }
+  for (final chunk in result.chunks) {
+    final locator = chunk.locator;
+    expect(sectionIds, contains(chunk.sectionId));
+    expect(locator.documentVersionId, chunk.documentVersionId);
+    expect(locator.sectionId, chunk.sectionId);
+    expect(
+      result.normalizedText.substring(
+        locator.startOffset!,
+        locator.endOffset!,
+      ),
+      chunk.text,
+    );
+  }
+}
+
+void _expectNoStagingArtifacts(Directory stagingRoot) {
+  expect(stagingRoot.listSync(), isEmpty);
+}
+
+Future<void> _expectFailure(
+  Future<DataBankIngestionResult> future,
+  DataBankIngestionFailureCode code,
+) async {
+  await expectLater(
+    future,
+    throwsA(
+      isA<DataBankIngestionException>()
+          .having((error) => error.code, 'code', code),
+    ),
+  );
+}
+
+final class _FixturePdfTextExtractor implements DataBankPdfTextExtractor {
+  final List<int>? expectedBytes;
+  final List<DataBankPdfPage> pages;
+  bool called = false;
+
+  _FixturePdfTextExtractor({
+    this.expectedBytes,
+    this.pages = const [
+      DataBankPdfPage(pageNumber: 1, text: 'Fixture PDF text'),
+    ],
+  });
+
+  @override
+  Future<List<DataBankPdfPage>> extractPages(
+    File file, {
+    required DataBankCancellationToken cancellationToken,
+    required void Function(int completedPages, int totalPages) onProgress,
+  }) async {
+    called = true;
+    cancellationToken.throwIfCancelled();
+    if (expectedBytes != null) {
+      expect(await file.readAsBytes(), expectedBytes);
+    }
+    for (var index = 0; index < pages.length; index++) {
+      onProgress(index + 1, pages.length);
+      cancellationToken.throwIfCancelled();
+    }
+    return pages;
+  }
+}
+
+final class _ThrowingPdfTextExtractor implements DataBankPdfTextExtractor {
+  final DataBankIngestionFailureCode code;
+
+  const _ThrowingPdfTextExtractor(this.code);
+
+  @override
+  Future<List<DataBankPdfPage>> extractPages(
+    File file, {
+    required DataBankCancellationToken cancellationToken,
+    required void Function(int completedPages, int totalPages) onProgress,
+  }) {
+    throw DataBankIngestionException(code, 'Fixture PDF failure.');
+  }
+}

--- a/test/data_bank_pdf_native_integration_test.dart
+++ b/test/data_bank_pdf_native_integration_test.dart
@@ -1,0 +1,115 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:native_tavern/domain/services/data_bank_ingestion_service.dart';
+import 'package:path/path.dart' as path;
+import 'package:pdfrx/pdfrx.dart';
+
+import 'support/data_bank_document_fixtures.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  final pdfiumModulePath = Platform.environment['PDFIUM_MODULE_PATH'];
+  final skipWithoutPdfium = pdfiumModulePath == null
+      ? 'Set PDFIUM_MODULE_PATH to run the native PDFium integration test.'
+      : false;
+
+  setUpAll(() {
+    if (pdfiumModulePath != null) {
+      Pdfrx.pdfiumModulePath = pdfiumModulePath;
+    }
+  });
+
+  test(
+    'real PDFium ingestion extracts text with page provenance',
+    () async {
+      final sandbox = Directory.systemTemp.createTempSync('data_bank_pdf_e2e_');
+      final stagingRoot = Directory(path.join(sandbox.path, 'staging'))
+        ..createSync();
+      var stageIndex = 0;
+      try {
+        final source = File(path.join(sandbox.path, 'two-pages.pdf'))
+          ..writeAsBytesSync(
+            buildPdfFixture(
+                ['First native PDF page', 'Second native PDF page']),
+          );
+        final service = DataBankIngestionService(
+          createStagingDirectory: () async {
+            final directory = Directory(
+              path.join(stagingRoot.path, 'stage-${stageIndex++}'),
+            );
+            await directory.create();
+            return directory;
+          },
+        );
+
+        final result = await service.ingest(
+          DataBankIngestionRequest(
+            sourceFile: source,
+            documentVersionId: 'version-real-pdf',
+          ),
+        );
+
+        expect(result.normalizedText, contains('First native PDF page'));
+        expect(result.normalizedText, contains('Second native PDF page'));
+        expect(
+          result.sections.map((section) => section.locator.pageStart),
+          [1, 2],
+        );
+        for (final chunk in result.chunks) {
+          expect(
+            result.normalizedText.substring(
+              chunk.locator.startOffset!,
+              chunk.locator.endOffset!,
+            ),
+            chunk.text,
+          );
+        }
+        expect(stagingRoot.listSync(), isEmpty);
+      } finally {
+        if (sandbox.existsSync()) sandbox.deleteSync(recursive: true);
+      }
+    },
+    skip: skipWithoutPdfium,
+  );
+
+  test(
+    'real PDFium rejects a damaged PDF without staging residue',
+    () async {
+      final sandbox = Directory.systemTemp.createTempSync('data_bank_pdf_e2e_');
+      final stagingRoot = Directory(path.join(sandbox.path, 'staging'))
+        ..createSync();
+      try {
+        final source = File(path.join(sandbox.path, 'damaged.pdf'))
+          ..writeAsStringSync('%PDF-1.4\nnot a valid document');
+        final service = DataBankIngestionService(
+          createStagingDirectory: () async {
+            final directory = Directory(path.join(stagingRoot.path, 'stage'));
+            await directory.create();
+            return directory;
+          },
+        );
+
+        await expectLater(
+          service.ingest(
+            DataBankIngestionRequest(
+              sourceFile: source,
+              documentVersionId: 'version-damaged-pdf',
+            ),
+          ),
+          throwsA(
+            isA<DataBankIngestionException>().having(
+              (error) => error.code,
+              'code',
+              DataBankIngestionFailureCode.corruptDocument,
+            ),
+          ),
+        );
+        expect(stagingRoot.listSync(), isEmpty);
+      } finally {
+        if (sandbox.existsSync()) sandbox.deleteSync(recursive: true);
+      }
+    },
+    skip: skipWithoutPdfium,
+  );
+}

--- a/test/support/data_bank_document_fixtures.dart
+++ b/test/support/data_bank_document_fixtures.dart
@@ -1,0 +1,141 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:archive/archive.dart';
+
+Uint8List buildPdfFixture(List<String> pageTexts) {
+  if (pageTexts.isEmpty) {
+    throw ArgumentError.value(pageTexts, 'pageTexts', 'must not be empty');
+  }
+  if (pageTexts.any((text) => text.codeUnits.any((unit) => unit > 0x7f))) {
+    throw ArgumentError('The minimal PDF fixture supports ASCII text only.');
+  }
+
+  final pageIds = [
+    for (var index = 0; index < pageTexts.length; index++) 4 + index * 2
+  ];
+  final objects = <String>[
+    '<< /Type /Catalog /Pages 2 0 R >>',
+    '<< /Type /Pages /Kids [${pageIds.map((id) => '$id 0 R').join(' ')}] '
+        '/Count ${pageTexts.length} >>',
+    '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>',
+  ];
+
+  for (var index = 0; index < pageTexts.length; index++) {
+    final contentId = pageIds[index] + 1;
+    final escapedText = pageTexts[index]
+        .replaceAll(r'\', r'\\')
+        .replaceAll('(', r'\(')
+        .replaceAll(')', r'\)');
+    final stream = 'BT /F1 18 Tf 72 720 Td ($escapedText) Tj ET';
+    objects.add(
+      '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] '
+      '/Resources << /Font << /F1 3 0 R >> >> '
+      '/Contents $contentId 0 R >>',
+    );
+    objects.add('<< /Length ${stream.length} >>\nstream\n$stream\nendstream');
+  }
+
+  final output = StringBuffer('%PDF-1.4\n');
+  final offsets = <int>[0];
+  for (var index = 0; index < objects.length; index++) {
+    offsets.add(output.length);
+    output
+      ..writeln('${index + 1} 0 obj')
+      ..writeln(objects[index])
+      ..writeln('endobj');
+  }
+  final xrefOffset = output.length;
+  output
+    ..writeln('xref')
+    ..writeln('0 ${objects.length + 1}')
+    ..writeln('0000000000 65535 f ');
+  for (final offset in offsets.skip(1)) {
+    output.writeln('${offset.toString().padLeft(10, '0')} 00000 n ');
+  }
+  output
+    ..writeln('trailer')
+    ..writeln('<< /Size ${objects.length + 1} /Root 1 0 R >>')
+    ..writeln('startxref')
+    ..writeln(xrefOffset)
+    ..writeln('%%EOF');
+  return Uint8List.fromList(ascii.encode(output.toString()));
+}
+
+Uint8List buildEpubFixture({bool encryptSecondChapter = false}) {
+  final files = <String, String>{
+    'META-INF/container.xml': '''
+<?xml version="1.0"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="OEBPS/package.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>
+''',
+    'OEBPS/package.opf': '''
+<?xml version="1.0" encoding="UTF-8"?>
+<package version="3.0" xmlns="http://www.idpf.org/2007/opf" unique-identifier="book-id">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:identifier id="book-id">fixture-book</dc:identifier>
+    <dc:title>Fixture Book</dc:title>
+  </metadata>
+  <manifest>
+    <item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+    <item id="chapter-one" href="text/chapter-one.xhtml" media-type="application/xhtml+xml"/>
+    <item id="chapter-two" href="text/chapter-two.xhtml" media-type="application/xhtml+xml"/>
+  </manifest>
+  <spine>
+    <itemref idref="chapter-one"/>
+    <itemref idref="chapter-two"/>
+  </spine>
+</package>
+''',
+    'OEBPS/nav.xhtml': '''
+<!doctype html>
+<html xmlns="http://www.w3.org/1999/xhtml"><body>
+  <nav><ol>
+    <li><a href="text/chapter-one.xhtml">Arrival</a></li>
+    <li><a href="text/chapter-two.xhtml">Safe Harbor</a></li>
+  </ol></nav>
+</body></html>
+''',
+    'OEBPS/text/chapter-one.xhtml': '''
+<!doctype html>
+<html xmlns="http://www.w3.org/1999/xhtml"><body>
+  <h1>Arrival</h1><p>The train arrived before dawn.</p>
+</body></html>
+''',
+    'OEBPS/text/chapter-two.xhtml': '''
+<!doctype html>
+<html xmlns="http://www.w3.org/1999/xhtml"><body>
+  <h1>Safe Harbor</h1><p>Ships enter from the eastern channel.</p>
+</body></html>
+''',
+    if (encryptSecondChapter)
+      'META-INF/encryption.xml': '''
+<?xml version="1.0"?>
+<encryption xmlns="urn:oasis:names:tc:opendocument:xmlns:container"
+    xmlns:enc="http://www.w3.org/2001/04/xmlenc#">
+  <enc:EncryptedData>
+    <enc:CipherData>
+      <enc:CipherReference URI="OEBPS/text/chapter-two.xhtml"/>
+    </enc:CipherData>
+  </enc:EncryptedData>
+</encryption>
+''',
+  };
+
+  final archive = Archive()
+    ..addFile(
+      ArchiveFile.noCompress(
+        'mimetype',
+        'application/epub+zip'.length,
+        utf8.encode('application/epub+zip'),
+      ),
+    );
+  for (final entry in files.entries) {
+    final bytes = utf8.encode(entry.value.trim());
+    archive.addFile(ArchiveFile(entry.key, bytes.length, bytes));
+  }
+  return Uint8List.fromList(ZipEncoder().encode(archive)!);
+}


### PR DESCRIPTION
## Summary

- F02: parse TXT, Markdown, and HTML with charset detection, binary rejection, cleanup, and preserved heading structure
- F03: extract PDF text with page provenance and EPUB content by reading the OPF spine; classify encrypted/corrupt inputs and support progress, cancellation, and staging cleanup
- F04: chunk by fixed length, paragraph, or section while retaining version/section/page/chapter/offset provenance; fingerprint original bytes with SHA-256 for duplicate/change detection

## Verification

- flutter analyze lib/domain/services/data_bank_ingestion_service.dart test/data_bank_ingestion_end_to_end_test.dart test/data_bank_pdf_native_integration_test.dart
- flutter test test/data_bank_ingestion_end_to_end_test.dart (10 passed)
- PDFIUM_MODULE_PATH=<official chromium/7202 arm64 PDFium dylib> flutter test test/data_bank_pdf_native_integration_test.dart (2 passed)
- flutter test (223 passed, 2 skipped)

Closes #29