### PR TITLE
feat(rpg): add deterministic state engine

### DIFF
--- a/lib/data/models/rpg/rpg_validation.dart
+++ b/lib/data/models/rpg/rpg_validation.dart
@@ -289,6 +289,44 @@ class RpgScenarioValidator {
     return RpgValidationResult(List.unmodifiable(collector.issues));
   }
 
+  /// Validates a resumed or newly produced runtime state against its scenario.
+  RpgValidationResult validateRuntimeState(
+    RpgScenario scenario,
+    RpgRuntimeState state,
+  ) {
+    final collector = _ValidationCollector();
+    final attributeIds = scenario.attributes.map((item) => item.id).toSet();
+    final itemIds = scenario.items.map((item) => item.id).toSet();
+    final actorIds = scenario.actors.map((item) => item.id).toSet();
+    final locationIds = scenario.locations.map((item) => item.id).toSet();
+    final questIds = scenario.quests.map((item) => item.id).toSet();
+    final actionIds = scenario.actions.map((item) => item.id).toSet();
+    final questStages = <String, Set<String>>{
+      for (final quest in scenario.quests)
+        quest.id: quest.stages.map((stage) => stage.id).toSet(),
+    };
+    final questObjectives = <String, Set<String>>{
+      for (final quest in scenario.quests)
+        quest.id: quest.stages.expand((stage) => stage.objectiveIds).toSet(),
+    };
+
+    _validateRuntimeState(
+      collector,
+      state,
+      'state',
+      scenario: scenario,
+      attributeIds: attributeIds,
+      itemIds: itemIds,
+      actorIds: actorIds,
+      locationIds: locationIds,
+      questIds: questIds,
+      actionIds: actionIds,
+      questStages: questStages,
+      questObjectives: questObjectives,
+    );
+    return RpgValidationResult(List.unmodifiable(collector.issues));
+  }
+
   RpgValidationResult validateSnapshot(
     RpgScenario scenario,
     RpgStateSnapshot snapshot,

--- a/lib/data/repositories/drift_rpg_persistence_repository.dart
+++ b/lib/data/repositories/drift_rpg_persistence_repository.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:collection/collection.dart';
 import 'package:drift/drift.dart';
 import 'package:native_tavern/data/database/database.dart';
 import 'package:native_tavern/data/models/rpg/rpg.dart';
@@ -29,20 +30,42 @@ class DriftRpgPersistenceRepository implements RpgPersistenceRepository {
   @override
   Future<void> saveScenario(RpgScenario scenario) async {
     const RpgScenarioValidator().validate(scenario).throwIfInvalid();
-    final existing = await (_database.select(_database.rpgScenarios)
-          ..where((table) => table.id.equals(scenario.metadata.id)))
-        .getSingleOrNull();
-    final now = DateTime.now().toUtc();
-    await _database.into(_database.rpgScenarios).insertOnConflictUpdate(
-          RpgScenariosCompanion.insert(
-            id: scenario.metadata.id,
-            version: scenario.metadata.version,
-            contractSchemaVersion: scenario.schemaVersion,
-            scenarioJson: jsonEncode(scenario.toJson()),
-            createdAt: existing?.createdAt ?? now,
-            updatedAt: now,
-          ),
-        );
+    final encoded = jsonEncode(scenario.toJson());
+    await _database.transaction(() async {
+      final existing = await (_database.select(_database.rpgScenarios)
+            ..where((table) => table.id.equals(scenario.metadata.id)))
+          .getSingleOrNull();
+      if (existing != null && existing.scenarioJson != encoded) {
+        final snapshot = await (_database.select(_database.rpgStateSnapshots)
+              ..where(
+                (table) => table.scenarioId.equals(scenario.metadata.id),
+              )
+              ..limit(1))
+            .getSingleOrNull();
+        final chatState = await (_database.select(_database.rpgChatStates)
+              ..where(
+                (table) => table.scenarioId.equals(scenario.metadata.id),
+              )
+              ..limit(1))
+            .getSingleOrNull();
+        if (snapshot != null || chatState != null) {
+          throw StateError(
+            'Cannot replace an RPG scenario with persisted sessions.',
+          );
+        }
+      }
+      final now = DateTime.now().toUtc();
+      await _database.into(_database.rpgScenarios).insertOnConflictUpdate(
+            RpgScenariosCompanion.insert(
+              id: scenario.metadata.id,
+              version: scenario.metadata.version,
+              contractSchemaVersion: scenario.schemaVersion,
+              scenarioJson: encoded,
+              createdAt: existing?.createdAt ?? now,
+              updatedAt: now,
+            ),
+          );
+    });
   }
 
   @override
@@ -77,6 +100,26 @@ class DriftRpgPersistenceRepository implements RpgPersistenceRepository {
     required String scenarioId,
     required RpgRuntimeState state,
     String? currentSnapshotId,
+    String? expectedCurrentSnapshotId,
+    required DateTime updatedAt,
+  }) =>
+      _database.transaction(
+        () => _saveCurrentStateValidated(
+          chatId: chatId,
+          scenarioId: scenarioId,
+          state: state,
+          currentSnapshotId: currentSnapshotId,
+          expectedCurrentSnapshotId: expectedCurrentSnapshotId,
+          updatedAt: updatedAt,
+        ),
+      );
+
+  Future<void> _saveCurrentStateValidated({
+    required String chatId,
+    required String scenarioId,
+    required RpgRuntimeState state,
+    required String? currentSnapshotId,
+    required String? expectedCurrentSnapshotId,
     required DateTime updatedAt,
   }) async {
     if (state.scenarioId != scenarioId) {
@@ -86,24 +129,36 @@ class DriftRpgPersistenceRepository implements RpgPersistenceRepository {
     if (state.scenarioVersion != scenario.metadata.version) {
       throw ArgumentError('Runtime state scenario version is not current.');
     }
+    const RpgScenarioValidator()
+        .validateRuntimeState(scenario, state)
+        .throwIfInvalid();
     if (currentSnapshotId != null) {
       final snapshot = await _requireSnapshot(currentSnapshotId);
       if (snapshot.metadata.scenarioId != scenarioId ||
           snapshot.metadata.scenarioVersion != state.scenarioVersion) {
         throw ArgumentError('Current snapshot belongs to another scenario.');
       }
+      if (!const DeepCollectionEquality().equals(
+        snapshot.state.toJson(),
+        state.toJson(),
+      )) {
+        throw ArgumentError('Current state must match its current snapshot.');
+      }
+    }
+    if (expectedCurrentSnapshotId != null) {
+      await _requireCurrentSnapshot(
+        chatId,
+        expectedCurrentSnapshotId,
+      );
     }
 
-    await _database.into(_database.rpgChatStates).insertOnConflictUpdate(
-          RpgChatStatesCompanion.insert(
-            chatId: chatId,
-            scenarioId: scenarioId,
-            currentSnapshotId: Value(currentSnapshotId),
-            turn: state.turn,
-            stateJson: jsonEncode(state.toJson()),
-            updatedAt: updatedAt,
-          ),
-        );
+    await _writeCurrentState(
+      chatId: chatId,
+      scenarioId: scenarioId,
+      state: state,
+      currentSnapshotId: currentSnapshotId,
+      updatedAt: updatedAt,
+    );
   }
 
   @override
@@ -134,7 +189,45 @@ class DriftRpgPersistenceRepository implements RpgPersistenceRepository {
   }
 
   @override
-  Future<void> saveSnapshot(RpgStateSnapshot snapshot) async {
+  Future<void> saveSnapshot(RpgStateSnapshot snapshot) =>
+      _database.transaction(() async {
+        await _validateSnapshotForInsert(snapshot);
+        await _writeSnapshot(snapshot);
+      });
+
+  @override
+  Future<void> commitSnapshotAndCurrentState({
+    required String chatId,
+    required RpgStateSnapshot snapshot,
+    required String? expectedCurrentSnapshotId,
+    required DateTime updatedAt,
+  }) async {
+    await _database.transaction(() async {
+      final current = await (_database.select(_database.rpgChatStates)
+            ..where((table) => table.chatId.equals(chatId)))
+          .getSingleOrNull();
+      if (expectedCurrentSnapshotId == null) {
+        if (current != null) {
+          throw StateError('RPG session for chat $chatId already exists.');
+        }
+      } else if (current?.currentSnapshotId != expectedCurrentSnapshotId) {
+        throw StateError(
+          'RPG session for chat $chatId changed before commit.',
+        );
+      }
+      await _validateSnapshotForInsert(snapshot);
+      await _writeSnapshot(snapshot);
+      await _writeCurrentState(
+        chatId: chatId,
+        scenarioId: snapshot.metadata.scenarioId,
+        state: snapshot.state,
+        currentSnapshotId: snapshot.metadata.id,
+        updatedAt: updatedAt,
+      );
+    });
+  }
+
+  Future<void> _validateSnapshotForInsert(RpgStateSnapshot snapshot) async {
     final metadata = snapshot.metadata;
     final scenario = await _requireScenario(metadata.scenarioId);
     if (metadata.scenarioVersion != scenario.metadata.version ||
@@ -145,17 +238,48 @@ class DriftRpgPersistenceRepository implements RpgPersistenceRepository {
     const RpgScenarioValidator()
         .validateSnapshot(scenario, snapshot)
         .throwIfInvalid();
+    const RpgScenarioValidator()
+        .validateRuntimeState(scenario, snapshot.state)
+        .throwIfInvalid();
+
+    final existing = await getSnapshot(metadata.id);
+    if (existing != null) {
+      throw StateError('RPG snapshot ${metadata.id} already exists.');
+    }
 
     if (metadata.parentSnapshotId != null) {
       final parent = await _requireSnapshot(metadata.parentSnapshotId!);
       if (parent.metadata.scenarioId != metadata.scenarioId ||
-          parent.metadata.branchId != metadata.branchId ||
+          parent.metadata.scenarioVersion != metadata.scenarioVersion ||
           parent.metadata.turn > metadata.turn) {
         throw ArgumentError('Snapshot parent lineage is invalid.');
       }
+      if (parent.metadata.branchId != metadata.branchId) {
+        final existingBranch = await listSnapshots(
+          scenarioId: metadata.scenarioId,
+          branchId: metadata.branchId,
+        );
+        if (existingBranch.isNotEmpty ||
+            parent.metadata.turn != metadata.turn) {
+          throw ArgumentError(
+            'A cross-branch parent is only valid for a new branch root.',
+          );
+        }
+      }
+    } else {
+      final existingBranch = await listSnapshots(
+        scenarioId: metadata.scenarioId,
+        branchId: metadata.branchId,
+      );
+      if (existingBranch.isNotEmpty) {
+        throw ArgumentError('Snapshot branch already has a root.');
+      }
     }
+  }
 
-    await _database.into(_database.rpgStateSnapshots).insertOnConflictUpdate(
+  Future<void> _writeSnapshot(RpgStateSnapshot snapshot) async {
+    final metadata = snapshot.metadata;
+    await _database.into(_database.rpgStateSnapshots).insert(
           RpgStateSnapshotsCompanion.insert(
             id: metadata.id,
             scenarioId: metadata.scenarioId,
@@ -168,6 +292,25 @@ class DriftRpgPersistenceRepository implements RpgPersistenceRepository {
             createdAt: metadata.createdAt,
             stateHash: Value(metadata.stateHash),
             snapshotJson: jsonEncode(snapshot.toJson()),
+          ),
+        );
+  }
+
+  Future<void> _writeCurrentState({
+    required String chatId,
+    required String scenarioId,
+    required RpgRuntimeState state,
+    required String? currentSnapshotId,
+    required DateTime updatedAt,
+  }) async {
+    await _database.into(_database.rpgChatStates).insertOnConflictUpdate(
+          RpgChatStatesCompanion.insert(
+            chatId: chatId,
+            scenarioId: scenarioId,
+            currentSnapshotId: Value(currentSnapshotId),
+            turn: state.turn,
+            stateJson: jsonEncode(state.toJson()),
+            updatedAt: updatedAt,
           ),
         );
   }
@@ -186,6 +329,18 @@ class DriftRpgPersistenceRepository implements RpgPersistenceRepository {
       throw StateError('RPG snapshot $snapshotId does not exist.');
     }
     return snapshot;
+  }
+
+  Future<void> _requireCurrentSnapshot(
+    String chatId,
+    String expectedSnapshotId,
+  ) async {
+    final current = await (_database.select(_database.rpgChatStates)
+          ..where((table) => table.chatId.equals(chatId)))
+        .getSingleOrNull();
+    if (current?.currentSnapshotId != expectedSnapshotId) {
+      throw StateError('RPG session for chat $chatId changed before update.');
+    }
   }
 }
 

--- a/lib/domain/repositories/rpg_persistence_repository.dart
+++ b/lib/domain/repositories/rpg_persistence_repository.dart
@@ -18,6 +18,7 @@ abstract interface class RpgPersistenceRepository {
     required String scenarioId,
     required RpgRuntimeState state,
     String? currentSnapshotId,
+    String? expectedCurrentSnapshotId,
     required DateTime updatedAt,
   });
 
@@ -29,4 +30,11 @@ abstract interface class RpgPersistenceRepository {
   });
 
   Future<void> saveSnapshot(RpgStateSnapshot snapshot);
+
+  Future<void> commitSnapshotAndCurrentState({
+    required String chatId,
+    required RpgStateSnapshot snapshot,
+    required String? expectedCurrentSnapshotId,
+    required DateTime updatedAt,
+  });
 }

--- a/lib/domain/services/rpg_game_session_service.dart
+++ b/lib/domain/services/rpg_game_session_service.dart
@@ -1,0 +1,351 @@
+import 'dart:convert';
+
+import 'package:collection/collection.dart';
+import 'package:crypto/crypto.dart';
+import 'package:native_tavern/data/models/rpg/rpg.dart';
+import 'package:native_tavern/domain/repositories/rpg_persistence_repository.dart';
+import 'package:native_tavern/domain/services/rpg_rule_engine.dart';
+import 'package:uuid/uuid.dart';
+
+class RpgGameSession {
+  const RpgGameSession({
+    required this.chatId,
+    required this.scenario,
+    required this.snapshot,
+  });
+
+  final String chatId;
+  final RpgScenario scenario;
+  final RpgStateSnapshot snapshot;
+
+  RpgRuntimeState get state => snapshot.state;
+  String get branchId => snapshot.metadata.branchId;
+}
+
+class RpgCommittedAction {
+  const RpgCommittedAction({required this.execution, required this.snapshot});
+
+  final RpgActionExecution execution;
+  final RpgStateSnapshot snapshot;
+}
+
+class RpgSessionException implements Exception {
+  const RpgSessionException(this.code, this.message);
+
+  final String code;
+  final String message;
+
+  @override
+  String toString() => 'RpgSessionException($code): $message';
+}
+
+/// Coordinates rule execution and snapshot persistence for one chat session.
+class RpgGameSessionService {
+  RpgGameSessionService({
+    required RpgPersistenceRepository repository,
+    RpgRuleEngine engine = const RpgRuleEngine(),
+    DateTime Function()? now,
+    String Function()? idFactory,
+  })  : _repository = repository,
+        _engine = engine,
+        _now = now ?? _utcNow,
+        _idFactory = idFactory ?? _newId;
+
+  final RpgPersistenceRepository _repository;
+  final RpgRuleEngine _engine;
+  final DateTime Function() _now;
+  final String Function() _idFactory;
+
+  Future<RpgGameSession> initialize({
+    required String chatId,
+    required RpgScenario scenario,
+    String? branchId,
+  }) async {
+    if (await _repository.getCurrentState(chatId) != null) {
+      throw RpgSessionException(
+        'session_already_exists',
+        'Chat `$chatId` already has an RPG session.',
+      );
+    }
+    final persistedScenario = await _repository.getScenario(
+      scenario.metadata.id,
+    );
+    if (persistedScenario == null) {
+      await _repository.saveScenario(scenario);
+    } else if (!const DeepCollectionEquality().equals(
+      persistedScenario.toJson(),
+      scenario.toJson(),
+    )) {
+      throw RpgSessionException(
+        'scenario_conflict',
+        'Scenario `${scenario.metadata.id}` differs from the persisted version.',
+      );
+    }
+
+    final createdAt = _now().toUtc();
+    final snapshot = _createSnapshot(
+      state: scenario.initialState,
+      branchId: branchId ?? _defaultBranchId(chatId),
+      createdAt: createdAt,
+    );
+    await _repository.commitSnapshotAndCurrentState(
+      chatId: chatId,
+      snapshot: snapshot,
+      expectedCurrentSnapshotId: null,
+      updatedAt: createdAt,
+    );
+    return RpgGameSession(
+      chatId: chatId,
+      scenario: scenario,
+      snapshot: snapshot,
+    );
+  }
+
+  Future<RpgGameSession?> load(String chatId) async {
+    final state = await _repository.getCurrentState(chatId);
+    if (state == null) return null;
+    final scenario = await _repository.getScenario(state.scenarioId);
+    final snapshotId = await _repository.getCurrentSnapshotId(chatId);
+    final snapshot =
+        snapshotId == null ? null : await _requireSnapshot(snapshotId);
+    if (scenario == null || snapshot == null) {
+      throw RpgSessionException(
+        'incomplete_session',
+        'Chat `$chatId` has incomplete RPG persistence records.',
+      );
+    }
+    if (!const DeepCollectionEquality().equals(
+      snapshot.state.toJson(),
+      state.toJson(),
+    )) {
+      throw RpgSessionException(
+        'state_snapshot_mismatch',
+        'Chat `$chatId` state does not match its current snapshot.',
+      );
+    }
+    return RpgGameSession(
+      chatId: chatId,
+      scenario: scenario,
+      snapshot: snapshot,
+    );
+  }
+
+  Future<RpgCommittedAction> executeAction({
+    required String chatId,
+    required String actionId,
+  }) async {
+    final session = await _requireSession(chatId);
+    final execution = _engine.execute(
+      scenario: session.scenario,
+      state: session.state,
+      actionId: actionId,
+    );
+    final createdAt = _now().toUtc();
+    final snapshot = _createSnapshot(
+      state: execution.state,
+      branchId: session.branchId,
+      parentSnapshotId: session.snapshot.metadata.id,
+      createdAt: createdAt,
+    );
+    await _repository.commitSnapshotAndCurrentState(
+      chatId: chatId,
+      snapshot: snapshot,
+      expectedCurrentSnapshotId: session.snapshot.metadata.id,
+      updatedAt: createdAt,
+    );
+    return RpgCommittedAction(execution: execution, snapshot: snapshot);
+  }
+
+  Future<RpgGameSession> rollback({
+    required String chatId,
+    required String snapshotId,
+  }) async {
+    final session = await _requireSession(chatId);
+    final snapshot = await _requireSnapshot(snapshotId);
+    _requireSameScenario(session.scenario, snapshot);
+    await _requireSameSnapshotGraph(session.snapshot, snapshot);
+    final updatedAt = _now().toUtc();
+    await _repository.saveCurrentState(
+      chatId: chatId,
+      scenarioId: snapshot.metadata.scenarioId,
+      state: snapshot.state,
+      currentSnapshotId: snapshot.metadata.id,
+      expectedCurrentSnapshotId: session.snapshot.metadata.id,
+      updatedAt: updatedAt,
+    );
+    return RpgGameSession(
+      chatId: chatId,
+      scenario: session.scenario,
+      snapshot: snapshot,
+    );
+  }
+
+  Future<RpgGameSession> forkBranch({
+    required String chatId,
+    required String fromSnapshotId,
+    required String branchId,
+  }) async {
+    final session = await _requireSession(chatId);
+    final source = await _requireSnapshot(fromSnapshotId);
+    _requireSameScenario(session.scenario, source);
+    await _requireSameSnapshotGraph(session.snapshot, source);
+    if (source.metadata.branchId == branchId) {
+      throw RpgSessionException(
+        'branch_not_new',
+        'Branch `$branchId` is already the source branch.',
+      );
+    }
+    final existing = await _repository.listSnapshots(
+      scenarioId: source.metadata.scenarioId,
+      branchId: branchId,
+    );
+    if (existing.isNotEmpty) {
+      throw RpgSessionException(
+        'branch_already_exists',
+        'Branch `$branchId` already exists.',
+      );
+    }
+
+    final createdAt = _now().toUtc();
+    final branchRoot = _createSnapshot(
+      state: source.state,
+      branchId: branchId,
+      parentSnapshotId: source.metadata.id,
+      createdAt: createdAt,
+    );
+    await _repository.commitSnapshotAndCurrentState(
+      chatId: chatId,
+      snapshot: branchRoot,
+      expectedCurrentSnapshotId: session.snapshot.metadata.id,
+      updatedAt: createdAt,
+    );
+    return RpgGameSession(
+      chatId: chatId,
+      scenario: session.scenario,
+      snapshot: branchRoot,
+    );
+  }
+
+  Future<List<RpgEventRecord>> getTurnLog(String chatId) async {
+    final session = await _requireSession(chatId);
+    return List.unmodifiable(session.state.eventHistory);
+  }
+
+  Future<RpgGameSession> _requireSession(String chatId) async {
+    final session = await load(chatId);
+    if (session == null) {
+      throw RpgSessionException(
+        'session_not_found',
+        'Chat `$chatId` does not have an RPG session.',
+      );
+    }
+    return session;
+  }
+
+  Future<RpgStateSnapshot> _requireSnapshot(String snapshotId) async {
+    final snapshot = await _repository.getSnapshot(snapshotId);
+    if (snapshot == null) {
+      throw RpgSessionException(
+        'snapshot_not_found',
+        'RPG snapshot `$snapshotId` does not exist.',
+      );
+    }
+    final expectedHash = snapshot.metadata.stateHash;
+    if (expectedHash != null && expectedHash != _stateHash(snapshot.state)) {
+      throw RpgSessionException(
+        'snapshot_hash_mismatch',
+        'RPG snapshot `$snapshotId` failed its state integrity check.',
+      );
+    }
+    return snapshot;
+  }
+
+  void _requireSameScenario(RpgScenario scenario, RpgStateSnapshot snapshot) {
+    if (snapshot.metadata.scenarioId != scenario.metadata.id ||
+        snapshot.metadata.scenarioVersion != scenario.metadata.version) {
+      throw RpgSessionException(
+        'snapshot_scenario_mismatch',
+        'Snapshot `${snapshot.metadata.id}` belongs to another scenario.',
+      );
+    }
+  }
+
+  Future<void> _requireSameSnapshotGraph(
+    RpgStateSnapshot current,
+    RpgStateSnapshot target,
+  ) async {
+    final currentRoot = await _rootSnapshotId(current);
+    final targetRoot = await _rootSnapshotId(target);
+    if (currentRoot != targetRoot) {
+      throw RpgSessionException(
+        'snapshot_session_mismatch',
+        'Snapshot `${target.metadata.id}` belongs to another RPG session.',
+      );
+    }
+  }
+
+  Future<String> _rootSnapshotId(RpgStateSnapshot snapshot) async {
+    final visited = <String>{};
+    var cursor = snapshot;
+    while (true) {
+      final parentId = cursor.metadata.parentSnapshotId;
+      if (parentId == null) break;
+      if (!visited.add(cursor.metadata.id)) {
+        throw RpgSessionException(
+          'snapshot_lineage_cycle',
+          'Snapshot lineage contains a cycle at `${cursor.metadata.id}`.',
+        );
+      }
+      cursor = await _requireSnapshot(parentId);
+    }
+    return cursor.metadata.id;
+  }
+
+  RpgStateSnapshot _createSnapshot({
+    required RpgRuntimeState state,
+    required String branchId,
+    String? parentSnapshotId,
+    required DateTime createdAt,
+  }) {
+    return RpgStateSnapshot(
+      metadata: RpgSnapshotMetadata(
+        id: 'snapshot_${_idFactory()}',
+        scenarioId: state.scenarioId,
+        scenarioVersion: state.scenarioVersion,
+        branchId: branchId,
+        parentSnapshotId: parentSnapshotId,
+        turn: state.turn,
+        randomState: state.random.state,
+        rollsConsumed: state.random.rollsConsumed,
+        createdAt: createdAt,
+        stateHash: _stateHash(state),
+      ),
+      state: state,
+    );
+  }
+}
+
+String _defaultBranchId(String chatId) {
+  final safeChatId = chatId.replaceAll(RegExp(r'[^A-Za-z0-9_-]'), '_');
+  return 'chat_${safeChatId}_main';
+}
+
+String _stateHash(RpgRuntimeState state) {
+  final canonical = _canonicalize(state.toJson());
+  return 'sha256:${sha256.convert(utf8.encode(jsonEncode(canonical)))}';
+}
+
+Object? _canonicalize(Object? value) {
+  if (value is List<Object?>) return value.map(_canonicalize).toList();
+  if (value is Map<Object?, Object?>) {
+    final keys = value.keys.map((key) => key.toString()).toList()..sort();
+    return <String, Object?>{
+      for (final key in keys) key: _canonicalize(value[key]),
+    };
+  }
+  return value;
+}
+
+DateTime _utcNow() => DateTime.now().toUtc();
+
+String _newId() => const Uuid().v4();

--- a/lib/domain/services/rpg_rule_engine.dart
+++ b/lib/domain/services/rpg_rule_engine.dart
@@ -1,0 +1,663 @@
+import 'package:collection/collection.dart';
+import 'package:native_tavern/data/models/rpg/rpg.dart';
+
+enum RpgActionOutcome { succeeded, failedCheck }
+
+class RpgDiceRoll {
+  const RpgDiceRoll({
+    required this.expression,
+    required this.values,
+    required this.modifier,
+  });
+
+  final String expression;
+  final List<int> values;
+  final int modifier;
+
+  int get total => values.fold(modifier, (sum, value) => sum + value);
+
+  Map<String, Object?> toJson() => {
+        'expression': expression,
+        'values': values,
+        'modifier': modifier,
+        'total': total,
+      };
+}
+
+class RpgActionExecution {
+  const RpgActionExecution({
+    required this.actionId,
+    required this.outcome,
+    required this.previousState,
+    required this.state,
+    this.roll,
+    this.checkTotal,
+    this.difficulty,
+  });
+
+  final String actionId;
+  final RpgActionOutcome outcome;
+  final RpgRuntimeState previousState;
+  final RpgRuntimeState state;
+  final RpgDiceRoll? roll;
+  final num? checkTotal;
+  final num? difficulty;
+
+  bool get succeeded => outcome == RpgActionOutcome.succeeded;
+}
+
+class RpgRuleViolation implements Exception {
+  const RpgRuleViolation(this.code, this.message, {this.path});
+
+  final String code;
+  final String message;
+  final String? path;
+
+  @override
+  String toString() => path == null
+      ? 'RpgRuleViolation($code): $message'
+      : 'RpgRuleViolation($code) at $path: $message';
+}
+
+/// Executes declarative scenario rules without wall-clock or platform inputs.
+class RpgRuleEngine {
+  const RpgRuleEngine({this.validator = const RpgScenarioValidator()});
+
+  final RpgScenarioValidator validator;
+
+  List<RpgActionDefinition> availableActions(
+    RpgScenario scenario,
+    RpgRuntimeState state,
+  ) {
+    _validateRuntimeState(scenario, state);
+    return List.unmodifiable(
+      scenario.actions.where(
+        (action) =>
+            (state.cooldowns[action.id] ?? 0) == 0 &&
+            action.availability.every(
+              (condition) => _evaluateCondition(condition, state),
+            ) &&
+            action.costs.every((cost) => _canPayCost(scenario, state, cost)),
+      ),
+    );
+  }
+
+  RpgActionExecution execute({
+    required RpgScenario scenario,
+    required RpgRuntimeState state,
+    required String actionId,
+  }) {
+    _validateRuntimeState(scenario, state);
+    final action = scenario.actions
+        .where((candidate) => candidate.id == actionId)
+        .firstOrNull;
+    if (action == null) {
+      throw RpgRuleViolation(
+        'unknown_action',
+        'Action `$actionId` is not defined by scenario `${scenario.metadata.id}`.',
+        path: 'actionId',
+      );
+    }
+
+    final cooldown = state.cooldowns[action.id] ?? 0;
+    if (cooldown > 0) {
+      throw RpgRuleViolation(
+        'action_on_cooldown',
+        'Action `${action.id}` is unavailable for $cooldown more turn(s).',
+        path: 'cooldowns.${action.id}',
+      );
+    }
+    for (var index = 0; index < action.availability.length; index++) {
+      if (!_evaluateCondition(action.availability[index], state)) {
+        throw RpgRuleViolation(
+          'condition_not_met',
+          'Action `${action.id}` does not satisfy availability condition $index.',
+          path: 'actions.${action.id}.availability[$index]',
+        );
+      }
+    }
+    for (var index = 0; index < action.costs.length; index++) {
+      if (!_canPayCost(scenario, state, action.costs[index])) {
+        throw RpgRuleViolation(
+          'insufficient_resource',
+          'Action `${action.id}` cannot pay cost `${action.costs[index].path}`.',
+          path: 'actions.${action.id}.costs[$index]',
+        );
+      }
+    }
+
+    final draft = _RpgStateDraft.fromState(state)..tickCooldowns();
+    for (final cost in action.costs) {
+      draft.adjustNumeric(cost.path, -cost.amount);
+    }
+
+    RpgDiceRoll? roll;
+    num? checkTotal;
+    var outcome = RpgActionOutcome.succeeded;
+    final selectedEffects = <RpgEffect>[];
+    if (action.check case final check?) {
+      roll = draft.roll(check.dice);
+      checkTotal = roll.total + (draft.attributes[check.attributeId] ?? 0);
+      outcome = checkTotal >= check.difficulty
+          ? RpgActionOutcome.succeeded
+          : RpgActionOutcome.failedCheck;
+      selectedEffects.addAll(
+        outcome == RpgActionOutcome.succeeded
+            ? check.successEffects
+            : check.failureEffects,
+      );
+    }
+    selectedEffects.addAll(action.effects);
+
+    for (var index = 0; index < selectedEffects.length; index++) {
+      try {
+        draft.applyEffect(selectedEffects[index]);
+      } on RpgRuleViolation catch (error) {
+        throw RpgRuleViolation(
+          error.code,
+          error.message,
+          path:
+              'actions.${action.id}.effects[$index]${error.path == null ? '' : '.${error.path}'}',
+        );
+      }
+    }
+
+    draft.turn = state.turn + 1;
+    draft.appendTurnRecord(
+      action: action,
+      outcome: outcome,
+      costs: action.costs,
+      roll: roll,
+      checkTotal: checkTotal,
+      difficulty: action.check?.difficulty,
+      appliedEffects: selectedEffects,
+    );
+    final nextState = draft.build();
+    _validateRuntimeState(scenario, nextState);
+
+    return RpgActionExecution(
+      actionId: action.id,
+      outcome: outcome,
+      previousState: state,
+      state: nextState,
+      roll: roll,
+      checkTotal: checkTotal,
+      difficulty: action.check?.difficulty,
+    );
+  }
+
+  /// Applies a typed patch after enforcing its declared mutation source.
+  /// This does not advance a turn; action execution owns turn progression.
+  RpgRuntimeState applyPatch({
+    required RpgScenario scenario,
+    required RpgRuntimeState state,
+    required RpgStatePatch patch,
+  }) {
+    _validateRuntimeState(scenario, state);
+    final validation = validator.validatePatch(scenario, patch);
+    if (!validation.isValid) {
+      final issue = validation.issues.first;
+      throw RpgRuleViolation(issue.code, issue.message, path: issue.path);
+    }
+    final draft = _RpgStateDraft.fromState(state);
+    for (final effect in patch.effects) {
+      draft.applyEffect(effect);
+    }
+    final nextState = draft.build();
+    _validateRuntimeState(scenario, nextState);
+    return nextState;
+  }
+
+  void _validateRuntimeState(RpgScenario scenario, RpgRuntimeState state) {
+    final scenarioValidation = validator.validate(scenario);
+    if (!scenarioValidation.isValid) {
+      final issue = scenarioValidation.issues.first;
+      throw RpgRuleViolation(
+        'invalid_scenario',
+        issue.message,
+        path: issue.path,
+      );
+    }
+    final stateValidation = validator.validateRuntimeState(scenario, state);
+    if (!stateValidation.isValid) {
+      final issue = stateValidation.issues.first;
+      throw RpgRuleViolation('invalid_state', issue.message, path: issue.path);
+    }
+  }
+
+  bool _canPayCost(
+    RpgScenario scenario,
+    RpgRuntimeState state,
+    RpgActionCost cost,
+  ) {
+    final resolved = _resolvePath(state, cost.path);
+    if (!resolved.exists || resolved.value is! num) return false;
+    final nextValue = (resolved.value as num) - cost.amount;
+    if (!nextValue.isFinite) return false;
+    if (cost.path.startsWith('attributes.')) {
+      final attributeId = cost.path.substring('attributes.'.length);
+      final definition = scenario.attributes
+          .where((attribute) => attribute.id == attributeId)
+          .firstOrNull;
+      return definition != null &&
+          (definition.minimum == null || nextValue >= definition.minimum!);
+    }
+    return nextValue >= 0;
+  }
+
+  bool _evaluateCondition(RpgCondition condition, RpgRuntimeState state) {
+    switch (condition.operator) {
+      case RpgConditionOperator.all:
+        return condition.conditions.every(
+          (nested) => _evaluateCondition(nested, state),
+        );
+      case RpgConditionOperator.any:
+        return condition.conditions.any(
+          (nested) => _evaluateCondition(nested, state),
+        );
+      case RpgConditionOperator.not:
+        return !_evaluateCondition(condition.conditions.single, state);
+      case RpgConditionOperator.exists:
+        return _resolvePath(state, condition.path!).exists;
+      case RpgConditionOperator.equals:
+        return const DeepCollectionEquality().equals(
+          _resolvePath(state, condition.path!).value,
+          condition.value,
+        );
+      case RpgConditionOperator.notEquals:
+        return !const DeepCollectionEquality().equals(
+          _resolvePath(state, condition.path!).value,
+          condition.value,
+        );
+      case RpgConditionOperator.greaterThan:
+        final comparison = _compare(
+          _resolvePath(state, condition.path!).value,
+          condition.value,
+        );
+        return comparison != null && comparison > 0;
+      case RpgConditionOperator.greaterThanOrEqual:
+        final comparison = _compare(
+          _resolvePath(state, condition.path!).value,
+          condition.value,
+        );
+        return comparison != null && comparison >= 0;
+      case RpgConditionOperator.lessThan:
+        final comparison = _compare(
+          _resolvePath(state, condition.path!).value,
+          condition.value,
+        );
+        return comparison != null && comparison < 0;
+      case RpgConditionOperator.lessThanOrEqual:
+        final comparison = _compare(
+          _resolvePath(state, condition.path!).value,
+          condition.value,
+        );
+        return comparison != null && comparison <= 0;
+      case RpgConditionOperator.contains:
+        return _contains(
+          _resolvePath(state, condition.path!).value,
+          condition.value,
+        );
+      case RpgConditionOperator.notContains:
+        return !_contains(
+          _resolvePath(state, condition.path!).value,
+          condition.value,
+        );
+    }
+  }
+}
+
+int? _compare(Object? left, Object? right) {
+  if (left is num && right is num) return left.compareTo(right);
+  if (left is String && right is String) return left.compareTo(right);
+  return null;
+}
+
+bool _contains(Object? container, Object? value) {
+  if (container is String && value is String) return container.contains(value);
+  if (container is Iterable<Object?>) {
+    return container.any(
+      (item) => const DeepCollectionEquality().equals(item, value),
+    );
+  }
+  if (container is Map<Object?, Object?>) return container.containsKey(value);
+  return false;
+}
+
+class _ResolvedPath {
+  const _ResolvedPath(this.exists, this.value);
+
+  final bool exists;
+  final Object? value;
+}
+
+_ResolvedPath _resolvePath(RpgRuntimeState state, String path) {
+  switch (path) {
+    case 'turn':
+      return _ResolvedPath(true, state.turn);
+    case 'random.initialSeed':
+      return _ResolvedPath(true, state.random.initialSeed);
+    case 'random.state':
+      return _ResolvedPath(true, state.random.state);
+    case 'random.rollsConsumed':
+      return _ResolvedPath(true, state.random.rollsConsumed);
+    case 'clock.elapsedMinutes':
+      return _ResolvedPath(true, state.clock.elapsedMinutes);
+    case 'clock.day':
+      return _ResolvedPath(true, state.clock.day);
+    case 'clock.minuteOfDay':
+      return _ResolvedPath(true, state.clock.minuteOfDay);
+    case 'locationId':
+      return _ResolvedPath(true, state.locationId);
+  }
+
+  final segments = path.split('.');
+  if (segments.length == 2) {
+    final id = segments[1];
+    return switch (segments.first) {
+      'attributes' => _ResolvedPath(
+          state.attributes.containsKey(id),
+          state.attributes[id],
+        ),
+      'variables' => _ResolvedPath(
+          state.variables.containsKey(id),
+          state.variables[id],
+        ),
+      'cooldowns' => _ResolvedPath(
+          state.cooldowns.containsKey(id),
+          state.cooldowns[id],
+        ),
+      _ => const _ResolvedPath(false, null),
+    };
+  }
+  if (segments.length == 3) {
+    final id = segments[1];
+    if (segments.first == 'inventory' && segments.last == 'quantity') {
+      final entry =
+          state.inventory.where((item) => item.itemId == id).firstOrNull;
+      return _ResolvedPath(entry != null, entry?.quantity);
+    }
+    if (segments.first == 'relationships' && segments.last == 'score') {
+      final entry = state.relationships
+          .where((relationship) => relationship.actorId == id)
+          .firstOrNull;
+      return _ResolvedPath(entry != null, entry?.score);
+    }
+    if (segments.first == 'quests') {
+      final entry =
+          state.quests.where((quest) => quest.questId == id).firstOrNull;
+      return switch (segments.last) {
+        'status' => _ResolvedPath(entry != null, entry?.status.name),
+        'stageId' => _ResolvedPath(entry != null, entry?.stageId),
+        _ => const _ResolvedPath(false, null),
+      };
+    }
+  }
+  return const _ResolvedPath(false, null);
+}
+
+class _RpgStateDraft {
+  _RpgStateDraft.fromState(RpgRuntimeState state)
+      : scenarioId = state.scenarioId,
+        scenarioVersion = state.scenarioVersion,
+        turn = state.turn,
+        initialSeed = state.random.initialSeed,
+        randomState = state.random.state,
+        rollsConsumed = state.random.rollsConsumed,
+        attributes = Map.of(state.attributes),
+        variables = Map.of(state.variables),
+        inventory = {for (final entry in state.inventory) entry.itemId: entry},
+        relationships = {
+          for (final relationship in state.relationships)
+            relationship.actorId: relationship,
+        },
+        clock = state.clock,
+        locationId = state.locationId,
+        quests = {for (final quest in state.quests) quest.questId: quest},
+        cooldowns = Map.of(state.cooldowns),
+        eventHistory = List.of(state.eventHistory);
+
+  final String scenarioId;
+  final String scenarioVersion;
+  int turn;
+  final int initialSeed;
+  int randomState;
+  int rollsConsumed;
+  final Map<String, num> attributes;
+  final Map<String, Object?> variables;
+  final Map<String, RpgInventoryEntry> inventory;
+  final Map<String, RpgRelationshipState> relationships;
+  RpgClockState clock;
+  String locationId;
+  final Map<String, RpgQuestState> quests;
+  final Map<String, int> cooldowns;
+  final List<RpgEventRecord> eventHistory;
+
+  void tickCooldowns() {
+    for (final entry in cooldowns.entries.toList()) {
+      final next = entry.value - 1;
+      if (next <= 0) {
+        cooldowns.remove(entry.key);
+      } else {
+        cooldowns[entry.key] = next;
+      }
+    }
+  }
+
+  RpgDiceRoll roll(RpgDiceSpec spec) {
+    final match = RegExp(
+      r'^(\d+)d(\d+)([+-]\d+)?$',
+    ).firstMatch(spec.expression);
+    if (match == null) {
+      throw RpgRuleViolation(
+        'invalid_dice_expression',
+        'Cannot execute dice expression `${spec.expression}`.',
+      );
+    }
+    final count = int.parse(match.group(1)!);
+    final sides = int.parse(match.group(2)!);
+    final modifier = int.tryParse(match.group(3) ?? '') ?? 0;
+    final values = <int>[];
+    for (var index = 0; index < count; index++) {
+      randomState = _nextRandomState(randomState);
+      rollsConsumed++;
+      values.add((randomState % sides) + 1);
+    }
+    return RpgDiceRoll(
+      expression: spec.expression,
+      values: List.unmodifiable(values),
+      modifier: modifier,
+    );
+  }
+
+  void adjustNumeric(String path, num delta) {
+    final segments = path.split('.');
+    if (segments.length == 2 && segments.first == 'attributes') {
+      final current = attributes[segments.last];
+      if (current == null) _missingNumericPath(path);
+      attributes[segments.last] = current + delta;
+      return;
+    }
+    if (segments.length == 2 && segments.first == 'variables') {
+      final current = variables[segments.last];
+      if (current is! num) _missingNumericPath(path);
+      variables[segments.last] = current + delta;
+      return;
+    }
+    if (segments.length == 3 &&
+        segments.first == 'relationships' &&
+        segments.last == 'score') {
+      final current = relationships[segments[1]];
+      if (current == null) _missingNumericPath(path);
+      relationships[segments[1]] = RpgRelationshipState(
+        actorId: current.actorId,
+        score: current.score + delta,
+        tags: current.tags,
+      );
+      return;
+    }
+    _missingNumericPath(path);
+  }
+
+  Never _missingNumericPath(String path) => throw RpgRuleViolation(
+        'invalid_numeric_state',
+        'State path `$path` does not contain a numeric value.',
+        path: path,
+      );
+
+  void applyEffect(RpgEffect effect) {
+    switch (effect.type) {
+      case RpgEffectType.setValue:
+        final segments = effect.target.split('.');
+        if (segments.first == 'attributes') {
+          final value = effect.value;
+          if (value is! num || !value.isFinite) {
+            throw RpgRuleViolation(
+              'invalid_attribute_value',
+              'Attribute `${segments.last}` requires a finite number.',
+            );
+          }
+          attributes[segments.last] = value;
+        } else {
+          variables[segments.last] = effect.value;
+        }
+      case RpgEffectType.incrementValue:
+        adjustNumeric(effect.target, effect.amount!);
+      case RpgEffectType.decrementValue:
+        adjustNumeric(effect.target, -effect.amount!);
+      case RpgEffectType.addItem:
+        final quantity = effect.amount!.toInt();
+        final current = inventory[effect.target];
+        inventory[effect.target] = RpgInventoryEntry(
+          itemId: effect.target,
+          quantity: (current?.quantity ?? 0) + quantity,
+          metadata: current?.metadata ?? const {},
+        );
+      case RpgEffectType.removeItem:
+        final quantity = effect.amount!.toInt();
+        final current = inventory[effect.target];
+        if (current == null || current.quantity < quantity) {
+          throw RpgRuleViolation(
+            'insufficient_item',
+            'Cannot remove $quantity `${effect.target}` item(s).',
+          );
+        }
+        final remaining = current.quantity - quantity;
+        if (remaining == 0) {
+          inventory.remove(effect.target);
+        } else {
+          inventory[effect.target] = RpgInventoryEntry(
+            itemId: current.itemId,
+            quantity: remaining,
+            metadata: current.metadata,
+          );
+        }
+      case RpgEffectType.adjustRelationship:
+        final current = relationships[effect.target];
+        relationships[effect.target] = RpgRelationshipState(
+          actorId: effect.target,
+          score: (current?.score ?? 0) + effect.amount!,
+          tags: current?.tags ?? const [],
+        );
+      case RpgEffectType.moveTo:
+        locationId = effect.target;
+      case RpgEffectType.setQuestStatus:
+        final current = quests[effect.target];
+        quests[effect.target] = RpgQuestState(
+          questId: effect.target,
+          status: RpgQuestStatus.fromJson(effect.value! as String),
+          stageId: current?.stageId,
+          objectiveProgress: current?.objectiveProgress ?? const {},
+        );
+      case RpgEffectType.setCooldown:
+        final turns = effect.amount!.toInt();
+        if (turns == 0) {
+          cooldowns.remove(effect.target);
+        } else {
+          cooldowns[effect.target] = turns;
+        }
+      case RpgEffectType.appendEvent:
+        final value = effect.value;
+        eventHistory.add(
+          RpgEventRecord(
+            id: _nextEventId('event_${turn + 1}_${eventHistory.length + 1}'),
+            turn: turn + 1,
+            type: effect.target,
+            data: value is Map<String, Object?>
+                ? Map.unmodifiable(value)
+                : <String, Object?>{'value': value},
+          ),
+        );
+    }
+  }
+
+  void appendTurnRecord({
+    required RpgActionDefinition action,
+    required RpgActionOutcome outcome,
+    required List<RpgActionCost> costs,
+    required RpgDiceRoll? roll,
+    required num? checkTotal,
+    required num? difficulty,
+    required List<RpgEffect> appliedEffects,
+  }) {
+    eventHistory.add(
+      RpgEventRecord(
+        id: _nextEventId('turn_$turn'),
+        turn: turn,
+        type: 'actionResolved',
+        actionId: action.id,
+        summary: outcome == RpgActionOutcome.succeeded
+            ? 'Action succeeded.'
+            : 'Skill check failed.',
+        data: {
+          'outcome': outcome.name,
+          if (costs.isNotEmpty)
+            'costs': costs.map((cost) => cost.toJson()).toList(),
+          if (roll != null) 'roll': roll.toJson(),
+          if (checkTotal != null) 'checkTotal': checkTotal,
+          if (difficulty != null) 'difficulty': difficulty,
+          if (appliedEffects.isNotEmpty)
+            'effects': appliedEffects.map((effect) => effect.toJson()).toList(),
+        },
+      ),
+    );
+  }
+
+  String _nextEventId(String base) {
+    final ids = eventHistory.map((event) => event.id).toSet();
+    if (!ids.contains(base)) return base;
+    var suffix = 2;
+    while (ids.contains('${base}_$suffix')) {
+      suffix++;
+    }
+    return '${base}_$suffix';
+  }
+
+  RpgRuntimeState build() => RpgRuntimeState(
+        scenarioId: scenarioId,
+        scenarioVersion: scenarioVersion,
+        turn: turn,
+        random: RpgRandomState(
+          initialSeed: initialSeed,
+          state: randomState,
+          rollsConsumed: rollsConsumed,
+        ),
+        attributes: Map.unmodifiable(attributes),
+        variables: Map.unmodifiable(variables),
+        inventory: List.unmodifiable(inventory.values),
+        relationships: List.unmodifiable(relationships.values),
+        clock: clock,
+        locationId: locationId,
+        quests: List.unmodifiable(quests.values),
+        cooldowns: Map.unmodifiable(cooldowns),
+        eventHistory: List.unmodifiable(eventHistory),
+      );
+}
+
+int _nextRandomState(int current) {
+  const modulus = 2147483647;
+  const multiplier = 48271;
+  var normalized = current % (modulus - 1);
+  if (normalized <= 0) normalized += modulus - 1;
+  return (normalized * multiplier) % modulus;
+}

--- a/test/rpg_rule_engine_end_to_end_test.dart
+++ b/test/rpg_rule_engine_end_to_end_test.dart
@@ -1,0 +1,654 @@
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:native_tavern/data/database/database.dart';
+import 'package:native_tavern/data/models/rpg/rpg.dart';
+import 'package:native_tavern/data/repositories/drift_rpg_persistence_repository.dart';
+import 'package:native_tavern/domain/services/rpg_game_session_service.dart';
+import 'package:native_tavern/domain/services/rpg_rule_engine.dart';
+
+void main() {
+  group('deterministic RPG rule engine', () {
+    const engine = RpgRuleEngine();
+    final scenario = _scenario();
+
+    test('same seed and action sequence produces identical state', () {
+      final first = engine.execute(
+        scenario: scenario,
+        state: scenario.initialState,
+        actionId: 'enter_vault',
+      );
+      final second = engine.execute(
+        scenario: scenario,
+        state: scenario.initialState,
+        actionId: 'enter_vault',
+      );
+
+      expect(first.outcome, RpgActionOutcome.succeeded);
+      expect(second.state.toJson(), first.state.toJson());
+      expect(first.roll?.values, second.roll?.values);
+      expect(first.state.turn, 1);
+      expect(first.state.random.rollsConsumed, 2);
+      expect(first.state.attributes, {'courage': 3, 'energy': 3});
+      expect(first.state.variables, {
+        'score': 3,
+        'ready': false,
+        'clues': ['map'],
+      });
+      expect(first.state.inventory.single.itemId, 'gem');
+      expect(first.state.inventory.single.quantity, 2);
+      expect(first.state.relationships.single.score, 3);
+      expect(first.state.locationId, 'vault');
+      expect(first.state.quests.single.status, RpgQuestStatus.completed);
+      expect(first.state.cooldowns, {'enter_vault': 2});
+      expect(
+        first.state.eventHistory.map((event) => event.type),
+        ['vaultEntered', 'actionResolved'],
+      );
+      expect(scenario.initialState.turn, 0);
+      expect(scenario.initialState.inventory.single.itemId, 'key');
+    });
+
+    test('failed checks use failure effects and still consume one atomic turn',
+        () {
+      final result = engine.execute(
+        scenario: scenario,
+        state: scenario.initialState,
+        actionId: 'impossible_check',
+      );
+
+      expect(result.outcome, RpgActionOutcome.failedCheck);
+      expect(result.checkTotal, lessThan(1000));
+      expect(result.state.turn, 1);
+      expect(result.state.cooldowns, {'impossible_check': 1});
+      expect(result.state.random.rollsConsumed, 1);
+      expect(
+        result.state.eventHistory.single.data['outcome'],
+        RpgActionOutcome.failedCheck.name,
+      );
+    });
+
+    test('protected narrative mutation and invalid effects leave input intact',
+        () {
+      final before = scenario.initialState.toJson();
+
+      expect(
+        () => engine.applyPatch(
+          scenario: scenario,
+          state: scenario.initialState,
+          patch: const RpgStatePatch(
+            source: RpgMutationSource.narrative,
+            effects: [
+              RpgEffect(
+                type: RpgEffectType.incrementValue,
+                target: 'attributes.courage',
+                amount: 1,
+              ),
+            ],
+          ),
+        ),
+        throwsA(
+          isA<RpgRuleViolation>().having(
+            (error) => error.code,
+            'code',
+            'protected_state_mutation',
+          ),
+        ),
+      );
+      expect(
+        () => engine.applyPatch(
+          scenario: scenario,
+          state: scenario.initialState,
+          patch: const RpgStatePatch(
+            source: RpgMutationSource.ruleEngine,
+            effects: [
+              RpgEffect(
+                type: RpgEffectType.addItem,
+                target: 'key',
+                amount: 1,
+              ),
+            ],
+          ),
+        ),
+        throwsA(
+          isA<RpgRuleViolation>().having(
+            (error) => error.code,
+            'code',
+            'invalid_state',
+          ),
+        ),
+      );
+      expect(scenario.initialState.toJson(), before);
+    });
+
+    test('unavailable actions and resource underflow do not advance state', () {
+      final before = scenario.initialState.toJson();
+
+      expect(
+        () => engine.execute(
+          scenario: scenario,
+          state: scenario.initialState,
+          actionId: 'too_expensive',
+        ),
+        throwsA(
+          isA<RpgRuleViolation>().having(
+            (error) => error.code,
+            'code',
+            'insufficient_resource',
+          ),
+        ),
+      );
+      expect(scenario.initialState.toJson(), before);
+      expect(
+        engine
+            .availableActions(scenario, scenario.initialState)
+            .map((action) => action.id),
+        containsAll(['enter_vault', 'wait', 'impossible_check']),
+      );
+      expect(
+        engine
+            .availableActions(scenario, scenario.initialState)
+            .map((action) => action.id),
+        isNot(contains('too_expensive')),
+      );
+    });
+  });
+
+  group('RPG session with real SQLite persistence', () {
+    late Directory temporaryDirectory;
+    late File databaseFile;
+    late AppDatabase database;
+    late DriftRpgPersistenceRepository repository;
+    late RpgGameSessionService service;
+    late int idCounter;
+    late int clockMinute;
+
+    DateTime now() =>
+        DateTime.utc(2026, 8, 8, 12).add(Duration(minutes: clockMinute++));
+    String nextId() => 'id_${++idCounter}';
+
+    setUp(() async {
+      temporaryDirectory = await Directory.systemTemp.createTemp('rpg-engine-');
+      databaseFile = File('${temporaryDirectory.path}/rpg.sqlite');
+      database = AppDatabase.forTesting(NativeDatabase(databaseFile));
+      await database.customSelect('SELECT 1').get();
+      await _seedChat(database);
+      repository = DriftRpgPersistenceRepository(database);
+      idCounter = 0;
+      clockMinute = 0;
+      service = RpgGameSessionService(
+        repository: repository,
+        now: now,
+        idFactory: nextId,
+      );
+    });
+
+    tearDown(() async {
+      await database.close();
+      await temporaryDirectory.delete(recursive: true);
+    });
+
+    test('commits turns, survives restart, and records source lineage',
+        () async {
+      final scenario = _scenario();
+      final initial = await service.initialize(
+        chatId: 'chat-1',
+        scenario: scenario,
+        branchId: 'main',
+      );
+      final committed = await service.executeAction(
+        chatId: 'chat-1',
+        actionId: 'enter_vault',
+      );
+
+      expect(committed.snapshot.metadata.parentSnapshotId,
+          initial.snapshot.metadata.id);
+      expect(committed.snapshot.metadata.stateHash, startsWith('sha256:'));
+      expect(await repository.getCurrentSnapshotId('chat-1'),
+          committed.snapshot.metadata.id);
+      expect((await service.getTurnLog('chat-1')).last.actionId, 'enter_vault');
+      final persistedState = await repository.getCurrentState('chat-1');
+      expect(persistedState?.toJson(), committed.execution.state.toJson());
+
+      await database.close();
+      database = AppDatabase.forTesting(NativeDatabase(databaseFile));
+      await database.customSelect('SELECT 1').get();
+      repository = DriftRpgPersistenceRepository(database);
+      service = RpgGameSessionService(
+        repository: repository,
+        now: now,
+        idFactory: nextId,
+      );
+
+      final restored = await service.load('chat-1');
+      expect(restored?.snapshot.metadata.id, committed.snapshot.metadata.id);
+      expect(restored?.state.toJson(), committed.execution.state.toJson());
+      expect(await _foreignKeyViolations(database), isEmpty);
+    });
+
+    test('rollback replay is deterministic and branches remain isolated',
+        () async {
+      final initial = await service.initialize(
+        chatId: 'chat-1',
+        scenario: _scenario(),
+        branchId: 'main',
+      );
+      final first = await service.executeAction(
+        chatId: 'chat-1',
+        actionId: 'enter_vault',
+      );
+      await service.rollback(
+        chatId: 'chat-1',
+        snapshotId: initial.snapshot.metadata.id,
+      );
+      final replay = await service.executeAction(
+        chatId: 'chat-1',
+        actionId: 'enter_vault',
+      );
+
+      expect(replay.execution.state.toJson(), first.execution.state.toJson());
+      expect(replay.snapshot.metadata.parentSnapshotId,
+          initial.snapshot.metadata.id);
+
+      final alternate = await service.forkBranch(
+        chatId: 'chat-1',
+        fromSnapshotId: first.snapshot.metadata.id,
+        branchId: 'alternate',
+      );
+      expect(alternate.snapshot.metadata.parentSnapshotId,
+          first.snapshot.metadata.id);
+      expect(alternate.snapshot.metadata.turn, first.snapshot.metadata.turn);
+      final alternateTurn = await service.executeAction(
+        chatId: 'chat-1',
+        actionId: 'wait',
+      );
+      expect(alternateTurn.snapshot.metadata.branchId, 'alternate');
+      expect(alternateTurn.execution.state.variables['route'], 'alternate');
+
+      final mainSnapshots = await repository.listSnapshots(
+        scenarioId: 'vault_run',
+        branchId: 'main',
+      );
+      final alternateSnapshots = await repository.listSnapshots(
+        scenarioId: 'vault_run',
+        branchId: 'alternate',
+      );
+      expect(mainSnapshots, hasLength(3));
+      expect(alternateSnapshots, hasLength(2));
+      expect(
+        mainSnapshots.every(
+          (snapshot) => !snapshot.state.variables.containsKey('route'),
+        ),
+        isTrue,
+      );
+
+      final restoredMain = await service.rollback(
+        chatId: 'chat-1',
+        snapshotId: first.snapshot.metadata.id,
+      );
+      expect(restoredMain.branchId, 'main');
+      expect(restoredMain.state.variables.containsKey('route'), isFalse);
+      expect(await _foreignKeyViolations(database), isEmpty);
+    });
+
+    test('rejected actions and failed chat commits leave no partial writes',
+        () async {
+      final initial = await service.initialize(
+        chatId: 'chat-1',
+        scenario: _scenario(),
+        branchId: 'main',
+      );
+      final advanced = await service.executeAction(
+        chatId: 'chat-1',
+        actionId: 'wait',
+      );
+      final beforeState = await repository.getCurrentState('chat-1');
+      final beforeSnapshotId = await repository.getCurrentSnapshotId('chat-1');
+      final beforeSnapshots = await repository.listSnapshots(
+        scenarioId: 'vault_run',
+      );
+
+      await expectLater(
+        service.executeAction(
+          chatId: 'chat-1',
+          actionId: 'too_expensive',
+        ),
+        throwsA(
+          isA<RpgRuleViolation>().having(
+            (error) => error.code,
+            'code',
+            'insufficient_resource',
+          ),
+        ),
+      );
+      expect((await repository.getCurrentState('chat-1'))?.toJson(),
+          beforeState?.toJson());
+      expect(await repository.getCurrentSnapshotId('chat-1'), beforeSnapshotId);
+      expect(
+        await repository.listSnapshots(scenarioId: 'vault_run'),
+        hasLength(beforeSnapshots.length),
+      );
+
+      final staleSnapshot = RpgStateSnapshot(
+        metadata: RpgSnapshotMetadata(
+          id: 'snapshot_stale',
+          scenarioId: 'vault_run',
+          scenarioVersion: '1.0.0',
+          branchId: 'main',
+          parentSnapshotId: initial.snapshot.metadata.id,
+          turn: advanced.execution.state.turn,
+          randomState: advanced.execution.state.random.state,
+          rollsConsumed: advanced.execution.state.random.rollsConsumed,
+          createdAt: now(),
+        ),
+        state: advanced.execution.state,
+      );
+      await expectLater(
+        repository.commitSnapshotAndCurrentState(
+          chatId: 'chat-1',
+          snapshot: staleSnapshot,
+          expectedCurrentSnapshotId: initial.snapshot.metadata.id,
+          updatedAt: now(),
+        ),
+        throwsA(isA<StateError>()),
+      );
+      expect(await repository.getSnapshot(staleSnapshot.metadata.id), isNull);
+      expect(
+        await repository.getCurrentSnapshotId('chat-1'),
+        advanced.snapshot.metadata.id,
+      );
+
+      final changedJson = _scenario().toJson();
+      (changedJson['metadata'] as Map<String, dynamic>)['name'] = 'Changed';
+      final changedScenario = RpgScenario.fromJson(changedJson);
+      await expectLater(
+        repository.saveScenario(changedScenario),
+        throwsA(isA<StateError>()),
+      );
+      expect(
+        (await repository.getScenario('vault_run'))?.metadata.name,
+        'Vault Run',
+      );
+
+      final orphanService = RpgGameSessionService(
+        repository: repository,
+        now: now,
+        idFactory: () => 'orphan',
+      );
+      await expectLater(
+        orphanService.initialize(
+          chatId: 'missing-chat',
+          scenario: _scenario(),
+          branchId: 'orphan_branch',
+        ),
+        throwsA(anything),
+      );
+      expect(await repository.getSnapshot('snapshot_orphan'), isNull);
+      expect(
+        await repository.listSnapshots(
+          scenarioId: 'vault_run',
+          branchId: 'orphan_branch',
+        ),
+        isEmpty,
+      );
+      expect(await _foreignKeyViolations(database), isEmpty);
+    });
+
+    test('a chat cannot roll back to another session snapshot', () async {
+      final firstSession = await service.initialize(
+        chatId: 'chat-1',
+        scenario: _scenario(),
+        branchId: 'main',
+      );
+      final secondSession = await service.initialize(
+        chatId: 'chat-2',
+        scenario: _scenario(),
+      );
+
+      expect(secondSession.branchId, 'chat_chat-2_main');
+      await expectLater(
+        service.rollback(
+          chatId: 'chat-1',
+          snapshotId: secondSession.snapshot.metadata.id,
+        ),
+        throwsA(
+          isA<RpgSessionException>().having(
+            (error) => error.code,
+            'code',
+            'snapshot_session_mismatch',
+          ),
+        ),
+      );
+      expect(
+        await repository.getCurrentSnapshotId('chat-1'),
+        firstSession.snapshot.metadata.id,
+      );
+    });
+  });
+}
+
+Future<void> _seedChat(AppDatabase database) async {
+  await database.customStatement(
+    'INSERT INTO characters (id, name, created_at, modified_at) '
+    "VALUES ('character-1', 'Character', 1, 1)",
+  );
+  await database.customStatement(
+    'INSERT INTO chats (id, character_id, created_at, updated_at) '
+    "VALUES ('chat-1', 'character-1', 1, 1)",
+  );
+  await database.customStatement(
+    'INSERT INTO chats (id, character_id, created_at, updated_at) '
+    "VALUES ('chat-2', 'character-1', 1, 1)",
+  );
+}
+
+Future<List<Map<String, Object?>>> _foreignKeyViolations(
+  AppDatabase database,
+) async {
+  final rows = await database.customSelect('PRAGMA foreign_key_check').get();
+  return rows.map((row) => row.data).toList();
+}
+
+RpgScenario _scenario() => const RpgScenario(
+      metadata: RpgScenarioMetadata(
+        id: 'vault_run',
+        name: 'Vault Run',
+        version: '1.0.0',
+      ),
+      initialSeed: 12345,
+      protectedFields: [
+        'random.initialSeed',
+        'random.state',
+        'random.rollsConsumed',
+        'turn',
+        'attributes',
+        'inventory',
+        'quests',
+        'cooldowns',
+        'eventHistory',
+      ],
+      attributes: [
+        RpgAttributeDefinition(
+          id: 'courage',
+          label: 'Courage',
+          initialValue: 4,
+          minimum: 0,
+          maximum: 10,
+        ),
+        RpgAttributeDefinition(
+          id: 'energy',
+          label: 'Energy',
+          initialValue: 5,
+          minimum: 0,
+          maximum: 10,
+        ),
+      ],
+      items: [
+        RpgItemDefinition(id: 'key', label: 'Key', stackable: false),
+        RpgItemDefinition(id: 'gem', label: 'Gem'),
+      ],
+      actors: [RpgActorDefinition(id: 'guide', label: 'Guide')],
+      locations: [
+        RpgLocationDefinition(id: 'camp', label: 'Camp'),
+        RpgLocationDefinition(id: 'vault', label: 'Vault'),
+      ],
+      quests: [
+        RpgQuestDefinition(
+          id: 'open_vault',
+          label: 'Open the vault',
+          stages: [
+            RpgQuestStageDefinition(
+              id: 'unlock',
+              label: 'Unlock the door',
+              objectiveIds: ['door'],
+            ),
+          ],
+        ),
+      ],
+      actions: [
+        RpgActionDefinition(
+          id: 'enter_vault',
+          label: 'Enter the vault',
+          availability: [
+            RpgCondition(
+              operator: RpgConditionOperator.all,
+              conditions: [
+                RpgCondition(
+                  operator: RpgConditionOperator.greaterThanOrEqual,
+                  path: 'attributes.energy',
+                  value: 2,
+                ),
+                RpgCondition(
+                  operator: RpgConditionOperator.greaterThanOrEqual,
+                  path: 'inventory.key.quantity',
+                  value: 1,
+                ),
+                RpgCondition(
+                  operator: RpgConditionOperator.any,
+                  conditions: [
+                    RpgCondition(
+                      operator: RpgConditionOperator.equals,
+                      path: 'variables.ready',
+                      value: true,
+                    ),
+                    RpgCondition(
+                      operator: RpgConditionOperator.equals,
+                      path: 'locationId',
+                      value: 'vault',
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ],
+          costs: [RpgActionCost(path: 'attributes.energy', amount: 2)],
+          check: RpgSkillCheck(
+            attributeId: 'courage',
+            dice: RpgDiceSpec('2d6+1'),
+            difficulty: 1,
+            successEffects: [
+              RpgEffect(
+                type: RpgEffectType.setValue,
+                target: 'variables.ready',
+                value: false,
+              ),
+              RpgEffect(
+                type: RpgEffectType.incrementValue,
+                target: 'variables.score',
+                amount: 2,
+              ),
+              RpgEffect(
+                type: RpgEffectType.decrementValue,
+                target: 'attributes.courage',
+                amount: 1,
+              ),
+              RpgEffect(
+                type: RpgEffectType.addItem,
+                target: 'gem',
+                amount: 2,
+              ),
+              RpgEffect(
+                type: RpgEffectType.removeItem,
+                target: 'key',
+                amount: 1,
+              ),
+              RpgEffect(
+                type: RpgEffectType.adjustRelationship,
+                target: 'guide',
+                amount: 3,
+              ),
+              RpgEffect(type: RpgEffectType.moveTo, target: 'vault'),
+              RpgEffect(
+                type: RpgEffectType.setQuestStatus,
+                target: 'open_vault',
+                value: 'completed',
+              ),
+              RpgEffect(
+                type: RpgEffectType.setCooldown,
+                target: 'enter_vault',
+                amount: 2,
+              ),
+              RpgEffect(
+                type: RpgEffectType.appendEvent,
+                target: 'vaultEntered',
+                value: {'source': 'rule'},
+              ),
+            ],
+          ),
+        ),
+        RpgActionDefinition(
+          id: 'wait',
+          label: 'Wait',
+          effects: [
+            RpgEffect(
+              type: RpgEffectType.setValue,
+              target: 'variables.route',
+              value: 'alternate',
+            ),
+          ],
+        ),
+        RpgActionDefinition(
+          id: 'impossible_check',
+          label: 'Impossible check',
+          check: RpgSkillCheck(
+            attributeId: 'courage',
+            dice: RpgDiceSpec('1d6'),
+            difficulty: 1000,
+            failureEffects: [
+              RpgEffect(
+                type: RpgEffectType.setCooldown,
+                target: 'impossible_check',
+                amount: 1,
+              ),
+            ],
+          ),
+        ),
+        RpgActionDefinition(
+          id: 'too_expensive',
+          label: 'Too expensive',
+          costs: [RpgActionCost(path: 'attributes.energy', amount: 99)],
+        ),
+      ],
+      initialState: RpgRuntimeState(
+        scenarioId: 'vault_run',
+        scenarioVersion: '1.0.0',
+        random: RpgRandomState(initialSeed: 12345, state: 12345),
+        attributes: {'courage': 4, 'energy': 5},
+        variables: {
+          'score': 1,
+          'ready': true,
+          'clues': ['map'],
+        },
+        inventory: [RpgInventoryEntry(itemId: 'key', quantity: 1)],
+        locationId: 'camp',
+        quests: [
+          RpgQuestState(
+            questId: 'open_vault',
+            status: RpgQuestStatus.active,
+            stageId: 'unlock',
+            objectiveProgress: {'door': 0},
+          ),
+        ],
+      ),
+    );


### PR DESCRIPTION
## Summary

- C02: execute declarative condition trees, resource costs, seeded dice and skill checks, cooldowns, inventory, quest, relationship, location, variable, and event effects without mutating the input state
- C03: initialize and reload chat sessions, atomically commit current state plus immutable snapshots, record turn audit events and SHA-256 state hashes, roll back, replay, and fork branch roots with lineage and optimistic concurrency checks
- C08: reject protected narrative patches, invalid/underflow transitions, stale commits, scenario replacement with active sessions, cross-session snapshot access, and partial writes

## Verification

- flutter analyze lib/data/models/rpg/rpg_validation.dart lib/domain/repositories/rpg_persistence_repository.dart lib/data/repositories/drift_rpg_persistence_repository.dart lib/domain/services/rpg_rule_engine.dart lib/domain/services/rpg_game_session_service.dart test/rpg_rule_engine_end_to_end_test.dart
- flutter test test/rpg_rule_engine_end_to_end_test.dart (8 passed)
- flutter test test/centralized_persistence_end_to_end_test.dart test/rpg_scenario_contract_test.dart (12 passed)
- flutter test test/rpg_scenario_contract_test.dart test/rpg_scenario_end_to_end_test.dart test/rpg_scenario_package_service_test.dart test/rpg_scenario_editor_screen_test.dart test/centralized_persistence_end_to_end_test.dart test/rpg_rule_engine_end_to_end_test.dart (36 passed)
- flutter test (231 passed, 2 environment-gated PDFium tests skipped)

Closes #26