### PR TITLE
feat: secure built-in tool execution

### DIFF
--- a/lib/domain/models/built_in_tool.dart
+++ b/lib/domain/models/built_in_tool.dart
@@ -1,0 +1,149 @@
+import 'package:native_tavern/domain/models/tool_calling.dart';
+import 'package:native_tavern/domain/services/capability_registry.dart';
+
+enum ToolAccessLevel { readOnly, write, externalSideEffect }
+
+enum ToolDataScope {
+  randomValue,
+  variableName,
+  variableValue,
+  worldInfoQuery,
+  worldInfoContent,
+  imagePrompt,
+  generatedImage,
+}
+
+enum ToolAuthorizationSource { none, userSettings, oneTimeApproval, dryRun }
+
+enum ToolExecutionOutcome { succeeded, failed, cancelled, denied, dryRun }
+
+enum ToolApprovalDecision { approveOnce, deny, cancel }
+
+final class BuiltInToolException implements Exception {
+  final String code;
+  final String message;
+
+  const BuiltInToolException(this.code, this.message);
+
+  @override
+  String toString() => 'Built-in tool error [$code]: $message';
+}
+
+final class BuiltInToolDescriptor {
+  final ToolDefinition definition;
+  final ToolAccessLevel accessLevel;
+  final Set<CapabilityId> requiredCapabilities;
+  final Set<ToolDataScope> dataScopes;
+  final bool supportsDryRun;
+  final String target;
+  final Set<String> sensitiveArgumentNames;
+
+  BuiltInToolDescriptor({
+    required this.definition,
+    required this.accessLevel,
+    Iterable<CapabilityId> requiredCapabilities = const [],
+    Iterable<ToolDataScope> dataScopes = const [],
+    this.supportsDryRun = false,
+    required String target,
+    Iterable<String> sensitiveArgumentNames = const [],
+  })  : requiredCapabilities = Set<CapabilityId>.unmodifiable(
+          requiredCapabilities,
+        ),
+        dataScopes = Set<ToolDataScope>.unmodifiable(dataScopes),
+        target = _requireTarget(target),
+        sensitiveArgumentNames = Set<String>.unmodifiable(
+          sensitiveArgumentNames,
+        );
+
+  bool get requiresOneTimeApproval => accessLevel != ToolAccessLevel.readOnly;
+
+  static String _requireTarget(String value) {
+    final target = value.trim();
+    final validTarget = RegExp(r'^[A-Za-z0-9][A-Za-z0-9._:/-]{0,127}$');
+    if (!validTarget.hasMatch(target) || target.contains('..')) {
+      throw ArgumentError.value(
+        value,
+        'target',
+        'Target must be a logical identifier without credentials or query data.',
+      );
+    }
+    return target;
+  }
+}
+
+final class ToolPermissionSnapshot {
+  static const none = ToolPermissionSnapshot._(<String>{});
+
+  final Set<String> allowedToolNames;
+
+  factory ToolPermissionSnapshot.fromUserSettings(
+    Iterable<String> allowedToolNames,
+  ) {
+    final names = allowedToolNames.map((name) => name.trim()).toSet();
+    if (names.any((name) => name.isEmpty)) {
+      throw ArgumentError.value(
+        allowedToolNames,
+        'allowedToolNames',
+        'Enabled tool names must not be empty.',
+      );
+    }
+    return ToolPermissionSnapshot._(Set<String>.unmodifiable(names));
+  }
+
+  const ToolPermissionSnapshot._(this.allowedToolNames);
+
+  bool allows(String toolName) => allowedToolNames.contains(toolName);
+}
+
+final class ToolCapabilitySnapshot {
+  static const none = ToolCapabilitySnapshot._(<CapabilityId>{});
+
+  final Set<CapabilityId> availableCapabilities;
+
+  factory ToolCapabilitySnapshot.available(
+    Iterable<CapabilityId> capabilities,
+  ) {
+    return ToolCapabilitySnapshot._(
+      Set<CapabilityId>.unmodifiable(capabilities),
+    );
+  }
+
+  const ToolCapabilitySnapshot._(this.availableCapabilities);
+
+  bool satisfies(Iterable<CapabilityId> required) {
+    return required.every(availableCapabilities.contains);
+  }
+}
+
+final class ToolExecutionPreview {
+  final String callId;
+  final String toolName;
+  final ToolAccessLevel accessLevel;
+  final String target;
+  final Map<String, dynamic> parameters;
+  final Set<CapabilityId> requiredCapabilities;
+  final Set<ToolDataScope> dataScopes;
+  final bool requiresConfirmation;
+  final bool supportsDryRun;
+  final bool dryRun;
+
+  ToolExecutionPreview({
+    required this.callId,
+    required this.toolName,
+    required this.accessLevel,
+    required this.target,
+    required Map<String, dynamic> parameters,
+    required Iterable<CapabilityId> requiredCapabilities,
+    required Iterable<ToolDataScope> dataScopes,
+    required this.requiresConfirmation,
+    required this.supportsDryRun,
+    required this.dryRun,
+  })  : parameters = copyToolJsonObject(parameters),
+        requiredCapabilities = Set<CapabilityId>.unmodifiable(
+          requiredCapabilities,
+        ),
+        dataScopes = Set<ToolDataScope>.unmodifiable(dataScopes);
+}
+
+typedef ToolApprovalHandler = Future<ToolApprovalDecision> Function(
+    ToolExecutionPreview preview);

--- a/lib/domain/services/image_generation_service.dart
+++ b/lib/domain/services/image_generation_service.dart
@@ -741,7 +741,11 @@ class ImageGenerationService {
 
   /// Extract images from arbitrary response data (text containing URLs, base64, etc.)
   /// This is used as a fallback when the response doesn't contain images in standard format
-  Future<List<Uint8List>> _extractImagesFromResponse(dynamic responseData, {String debugPrefix = ''}) async {
+  Future<List<Uint8List>> _extractImagesFromResponse(
+    dynamic responseData, {
+    String debugPrefix = '',
+    CancelToken? cancelToken,
+  }) async {
     final images = <Uint8List>[];
     
     // Convert response to string for URL extraction
@@ -788,7 +792,7 @@ class ImageGenerationService {
     if (textContent.isNotEmpty) {
       final urls = extractImageUrls(textContent);
       for (final url in urls) {
-        debugPrint('$debugPrefix Found URL: $url');
+        debugPrint('$debugPrefix Found image URL');
         try {
           if (url.startsWith('data:image')) {
             // Base64 data URL
@@ -796,13 +800,13 @@ class ImageGenerationService {
             images.add(base64Decode(base64Data));
           } else {
             // Regular URL - download it
-            final imgData = await downloadImage(url);
+            final imgData = await downloadImage(url, cancelToken: cancelToken);
             if (imgData != null) {
               images.add(imgData);
             }
           }
-        } catch (e) {
-          debugPrint('$debugPrefix Failed to process URL $url: $e');
+        } catch (_) {
+          debugPrint('$debugPrefix Failed to process image URL');
         }
       }
     }
@@ -811,44 +815,58 @@ class ImageGenerationService {
   }
 
   /// Generate images based on current provider
-  Future<ImageGenResult?> generate(ImageGenRequest request) async {
+  Future<ImageGenResult?> generate(
+    ImageGenRequest request, {
+    CancelToken? cancelToken,
+  }) async {
     if (!_settings.enabled) return null;
 
     final model = request.model ?? _settings.model;
     
     try {
       debugPrint('Image Generation [${_settings.provider.displayName}]');
-      debugPrint('  Model: $model');
-      debugPrint('  Prompt: "${request.prompt}"');
+      debugPrint('  Model configured: ${model.isNotEmpty}');
+      debugPrint('  Prompt length: ${request.prompt.length}');
       debugPrint('  Size: ${request.width}x${request.height}');
-      debugPrint('  Endpoint: ${_settings.effectiveEndpoint}');
+      debugPrint('  Endpoint provider: ${_settings.provider.id}');
 
       switch (_settings.provider) {
         case ImageGenProvider.openai:
-          return await _generateOpenAI(request, model);
+          return await _generateOpenAI(request, model, cancelToken: cancelToken);
         case ImageGenProvider.openaiChat:
-          return await _generateOpenAIChat(request, model);
+          return await _generateOpenAIChat(
+            request,
+            model,
+            cancelToken: cancelToken,
+          );
         case ImageGenProvider.gemini:
-          return await _generateGemini(request, model);
+          return await _generateGemini(request, model, cancelToken: cancelToken);
         case ImageGenProvider.novelai:
-          return await _generateNovelAI(request, model);
+          return await _generateNovelAI(request, model, cancelToken: cancelToken);
         case ImageGenProvider.pollinations:
-          return await _generatePollinations(request, model);
+          return await _generatePollinations(
+            request,
+            model,
+            cancelToken: cancelToken,
+          );
         case ImageGenProvider.automatic1111:
-          return await _generateAutomatic1111(request);
+          return await _generateAutomatic1111(request, cancelToken: cancelToken);
         case ImageGenProvider.comfyui:
-          return await _generateComfyUI(request);
+          return await _generateComfyUI(request, cancelToken: cancelToken);
       }
-    } catch (e, stack) {
-      debugPrint('Image generation error: $e\n$stack');
-      onError?.call('Image generation error: $e');
+    } catch (error) {
+      debugPrint('Image generation error: ${error.runtimeType}');
+      onError?.call('Image generation failed');
       return null;
     }
   }
 
   /// Generate image using Pollinations (free, no API key)
   Future<ImageGenResult?> _generatePollinations(
-      ImageGenRequest request, String model) async {
+    ImageGenRequest request,
+    String model, {
+    CancelToken? cancelToken,
+  }) async {
     onProgress?.call(0.1);
 
     final requestSeed = request.seed;
@@ -866,6 +884,7 @@ class ImageGenerationService {
 
     final response = await _dio.get<List<int>>(
       url,
+      cancelToken: cancelToken,
       options: Options(
         responseType: ResponseType.bytes,
         receiveTimeout: const Duration(minutes: 3),
@@ -887,7 +906,11 @@ class ImageGenerationService {
   }
 
   /// Generate image using OpenAI (DALL-E 2/3 or GPT-Image-1)
-  Future<ImageGenResult?> _generateOpenAI(ImageGenRequest request, String model) async {
+  Future<ImageGenResult?> _generateOpenAI(
+    ImageGenRequest request,
+    String model, {
+    CancelToken? cancelToken,
+  }) async {
     final apiKey = _settings.apiKey;
     if (apiKey == null || apiKey.isEmpty) {
       throw Exception('OpenAI API key is required');
@@ -927,6 +950,7 @@ class ImageGenerationService {
     final endpoint = _settings.effectiveEndpoint;
     final response = await _dio.post<Map<String, dynamic>>(
       '$endpoint/images/generations',
+      cancelToken: cancelToken,
       options: Options(headers: {
         'Authorization': 'Bearer $apiKey',
         'Content-Type': 'application/json',
@@ -948,7 +972,10 @@ class ImageGenerationService {
         images.add(base64Decode(item['b64_json'] as String));
       } else if (item['url'] != null) {
         // Some responses return URL instead of base64
-        final imgData = await downloadImage(item['url'] as String);
+        final imgData = await downloadImage(
+          item['url'] as String,
+          cancelToken: cancelToken,
+        );
         if (imgData != null) {
           images.add(imgData);
         }
@@ -958,7 +985,11 @@ class ImageGenerationService {
     // Fallback: try to extract images from the raw response
     if (images.isEmpty) {
       debugPrint('OpenAI: No images in standard format, trying fallback extraction...');
-      final fallbackImages = await _extractImagesFromResponse(data, debugPrefix: 'OpenAI: ');
+      final fallbackImages = await _extractImagesFromResponse(
+        data,
+        debugPrefix: 'OpenAI: ',
+        cancelToken: cancelToken,
+      );
       images.addAll(fallbackImages);
     }
 
@@ -975,7 +1006,11 @@ class ImageGenerationService {
 
   /// Generate image using OpenAI Chat API (chat/completions)
   /// This is for APIs that use chat format for image generation (like some compatible APIs)
-  Future<ImageGenResult?> _generateOpenAIChat(ImageGenRequest request, String model) async {
+  Future<ImageGenResult?> _generateOpenAIChat(
+    ImageGenRequest request,
+    String model, {
+    CancelToken? cancelToken,
+  }) async {
     final apiKey = _settings.apiKey;
     if (apiKey == null || apiKey.isEmpty) {
       throw Exception('API key is required');
@@ -999,13 +1034,14 @@ class ImageGenerationService {
 
     debugPrint('OpenAI-Chat: Sending request to chat/completions');
     debugPrint('OpenAI-Chat: Model: $model');
-    debugPrint('OpenAI-Chat: Prompt: $prompt');
+    debugPrint('OpenAI-Chat: Prompt length: ${prompt.length}');
 
     onProgress?.call(0.3);
 
     final endpoint = _settings.effectiveEndpoint;
     final response = await _dio.post<Map<String, dynamic>>(
       '$endpoint/chat/completions',
+      cancelToken: cancelToken,
       options: Options(headers: {
         'Authorization': 'Bearer $apiKey',
         'Content-Type': 'application/json',
@@ -1048,8 +1084,11 @@ class ImageGenerationService {
                 final url = imageData['url'];
                 if (url != null && url is String) {
                   // Download the image from URL
-                  debugPrint('OpenAI-Chat: Downloading image from URL: $url');
-                  final imgData = await downloadImage(url);
+                  debugPrint('OpenAI-Chat: Downloading image from URL');
+                  final imgData = await downloadImage(
+                    url,
+                    cancelToken: cancelToken,
+                  );
                   if (imgData != null) {
                     images.add(imgData);
                   }
@@ -1064,14 +1103,17 @@ class ImageGenerationService {
         // Try to extract image URLs from the text response
         final urls = extractImageUrls(content);
         for (final url in urls) {
-          debugPrint('OpenAI-Chat: Found URL in response: $url');
+          debugPrint('OpenAI-Chat: Found image URL in response');
           if (url.startsWith('data:image')) {
             // Base64 data URL
             final base64Data = url.replaceFirst(RegExp(r'^data:image/[^;]+;base64,'), '');
             images.add(base64Decode(base64Data));
           } else {
             // Regular URL - download it
-            final imgData = await downloadImage(url);
+            final imgData = await downloadImage(
+              url,
+              cancelToken: cancelToken,
+            );
             if (imgData != null) {
               images.add(imgData);
             }
@@ -1084,7 +1126,7 @@ class ImageGenerationService {
 
     if (images.isEmpty) {
       debugPrint('OpenAI-Chat: No images found in response');
-      debugPrint('OpenAI-Chat: Response data: $data');
+      debugPrint('OpenAI-Chat: Response contained no usable image data');
       throw Exception('No images generated - response did not contain image data');
     }
 
@@ -1100,7 +1142,11 @@ class ImageGenerationService {
   }
 
   /// Generate image using Gemini (Imagen / Nano-Banana models)
-  Future<ImageGenResult?> _generateGemini(ImageGenRequest request, String model) async {
+  Future<ImageGenResult?> _generateGemini(
+    ImageGenRequest request,
+    String model, {
+    CancelToken? cancelToken,
+  }) async {
     final apiKey = _settings.apiKey;
     if (apiKey == null || apiKey.isEmpty) {
       throw Exception('Gemini API key is required');
@@ -1148,6 +1194,7 @@ class ImageGenerationService {
     final endpoint = _settings.effectiveEndpoint;
     final response = await _dio.post<Map<String, dynamic>>(
       '$endpoint/models/$model:generateContent?key=$apiKey',
+      cancelToken: cancelToken,
       options: Options(headers: {
         'Content-Type': 'application/json',
       }),
@@ -1180,7 +1227,11 @@ class ImageGenerationService {
           }
           // Also check for text content that may contain image URLs
           if (part['text'] != null && images.isEmpty) {
-            final textImages = await _extractImagesFromResponse(part['text'], debugPrefix: 'Gemini: ');
+            final textImages = await _extractImagesFromResponse(
+              part['text'],
+              debugPrefix: 'Gemini: ',
+              cancelToken: cancelToken,
+            );
             images.addAll(textImages);
           }
         }
@@ -1190,7 +1241,11 @@ class ImageGenerationService {
     // Fallback: try to extract images from the raw response
     if (images.isEmpty) {
       debugPrint('Gemini: No images in standard format, trying fallback extraction...');
-      final fallbackImages = await _extractImagesFromResponse(data, debugPrefix: 'Gemini: ');
+      final fallbackImages = await _extractImagesFromResponse(
+        data,
+        debugPrefix: 'Gemini: ',
+        cancelToken: cancelToken,
+      );
       images.addAll(fallbackImages);
     }
 
@@ -1210,7 +1265,11 @@ class ImageGenerationService {
   }
 
   /// Generate image using NovelAI
-  Future<ImageGenResult?> _generateNovelAI(ImageGenRequest request, String model) async {
+  Future<ImageGenResult?> _generateNovelAI(
+    ImageGenRequest request,
+    String model, {
+    CancelToken? cancelToken,
+  }) async {
     final apiKey = _settings.apiKey;
     if (apiKey == null || apiKey.isEmpty) {
       throw Exception('NovelAI API key is required');
@@ -1311,15 +1370,16 @@ class ImageGenerationService {
 
     onProgress?.call(0.2);
     
-    // Debug: print the request body
-    debugPrint('NovelAI: Request body:');
-    debugPrint(const JsonEncoder.withIndent('  ').convert(requestBody));
+    debugPrint(
+      'NovelAI: Request prepared (${request.prompt.length} prompt characters)',
+    );
 
     final endpoint = _settings.effectiveEndpoint;
     
     try {
       final response = await _dio.post<List<int>>(
         '$endpoint/ai/generate-image',
+        cancelToken: cancelToken,
         options: Options(
           headers: {
             'Authorization': 'Bearer $apiKey',
@@ -1338,7 +1398,6 @@ class ImageGenerationService {
         String errorMsg = 'NovelAI error: ${response.statusCode}';
         try {
           final errorBody = utf8.decode(response.data as List<int>);
-          debugPrint('NovelAI: Error response: $errorBody');
           errorMsg = 'NovelAI error: ${response.statusCode} - $errorBody';
         } catch (_) {
           debugPrint('NovelAI: Could not decode error body');
@@ -1374,7 +1433,6 @@ class ImageGenerationService {
       if (e is DioException && e.response != null) {
         try {
           final errorBody = utf8.decode(e.response!.data as List<int>);
-          debugPrint('NovelAI: DioException response: $errorBody');
           throw Exception('NovelAI error: ${e.response!.statusCode} - $errorBody');
         } catch (_) {}
       }
@@ -1399,7 +1457,10 @@ class ImageGenerationService {
   }
 
   /// Generate image using Automatic1111 WebUI
-  Future<ImageGenResult?> _generateAutomatic1111(ImageGenRequest request) async {
+  Future<ImageGenResult?> _generateAutomatic1111(
+    ImageGenRequest request, {
+    CancelToken? cancelToken,
+  }) async {
     onProgress?.call(0.1);
 
     final requestBody = {
@@ -1419,6 +1480,7 @@ class ImageGenerationService {
     final endpoint = _settings.effectiveEndpoint;
     final response = await _dio.post<Map<String, dynamic>>(
       '$endpoint/sdapi/v1/txt2img',
+      cancelToken: cancelToken,
       options: Options(headers: {
         'Content-Type': 'application/json',
       }),
@@ -1453,7 +1515,10 @@ class ImageGenerationService {
   }
 
   /// Generate image using ComfyUI (placeholder)
-  Future<ImageGenResult?> _generateComfyUI(ImageGenRequest request) async {
+  Future<ImageGenResult?> _generateComfyUI(
+    ImageGenRequest request, {
+    CancelToken? cancelToken,
+  }) async {
     // ComfyUI requires workflow-based generation
     throw UnimplementedError('ComfyUI generation requires workflow configuration');
   }
@@ -1489,7 +1554,10 @@ class ImageGenerationService {
   }
 
   /// Download image from URL
-  Future<Uint8List?> downloadImage(String url) async {
+  Future<Uint8List?> downloadImage(
+    String url, {
+    CancelToken? cancelToken,
+  }) async {
     try {
       if (url.startsWith('data:image')) {
         // Handle base64 data URL
@@ -1499,13 +1567,14 @@ class ImageGenerationService {
       
       final response = await _dio.get<List<int>>(
         url,
+        cancelToken: cancelToken,
         options: Options(responseType: ResponseType.bytes),
       );
       if (response.statusCode == 200) {
         return Uint8List.fromList(response.data as List<int>);
       }
-    } catch (e) {
-      debugPrint('Failed to download image: $e');
+    } catch (_) {
+      debugPrint('Failed to download image');
     }
     return null;
   }

--- a/lib/domain/services/tool_calling/built_in_tool_service.dart
+++ b/lib/domain/services/tool_calling/built_in_tool_service.dart
@@ -1,0 +1,1141 @@
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:dio/dio.dart';
+import 'package:native_tavern/data/models/world_info.dart';
+import 'package:native_tavern/data/repositories/world_info_repository.dart';
+import 'package:native_tavern/domain/models/built_in_tool.dart';
+import 'package:native_tavern/domain/models/tool_calling.dart';
+import 'package:native_tavern/domain/services/capability_registry.dart';
+import 'package:native_tavern/domain/services/image_generation_service.dart';
+import 'package:native_tavern/domain/services/tool_calling/tool_execution_audit_service.dart';
+import 'package:native_tavern/domain/services/variables_service.dart';
+
+abstract class BuiltInToolExecutor {
+  BuiltInToolDescriptor get descriptor;
+
+  Map<String, dynamic> validateArguments(Map<String, dynamic> arguments);
+
+  Future<Object?> execute(
+    Map<String, dynamic> arguments,
+    ToolInvocationContext context,
+  );
+
+  Future<Object?> dryRun(
+    Map<String, dynamic> arguments,
+    ToolInvocationContext context,
+  ) async {
+    throw const BuiltInToolException(
+      'dry_run_unsupported',
+      'This tool does not support dry-run.',
+    );
+  }
+}
+
+final class BuiltInToolRegistry {
+  final Object _identity = Object();
+  final Map<String, BuiltInToolExecutor> _executors;
+
+  BuiltInToolRegistry(Iterable<BuiltInToolExecutor> executors)
+      : _executors = _indexExecutors(executors);
+
+  factory BuiltInToolRegistry.nativeTavern({
+    required ToolImageGenerator imageGenerator,
+    required ToolVariableReader variableReader,
+    required ToolWorldInfoSource worldInfoSource,
+    math.Random? random,
+  }) {
+    return BuiltInToolRegistry([
+      GenerateImageToolExecutor(imageGenerator),
+      RollDiceToolExecutor(random: random),
+      ReadVariableToolExecutor(variableReader),
+      SearchWorldInfoToolExecutor(worldInfoSource),
+    ]);
+  }
+
+  List<BuiltInToolDescriptor> get descriptors => List.unmodifiable(
+        _executors.values.map((executor) => executor.descriptor),
+      );
+
+  List<ToolDefinition> get definitions => List.unmodifiable(
+        _executors.values.map((executor) => executor.descriptor.definition),
+      );
+
+  BuiltInToolDescriptor? descriptorFor(String toolName) {
+    return _executors[toolName]?.descriptor;
+  }
+
+  BuiltInToolExecutor? _executorFor(String toolName) => _executors[toolName];
+
+  static Map<String, BuiltInToolExecutor> _indexExecutors(
+    Iterable<BuiltInToolExecutor> executors,
+  ) {
+    final result = <String, BuiltInToolExecutor>{};
+    for (final executor in executors) {
+      final name = executor.descriptor.definition.name;
+      if (result.containsKey(name)) {
+        throw ArgumentError.value(name, 'executors', 'Duplicate tool name.');
+      }
+      result[name] = executor;
+    }
+    return Map<String, BuiltInToolExecutor>.unmodifiable(result);
+  }
+}
+
+final class BuiltInToolExecutionPlan {
+  final Object _registryIdentity;
+  final BuiltInToolExecutor _executor;
+  final Map<String, dynamic> _arguments;
+  final ToolExecutionPreview preview;
+
+  BuiltInToolExecutionPlan._(
+    this._registryIdentity,
+    this._executor,
+    Map<String, dynamic> arguments,
+    this.preview,
+  ) : _arguments = copyToolJsonObject(arguments);
+}
+
+final class BuiltInToolExecutionService {
+  final BuiltInToolRegistry registry;
+  final ToolExecutionAuditRepository auditRepository;
+  final DateTime Function() _clock;
+
+  BuiltInToolExecutionService({
+    required this.registry,
+    this.auditRepository = const NoopToolExecutionAuditRepository(),
+    DateTime Function()? clock,
+  }) : _clock = clock ?? DateTime.now;
+
+  BuiltInToolExecutionPlan prepare(ToolCall call, {bool dryRun = false}) {
+    if (call.status != ToolCallStatus.ready) {
+      throw BuiltInToolException(
+        'invalid_tool_call',
+        call.status == ToolCallStatus.cancelled
+            ? 'A cancelled tool call cannot be prepared.'
+            : 'Tool arguments must be valid before execution.',
+      );
+    }
+    final executor = registry._executorFor(call.name);
+    if (executor == null) {
+      throw const BuiltInToolException(
+        'unknown_tool',
+        'The requested built-in tool is not registered.',
+      );
+    }
+    final descriptor = executor.descriptor;
+    if (dryRun && !descriptor.supportsDryRun) {
+      throw const BuiltInToolException(
+        'dry_run_unsupported',
+        'This tool does not support dry-run.',
+      );
+    }
+
+    final arguments = executor.validateArguments(call.arguments);
+    final preview = ToolExecutionPreview(
+      callId: call.id,
+      toolName: call.name,
+      accessLevel: descriptor.accessLevel,
+      target: descriptor.target,
+      parameters: arguments,
+      requiredCapabilities: descriptor.requiredCapabilities,
+      dataScopes: descriptor.dataScopes,
+      requiresConfirmation: descriptor.requiresOneTimeApproval && !dryRun,
+      supportsDryRun: descriptor.supportsDryRun,
+      dryRun: dryRun,
+    );
+    return BuiltInToolExecutionPlan._(
+      registry._identity,
+      executor,
+      arguments,
+      preview,
+    );
+  }
+
+  Future<ToolResultMessage> execute(
+    BuiltInToolExecutionPlan plan, {
+    ToolPermissionSnapshot permissions = ToolPermissionSnapshot.none,
+    ToolCapabilitySnapshot capabilities = ToolCapabilitySnapshot.none,
+    ToolInvocationContext? invocationContext,
+    ToolApprovalHandler? requestApproval,
+  }) async {
+    final stopwatch = Stopwatch()..start();
+    final preview = plan.preview;
+    final descriptor = plan._executor.descriptor;
+    final context = invocationContext ??
+        ToolInvocationContext(
+          maxDepth: 1,
+          cancellationToken: ToolCancellationController().token,
+        );
+    var authorizationSource = ToolAuthorizationSource.none;
+
+    if (!identical(plan._registryIdentity, registry._identity)) {
+      return _finish(
+        preview: preview,
+        descriptor: descriptor,
+        arguments: plan._arguments,
+        stopwatch: stopwatch,
+        authorizationSource: authorizationSource,
+        outcome: ToolExecutionOutcome.denied,
+        status: ToolResultStatus.failed,
+        errorCode: 'invalid_execution_plan',
+        errorMessage: 'The execution plan belongs to another registry.',
+      );
+    }
+
+    try {
+      context.cancellationToken.throwIfCancelled();
+      if (!permissions.allows(preview.toolName)) {
+        return _finish(
+          preview: preview,
+          descriptor: descriptor,
+          arguments: plan._arguments,
+          stopwatch: stopwatch,
+          authorizationSource: authorizationSource,
+          outcome: ToolExecutionOutcome.denied,
+          status: ToolResultStatus.failed,
+          errorCode: 'permission_denied',
+          errorMessage: 'The tool is disabled in user settings.',
+        );
+      }
+      authorizationSource = ToolAuthorizationSource.userSettings;
+
+      if (preview.dryRun) {
+        final output = await plan._executor.dryRun(plan._arguments, context);
+        context.cancellationToken.throwIfCancelled();
+        return _finish(
+          preview: preview,
+          descriptor: descriptor,
+          arguments: plan._arguments,
+          stopwatch: stopwatch,
+          authorizationSource: ToolAuthorizationSource.dryRun,
+          outcome: ToolExecutionOutcome.dryRun,
+          status: ToolResultStatus.succeeded,
+          output: output,
+        );
+      }
+
+      if (!capabilities.satisfies(descriptor.requiredCapabilities)) {
+        return _finish(
+          preview: preview,
+          descriptor: descriptor,
+          arguments: plan._arguments,
+          stopwatch: stopwatch,
+          authorizationSource: authorizationSource,
+          outcome: ToolExecutionOutcome.failed,
+          status: ToolResultStatus.failed,
+          errorCode: 'capability_unavailable',
+          errorMessage: 'A required capability is unavailable.',
+        );
+      }
+
+      if (descriptor.requiresOneTimeApproval) {
+        if (requestApproval == null) {
+          return _finish(
+            preview: preview,
+            descriptor: descriptor,
+            arguments: plan._arguments,
+            stopwatch: stopwatch,
+            authorizationSource: authorizationSource,
+            outcome: ToolExecutionOutcome.denied,
+            status: ToolResultStatus.failed,
+            errorCode: 'approval_required',
+            errorMessage: 'This tool requires one-time user approval.',
+          );
+        }
+        final decision = await requestApproval(preview);
+        context.cancellationToken.throwIfCancelled();
+        switch (decision) {
+          case ToolApprovalDecision.approveOnce:
+            authorizationSource = ToolAuthorizationSource.oneTimeApproval;
+          case ToolApprovalDecision.deny:
+            return _finish(
+              preview: preview,
+              descriptor: descriptor,
+              arguments: plan._arguments,
+              stopwatch: stopwatch,
+              authorizationSource: authorizationSource,
+              outcome: ToolExecutionOutcome.denied,
+              status: ToolResultStatus.failed,
+              errorCode: 'approval_denied',
+              errorMessage: 'The user denied this tool call.',
+            );
+          case ToolApprovalDecision.cancel:
+            return _finish(
+              preview: preview,
+              descriptor: descriptor,
+              arguments: plan._arguments,
+              stopwatch: stopwatch,
+              authorizationSource: authorizationSource,
+              outcome: ToolExecutionOutcome.cancelled,
+              status: ToolResultStatus.cancelled,
+              errorCode: 'cancelled',
+              errorMessage: 'The user cancelled this tool call.',
+            );
+        }
+      }
+
+      final output = await plan._executor.execute(plan._arguments, context);
+      context.cancellationToken.throwIfCancelled();
+      return _finish(
+        preview: preview,
+        descriptor: descriptor,
+        arguments: plan._arguments,
+        stopwatch: stopwatch,
+        authorizationSource: authorizationSource,
+        outcome: ToolExecutionOutcome.succeeded,
+        status: ToolResultStatus.succeeded,
+        output: output,
+      );
+    } on ToolProtocolException catch (error) {
+      final cancelled = error.code == 'cancelled';
+      return _finish(
+        preview: preview,
+        descriptor: descriptor,
+        arguments: plan._arguments,
+        stopwatch: stopwatch,
+        authorizationSource: authorizationSource,
+        outcome: cancelled
+            ? ToolExecutionOutcome.cancelled
+            : ToolExecutionOutcome.failed,
+        status:
+            cancelled ? ToolResultStatus.cancelled : ToolResultStatus.failed,
+        errorCode: error.code,
+        errorMessage: cancelled
+            ? 'Tool execution was cancelled.'
+            : 'Tool execution failed protocol validation.',
+      );
+    } on BuiltInToolException catch (error) {
+      return _finish(
+        preview: preview,
+        descriptor: descriptor,
+        arguments: plan._arguments,
+        stopwatch: stopwatch,
+        authorizationSource: authorizationSource,
+        outcome: ToolExecutionOutcome.failed,
+        status: ToolResultStatus.failed,
+        errorCode: error.code,
+        errorMessage: error.message,
+      );
+    } catch (_) {
+      return _finish(
+        preview: preview,
+        descriptor: descriptor,
+        arguments: plan._arguments,
+        stopwatch: stopwatch,
+        authorizationSource: authorizationSource,
+        outcome: ToolExecutionOutcome.failed,
+        status: ToolResultStatus.failed,
+        errorCode: 'execution_failed',
+        errorMessage: 'Tool execution failed.',
+      );
+    }
+  }
+
+  Future<ToolResultMessage> _finish({
+    required ToolExecutionPreview preview,
+    required BuiltInToolDescriptor descriptor,
+    required Map<String, dynamic> arguments,
+    required Stopwatch stopwatch,
+    required ToolAuthorizationSource authorizationSource,
+    required ToolExecutionOutcome outcome,
+    required ToolResultStatus status,
+    Object? output,
+    String? errorCode,
+    String? errorMessage,
+  }) async {
+    stopwatch.stop();
+    final record = ToolExecutionAuditRecord(
+      timestamp: _clock().toUtc(),
+      callIdFingerprint: fingerprintToolCallId(preview.callId),
+      toolName: preview.toolName,
+      accessLevel: preview.accessLevel,
+      parameterSummary: summarizeToolArguments(
+        arguments,
+        sensitiveArgumentNames: descriptor.sensitiveArgumentNames,
+      ),
+      target: preview.target,
+      authorizationSource: authorizationSource,
+      result: outcome,
+      errorCode: errorCode,
+      durationMilliseconds: stopwatch.elapsedMilliseconds,
+    );
+    try {
+      await auditRepository.record(record);
+    } catch (_) {
+      // Audit storage failure must not misreport an already executed side effect.
+    }
+
+    final resultOutput = errorCode == null
+        ? output
+        : {
+            'error': {
+              'code': errorCode,
+              'message': errorMessage ?? 'Tool execution failed.',
+            },
+          };
+    return ToolResultMessage(
+      callId: preview.callId,
+      toolName: preview.toolName,
+      output: resultOutput,
+      status: status,
+    );
+  }
+}
+
+abstract interface class ToolImageGenerator {
+  bool get isAvailable;
+
+  Future<ImageGenResult?> generate(
+    ImageGenRequest request,
+    ToolCancellationToken cancellationToken,
+  );
+}
+
+final class ImageGenerationServiceToolImageGenerator
+    implements ToolImageGenerator {
+  final ImageGenerationService service;
+
+  const ImageGenerationServiceToolImageGenerator(this.service);
+
+  @override
+  bool get isAvailable {
+    final settings = service.settings;
+    if (!settings.enabled) return false;
+    return !settings.provider.requiresApiKey ||
+        (settings.apiKey?.trim().isNotEmpty ?? false);
+  }
+
+  @override
+  Future<ImageGenResult?> generate(
+    ImageGenRequest request,
+    ToolCancellationToken cancellationToken,
+  ) async {
+    cancellationToken.throwIfCancelled();
+    final cancelToken = CancelToken();
+    cancellationToken.whenCancelled((reason) {
+      if (!cancelToken.isCancelled) cancelToken.cancel();
+    });
+    final result = await service.generate(request, cancelToken: cancelToken);
+    cancellationToken.throwIfCancelled();
+    return result;
+  }
+}
+
+final class GenerateImageToolExecutor extends BuiltInToolExecutor {
+  static const toolName = 'generate_image';
+  final ToolImageGenerator _generator;
+
+  GenerateImageToolExecutor(this._generator);
+
+  @override
+  BuiltInToolDescriptor get descriptor => BuiltInToolDescriptor(
+        definition: ToolDefinition(
+          name: toolName,
+          description: 'Generate an image with the configured image provider.',
+          inputSchema: const {
+            'type': 'object',
+            'additionalProperties': false,
+            'properties': {
+              'prompt': {'type': 'string', 'minLength': 1, 'maxLength': 8000},
+              'negative_prompt': {'type': 'string', 'maxLength': 8000},
+              'width': {'type': 'integer', 'minimum': 64, 'maximum': 4096},
+              'height': {'type': 'integer', 'minimum': 64, 'maximum': 4096},
+              'steps': {'type': 'integer', 'minimum': 1, 'maximum': 150},
+              'cfg_scale': {'type': 'number', 'minimum': 0, 'maximum': 30},
+              'sampler': {'type': 'string', 'maxLength': 64},
+              'scheduler': {'type': 'string', 'maxLength': 64},
+              'model': {'type': 'string', 'maxLength': 128},
+              'seed': {'type': 'integer', 'minimum': -1, 'maximum': 2147483647},
+              'batch_size': {'type': 'integer', 'minimum': 1, 'maximum': 4},
+            },
+            'required': ['prompt'],
+          },
+        ),
+        accessLevel: ToolAccessLevel.externalSideEffect,
+        requiredCapabilities: const {CapabilityId.imageGeneration},
+        dataScopes: const {
+          ToolDataScope.imagePrompt,
+          ToolDataScope.generatedImage
+        },
+        supportsDryRun: true,
+        target: 'configured:image-generation-provider',
+        sensitiveArgumentNames: const {'prompt', 'negative_prompt'},
+      );
+
+  @override
+  Map<String, dynamic> validateArguments(Map<String, dynamic> arguments) {
+    const allowed = {
+      'prompt',
+      'negative_prompt',
+      'width',
+      'height',
+      'steps',
+      'cfg_scale',
+      'sampler',
+      'scheduler',
+      'model',
+      'seed',
+      'batch_size',
+    };
+    final input = _StrictToolArguments(arguments, allowed);
+    final width =
+        input.optionalInt('width', minimum: 64, maximum: 4096) ?? 1024;
+    final height =
+        input.optionalInt('height', minimum: 64, maximum: 4096) ?? 1024;
+    if (width % 8 != 0 || height % 8 != 0) {
+      throw const BuiltInToolException(
+        'invalid_arguments',
+        'Image width and height must be divisible by 8.',
+      );
+    }
+    return {
+      'prompt': input.requiredString('prompt', maxLength: 8000),
+      if (input.optionalString('negative_prompt', maxLength: 8000)
+          case final value?)
+        'negative_prompt': value,
+      'width': width,
+      'height': height,
+      'steps': input.optionalInt('steps', minimum: 1, maximum: 150) ?? 20,
+      'cfg_scale':
+          input.optionalDouble('cfg_scale', minimum: 0, maximum: 30) ?? 7.0,
+      'sampler': input.optionalString('sampler', maxLength: 64) ?? 'euler_a',
+      if (input.optionalString('scheduler', maxLength: 64) case final value?)
+        'scheduler': value,
+      if (input.optionalString('model', maxLength: 128) case final value?)
+        'model': value,
+      if (input.optionalInt('seed', minimum: -1, maximum: 0x7fffffff)
+          case final value?)
+        'seed': value,
+      'batch_size':
+          input.optionalInt('batch_size', minimum: 1, maximum: 4) ?? 1,
+    };
+  }
+
+  @override
+  Future<Object?> dryRun(
+    Map<String, dynamic> arguments,
+    ToolInvocationContext context,
+  ) async {
+    context.cancellationToken.throwIfCancelled();
+    return {
+      'dry_run': true,
+      'target': descriptor.target,
+      'prompt_length': (arguments['prompt'] as String).length,
+      'negative_prompt_length':
+          (arguments['negative_prompt'] as String?)?.length ?? 0,
+      'width': arguments['width'],
+      'height': arguments['height'],
+      'steps': arguments['steps'],
+      'batch_size': arguments['batch_size'],
+      'would_execute': false,
+    };
+  }
+
+  @override
+  Future<Object?> execute(
+    Map<String, dynamic> arguments,
+    ToolInvocationContext context,
+  ) async {
+    if (!_generator.isAvailable) {
+      throw const BuiltInToolException(
+        'capability_unavailable',
+        'Image generation is not configured or enabled.',
+      );
+    }
+    final request = ImageGenRequest(
+      prompt: arguments['prompt'] as String,
+      negativePrompt: arguments['negative_prompt'] as String?,
+      width: arguments['width'] as int,
+      height: arguments['height'] as int,
+      steps: arguments['steps'] as int,
+      cfgScale: arguments['cfg_scale'] as double,
+      sampler: arguments['sampler'] as String,
+      scheduler: arguments['scheduler'] as String?,
+      model: arguments['model'] as String?,
+      seed: arguments['seed'] as int?,
+      batchSize: arguments['batch_size'] as int,
+    );
+    final result = await _generator.generate(
+      request,
+      context.cancellationToken,
+    );
+    if (result == null || !result.hasImages) {
+      throw const BuiltInToolException(
+        'no_image_generated',
+        'The image provider returned no image.',
+      );
+    }
+    return {
+      'generated': true,
+      'image_count': result.images.length + result.imageUrls.length,
+      'embedded_image_count': result.images.length,
+      'remote_image_count': result.imageUrls.length,
+      'total_bytes': result.images.fold<int>(
+        0,
+        (total, image) => total + image.length,
+      ),
+      'seed': result.seed,
+      'format': result.format,
+    };
+  }
+}
+
+final class RollDiceToolExecutor extends BuiltInToolExecutor {
+  static const toolName = 'roll_dice';
+  final math.Random _random;
+
+  RollDiceToolExecutor({math.Random? random})
+      : _random = random ?? math.Random.secure();
+
+  @override
+  BuiltInToolDescriptor get descriptor => BuiltInToolDescriptor(
+        definition: ToolDefinition(
+          name: toolName,
+          description: 'Roll one or more local dice with an optional modifier.',
+          inputSchema: const {
+            'type': 'object',
+            'additionalProperties': false,
+            'properties': {
+              'count': {'type': 'integer', 'minimum': 1, 'maximum': 100},
+              'sides': {'type': 'integer', 'minimum': 2, 'maximum': 1000},
+              'modifier': {
+                'type': 'integer',
+                'minimum': -1000000,
+                'maximum': 1000000,
+              },
+            },
+            'required': ['sides'],
+          },
+        ),
+        accessLevel: ToolAccessLevel.readOnly,
+        dataScopes: const {ToolDataScope.randomValue},
+        target: 'local:secure-random',
+      );
+
+  @override
+  Map<String, dynamic> validateArguments(Map<String, dynamic> arguments) {
+    final input = _StrictToolArguments(arguments, const {
+      'count',
+      'sides',
+      'modifier',
+    });
+    return {
+      'count': input.optionalInt('count', minimum: 1, maximum: 100) ?? 1,
+      'sides': input.requiredInt('sides', minimum: 2, maximum: 1000),
+      'modifier':
+          input.optionalInt('modifier', minimum: -1000000, maximum: 1000000) ??
+              0,
+    };
+  }
+
+  @override
+  Future<Object?> execute(
+    Map<String, dynamic> arguments,
+    ToolInvocationContext context,
+  ) async {
+    final count = arguments['count'] as int;
+    final sides = arguments['sides'] as int;
+    final modifier = arguments['modifier'] as int;
+    final rolls = <int>[];
+    for (var index = 0; index < count; index++) {
+      context.cancellationToken.throwIfCancelled();
+      rolls.add(_random.nextInt(sides) + 1);
+    }
+    final subtotal = rolls.fold<int>(0, (sum, roll) => sum + roll);
+    return {
+      'notation':
+          '${count}d$sides${modifier == 0 ? '' : modifier > 0 ? '+$modifier' : modifier}',
+      'rolls': rolls,
+      'modifier': modifier,
+      'total': subtotal + modifier,
+    };
+  }
+}
+
+final class ToolVariableReadResult {
+  final bool found;
+  final Object? value;
+
+  const ToolVariableReadResult({required this.found, this.value});
+}
+
+abstract interface class ToolVariableReader {
+  Future<ToolVariableReadResult> readGlobal(String name, {String? index});
+
+  Future<ToolVariableReadResult> readLocal(
+    String chatId,
+    String name, {
+    String? index,
+  });
+}
+
+final class VariablesServiceToolVariableReader implements ToolVariableReader {
+  final VariablesService service;
+
+  const VariablesServiceToolVariableReader(this.service);
+
+  @override
+  Future<ToolVariableReadResult> readGlobal(
+    String name, {
+    String? index,
+  }) async {
+    final found = service.existsGlobalVariable(name);
+    return ToolVariableReadResult(
+      found: found,
+      value: found ? service.getGlobalVariable(name, index: index) : null,
+    );
+  }
+
+  @override
+  Future<ToolVariableReadResult> readLocal(
+    String chatId,
+    String name, {
+    String? index,
+  }) async {
+    final found = service.existsLocalVariable(chatId, name);
+    return ToolVariableReadResult(
+      found: found,
+      value:
+          found ? service.getLocalVariable(chatId, name, index: index) : null,
+    );
+  }
+}
+
+final class ReadVariableToolExecutor extends BuiltInToolExecutor {
+  static const toolName = 'read_variable';
+  final ToolVariableReader _reader;
+
+  ReadVariableToolExecutor(this._reader);
+
+  @override
+  BuiltInToolDescriptor get descriptor => BuiltInToolDescriptor(
+        definition: ToolDefinition(
+          name: toolName,
+          description: 'Read one global or chat-local variable.',
+          inputSchema: const {
+            'type': 'object',
+            'additionalProperties': false,
+            'properties': {
+              'scope': {
+                'type': 'string',
+                'enum': ['global', 'local'],
+              },
+              'name': {'type': 'string', 'minLength': 1, 'maxLength': 128},
+              'chat_id': {'type': 'string', 'maxLength': 128},
+              'index': {'type': 'string', 'maxLength': 128},
+            },
+            'required': ['scope', 'name'],
+          },
+        ),
+        accessLevel: ToolAccessLevel.readOnly,
+        dataScopes: const {
+          ToolDataScope.variableName,
+          ToolDataScope.variableValue
+        },
+        target: 'local:variables',
+        sensitiveArgumentNames: const {'name', 'chat_id', 'index'},
+      );
+
+  @override
+  Map<String, dynamic> validateArguments(Map<String, dynamic> arguments) {
+    final input = _StrictToolArguments(arguments, const {
+      'scope',
+      'name',
+      'chat_id',
+      'index',
+    });
+    final scope = input.requiredString(
+      'scope',
+      maxLength: 16,
+      allowedValues: const {'global', 'local'},
+    );
+    final name = input.requiredString('name', maxLength: 128);
+    final chatId = input.optionalIdentifier('chat_id');
+    final index = input.optionalString('index', maxLength: 128);
+    if (scope == 'local' && chatId == null) {
+      throw const BuiltInToolException(
+        'invalid_arguments',
+        'chat_id is required for local variables.',
+      );
+    }
+    if (scope == 'global' && chatId != null) {
+      throw const BuiltInToolException(
+        'invalid_arguments',
+        'chat_id is not allowed for global variables.',
+      );
+    }
+    return {
+      'scope': scope,
+      'name': name,
+      if (chatId != null) 'chat_id': chatId,
+      if (index != null) 'index': index,
+    };
+  }
+
+  @override
+  Future<Object?> execute(
+    Map<String, dynamic> arguments,
+    ToolInvocationContext context,
+  ) async {
+    context.cancellationToken.throwIfCancelled();
+    final scope = arguments['scope'] as String;
+    final name = arguments['name'] as String;
+    final index = arguments['index'] as String?;
+    final result = scope == 'global'
+        ? await _reader.readGlobal(name, index: index)
+        : await _reader.readLocal(
+            arguments['chat_id'] as String,
+            name,
+            index: index,
+          );
+    context.cancellationToken.throwIfCancelled();
+    final bounded = _boundedJsonValue(result.value);
+    return {
+      'scope': scope,
+      'name': name,
+      'found': result.found,
+      'value': bounded.value,
+      'truncated': bounded.truncated,
+    };
+  }
+}
+
+abstract interface class ToolWorldInfoSource {
+  Future<List<WorldInfo>> readAllowedWorldInfos({
+    String? worldInfoId,
+    String? characterId,
+  });
+}
+
+final class WorldInfoRepositoryToolWorldInfoSource
+    implements ToolWorldInfoSource {
+  final WorldInfoRepository repository;
+
+  const WorldInfoRepositoryToolWorldInfoSource(this.repository);
+
+  @override
+  Future<List<WorldInfo>> readAllowedWorldInfos({
+    String? worldInfoId,
+    String? characterId,
+  }) async {
+    final worldInfos = <WorldInfo>[
+      ...await repository.getGlobalWorldInfos(),
+      if (characterId != null)
+        ...await repository.getWorldInfosForCharacter(characterId),
+    ];
+    final unique = <String, WorldInfo>{
+      for (final worldInfo in worldInfos) worldInfo.id: worldInfo,
+    };
+    return unique.values
+        .where((worldInfo) => worldInfo.enabled)
+        .where(
+          (worldInfo) => worldInfoId == null || worldInfo.id == worldInfoId,
+        )
+        .toList(growable: false);
+  }
+}
+
+final class SearchWorldInfoToolExecutor extends BuiltInToolExecutor {
+  static const toolName = 'search_world_info';
+  static const _maxContentLength = 2000;
+  final ToolWorldInfoSource _source;
+
+  SearchWorldInfoToolExecutor(this._source);
+
+  @override
+  BuiltInToolDescriptor get descriptor => BuiltInToolDescriptor(
+        definition: ToolDefinition(
+          name: toolName,
+          description: 'Search enabled global or character-scoped world info.',
+          inputSchema: const {
+            'type': 'object',
+            'additionalProperties': false,
+            'properties': {
+              'query': {'type': 'string', 'minLength': 1, 'maxLength': 500},
+              'world_info_id': {'type': 'string', 'maxLength': 128},
+              'character_id': {'type': 'string', 'maxLength': 128},
+              'limit': {'type': 'integer', 'minimum': 1, 'maximum': 10},
+            },
+            'required': ['query'],
+          },
+        ),
+        accessLevel: ToolAccessLevel.readOnly,
+        dataScopes: const {
+          ToolDataScope.worldInfoQuery,
+          ToolDataScope.worldInfoContent,
+        },
+        target: 'local:world-info',
+        sensitiveArgumentNames: const {'query'},
+      );
+
+  @override
+  Map<String, dynamic> validateArguments(Map<String, dynamic> arguments) {
+    final input = _StrictToolArguments(arguments, const {
+      'query',
+      'world_info_id',
+      'character_id',
+      'limit',
+    });
+    return {
+      'query': input.requiredString('query', maxLength: 500),
+      if (input.optionalIdentifier('world_info_id') case final value?)
+        'world_info_id': value,
+      if (input.optionalIdentifier('character_id') case final value?)
+        'character_id': value,
+      'limit': input.optionalInt('limit', minimum: 1, maximum: 10) ?? 5,
+    };
+  }
+
+  @override
+  Future<Object?> execute(
+    Map<String, dynamic> arguments,
+    ToolInvocationContext context,
+  ) async {
+    context.cancellationToken.throwIfCancelled();
+    final query = (arguments['query'] as String).toLowerCase();
+    final worldInfos = await _source.readAllowedWorldInfos(
+      worldInfoId: arguments['world_info_id'] as String?,
+      characterId: arguments['character_id'] as String?,
+    );
+    context.cancellationToken.throwIfCancelled();
+    final matches = <_WorldInfoMatch>[];
+    for (final worldInfo in worldInfos) {
+      for (final entry in worldInfo.entries) {
+        context.cancellationToken.throwIfCancelled();
+        if (!entry.enabled) continue;
+        final score = _matchScore(worldInfo, entry, query);
+        if (score == 0) continue;
+        matches.add(_WorldInfoMatch(worldInfo, entry, score));
+      }
+    }
+    matches.sort((left, right) {
+      final byScore = right.score.compareTo(left.score);
+      if (byScore != 0) return byScore;
+      final byOrder = left.entry.insertionOrder.compareTo(
+        right.entry.insertionOrder,
+      );
+      if (byOrder != 0) return byOrder;
+      return left.entry.id.compareTo(right.entry.id);
+    });
+    final limit = arguments['limit'] as int;
+    final selected = matches.take(limit);
+    return {
+      'match_count': matches.length,
+      'results': [
+        for (final match in selected)
+          {
+            'world_info_id': match.worldInfo.id,
+            'world_info_name': _clip(match.worldInfo.name, 256),
+            'entry_id': match.entry.id,
+            'keys': [
+              for (final key in match.entry.keys.take(16)) _clip(key, 256),
+            ],
+            'content': _clip(match.entry.content, _maxContentLength),
+            'truncated': match.entry.content.length > _maxContentLength,
+          },
+      ],
+    };
+  }
+
+  int _matchScore(WorldInfo worldInfo, WorldInfoEntry entry, String query) {
+    var score = 0;
+    for (final key in entry.keys) {
+      final normalized = key.toLowerCase();
+      if (normalized == query) {
+        score = math.max(score, 100);
+      } else if (normalized.contains(query) || query.contains(normalized)) {
+        score = math.max(score, 80);
+      }
+    }
+    if (entry.secondaryKeys.any((key) => key.toLowerCase().contains(query))) {
+      score = math.max(score, 60);
+    }
+    if (entry.comment.toLowerCase().contains(query)) {
+      score = math.max(score, 50);
+    }
+    if (entry.content.toLowerCase().contains(query)) {
+      score = math.max(score, 40);
+    }
+    if (worldInfo.name.toLowerCase().contains(query) ||
+        (worldInfo.description?.toLowerCase().contains(query) ?? false)) {
+      score = math.max(score, 20);
+    }
+    return score;
+  }
+}
+
+final class _WorldInfoMatch {
+  final WorldInfo worldInfo;
+  final WorldInfoEntry entry;
+  final int score;
+
+  const _WorldInfoMatch(this.worldInfo, this.entry, this.score);
+}
+
+final class _StrictToolArguments {
+  static final RegExp _unsafeControlCharacters = RegExp(
+    r'[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]',
+  );
+  static final RegExp _identifier = RegExp(
+    r'^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$',
+  );
+
+  final Map<String, dynamic> _values;
+
+  _StrictToolArguments(Map<String, dynamic> values, Set<String> allowed)
+      : _values = values {
+    final unknown = values.keys.where((key) => !allowed.contains(key)).toList();
+    if (unknown.isNotEmpty) {
+      throw const BuiltInToolException(
+        'invalid_arguments',
+        'Tool arguments contain unsupported fields.',
+      );
+    }
+  }
+
+  String requiredString(
+    String key, {
+    required int maxLength,
+    Set<String>? allowedValues,
+  }) {
+    final value = _values[key];
+    if (value is! String || value.trim().isEmpty) {
+      throw BuiltInToolException(
+        'invalid_arguments',
+        '$key must be a non-empty string.',
+      );
+    }
+    _validateString(key, value, maxLength);
+    if (allowedValues != null && !allowedValues.contains(value)) {
+      throw BuiltInToolException(
+        'invalid_arguments',
+        '$key contains an unsupported value.',
+      );
+    }
+    return value;
+  }
+
+  String? optionalString(String key, {required int maxLength}) {
+    final value = _values[key];
+    if (value == null) return null;
+    if (value is! String) {
+      throw BuiltInToolException('invalid_arguments', '$key must be a string.');
+    }
+    _validateString(key, value, maxLength);
+    return value;
+  }
+
+  String? optionalIdentifier(String key) {
+    final value = optionalString(key, maxLength: 128);
+    if (value == null) return null;
+    if (!_identifier.hasMatch(value) || value.contains('..')) {
+      throw BuiltInToolException(
+        'invalid_arguments',
+        '$key must be an opaque identifier, not a path.',
+      );
+    }
+    return value;
+  }
+
+  int requiredInt(String key, {required int minimum, required int maximum}) {
+    final value = optionalInt(key, minimum: minimum, maximum: maximum);
+    if (value == null) {
+      throw BuiltInToolException(
+        'invalid_arguments',
+        '$key must be an integer.',
+      );
+    }
+    return value;
+  }
+
+  int? optionalInt(String key, {required int minimum, required int maximum}) {
+    final value = _values[key];
+    if (value == null) return null;
+    if (value is! int || value < minimum || value > maximum) {
+      throw BuiltInToolException(
+        'invalid_arguments',
+        '$key must be an integer between $minimum and $maximum.',
+      );
+    }
+    return value;
+  }
+
+  double? optionalDouble(
+    String key, {
+    required double minimum,
+    required double maximum,
+  }) {
+    final value = _values[key];
+    if (value == null) return null;
+    if (value is! num ||
+        !value.isFinite ||
+        value < minimum ||
+        value > maximum) {
+      throw BuiltInToolException(
+        'invalid_arguments',
+        '$key must be a number between $minimum and $maximum.',
+      );
+    }
+    return value.toDouble();
+  }
+
+  void _validateString(String key, String value, int maxLength) {
+    if (value.length > maxLength || _unsafeControlCharacters.hasMatch(value)) {
+      throw BuiltInToolException(
+        'invalid_arguments',
+        '$key exceeds its length limit or contains control characters.',
+      );
+    }
+  }
+}
+
+final class _BoundedJsonValue {
+  final Object? value;
+  final bool truncated;
+
+  const _BoundedJsonValue(this.value, this.truncated);
+}
+
+_BoundedJsonValue _boundedJsonValue(Object? value, {int depth = 0}) {
+  if (value == null || value is bool || value is num) {
+    return _BoundedJsonValue(value, false);
+  }
+  if (depth >= 8) return const _BoundedJsonValue('[truncated]', true);
+  if (value is String) {
+    if (value.length <= 16000) return _BoundedJsonValue(value, false);
+    return _BoundedJsonValue('${value.substring(0, 16000)}[truncated]', true);
+  }
+  if (value is List) {
+    var truncated = value.length > 100;
+    final result = <Object?>[];
+    for (final item in value.take(100)) {
+      final bounded = _boundedJsonValue(item, depth: depth + 1);
+      result.add(bounded.value);
+      truncated = truncated || bounded.truncated;
+    }
+    return _BoundedJsonValue(result, truncated);
+  }
+  if (value is Map) {
+    var truncated = value.length > 100;
+    final result = <String, Object?>{};
+    for (final entry in value.entries.take(100)) {
+      if (entry.key is! String) {
+        truncated = true;
+        continue;
+      }
+      final bounded = _boundedJsonValue(entry.value, depth: depth + 1);
+      result[entry.key as String] = bounded.value;
+      truncated = truncated || bounded.truncated;
+    }
+    return _BoundedJsonValue(result, truncated);
+  }
+  final text = value.toString();
+  return _BoundedJsonValue(_clip(text, 16000), text.length > 16000);
+}
+
+String _clip(String value, int maximumLength) {
+  return value.length <= maximumLength
+      ? value
+      : value.substring(0, maximumLength);
+}

--- a/lib/domain/services/tool_calling/tool_execution_audit_service.dart
+++ b/lib/domain/services/tool_calling/tool_execution_audit_service.dart
@@ -1,0 +1,233 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:native_tavern/domain/models/built_in_tool.dart';
+import 'package:native_tavern/domain/models/tool_calling.dart';
+import 'package:path/path.dart' as p;
+
+final class ToolExecutionAuditRecord {
+  final DateTime timestamp;
+  final String callIdFingerprint;
+  final String toolName;
+  final ToolAccessLevel accessLevel;
+  final Map<String, dynamic> parameterSummary;
+  final String target;
+  final ToolAuthorizationSource authorizationSource;
+  final ToolExecutionOutcome result;
+  final String? errorCode;
+  final int durationMilliseconds;
+
+  ToolExecutionAuditRecord({
+    required this.timestamp,
+    required this.callIdFingerprint,
+    required this.toolName,
+    required this.accessLevel,
+    required Map<String, dynamic> parameterSummary,
+    required this.target,
+    required this.authorizationSource,
+    required this.result,
+    this.errorCode,
+    required this.durationMilliseconds,
+  }) : parameterSummary = copyToolJsonObject(parameterSummary);
+
+  factory ToolExecutionAuditRecord.fromJson(Map<String, dynamic> json) {
+    return ToolExecutionAuditRecord(
+      timestamp: DateTime.parse(json['timestamp'] as String),
+      callIdFingerprint: json['callIdFingerprint'] as String,
+      toolName: json['toolName'] as String,
+      accessLevel: ToolAccessLevel.values.firstWhere(
+        (candidate) => candidate.name == json['accessLevel'],
+      ),
+      parameterSummary: Map<String, dynamic>.from(
+        json['parameterSummary'] as Map<dynamic, dynamic>? ?? const {},
+      ),
+      target: json['target'] as String,
+      authorizationSource: ToolAuthorizationSource.values.firstWhere(
+        (candidate) => candidate.name == json['authorizationSource'],
+      ),
+      result: ToolExecutionOutcome.values.firstWhere(
+        (candidate) => candidate.name == json['result'],
+      ),
+      errorCode: json['errorCode'] as String?,
+      durationMilliseconds: json['durationMilliseconds'] as int? ?? 0,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'timestamp': timestamp.toUtc().toIso8601String(),
+        'callIdFingerprint': callIdFingerprint,
+        'toolName': toolName,
+        'accessLevel': accessLevel.name,
+        'parameterSummary': parameterSummary,
+        'target': target,
+        'authorizationSource': authorizationSource.name,
+        'result': result.name,
+        'errorCode': errorCode,
+        'durationMilliseconds': durationMilliseconds,
+      };
+}
+
+abstract interface class ToolExecutionAuditRepository {
+  Future<void> record(ToolExecutionAuditRecord record);
+
+  Future<List<ToolExecutionAuditRecord>> readRecent({int limit = 100});
+}
+
+final class NoopToolExecutionAuditRepository
+    implements ToolExecutionAuditRepository {
+  const NoopToolExecutionAuditRepository();
+
+  @override
+  Future<void> record(ToolExecutionAuditRecord record) async {}
+
+  @override
+  Future<List<ToolExecutionAuditRecord>> readRecent({int limit = 100}) async {
+    return const [];
+  }
+}
+
+final class MemoryToolExecutionAuditRepository
+    implements ToolExecutionAuditRepository {
+  final List<ToolExecutionAuditRecord> _records = [];
+
+  @override
+  Future<void> record(ToolExecutionAuditRecord record) async {
+    _records.add(record);
+  }
+
+  @override
+  Future<List<ToolExecutionAuditRecord>> readRecent({int limit = 100}) async {
+    if (limit <= 0) return const [];
+    final start = (_records.length - limit).clamp(0, _records.length);
+    return _records.sublist(start).reversed.toList(growable: false);
+  }
+}
+
+final class FileToolExecutionAuditRepository
+    implements ToolExecutionAuditRepository {
+  static const _relativePath = 'audit/tool_executions.jsonl';
+
+  final String dataPath;
+  Future<void> _writeTail = Future<void>.value();
+
+  FileToolExecutionAuditRepository({required this.dataPath});
+
+  File get _file => File(p.join(dataPath, _relativePath));
+
+  @override
+  Future<void> record(ToolExecutionAuditRecord record) {
+    final operation = _writeTail.then((_) async {
+      final file = _file;
+      await file.parent.create(recursive: true);
+      await file.writeAsString(
+        '${jsonEncode(record.toJson())}\n',
+        mode: FileMode.append,
+        flush: true,
+      );
+    });
+    _writeTail = operation.catchError((Object _) {});
+    return operation;
+  }
+
+  @override
+  Future<List<ToolExecutionAuditRecord>> readRecent({int limit = 100}) async {
+    if (limit <= 0) return const [];
+    await _writeTail;
+    final file = _file;
+    if (!file.existsSync()) return const [];
+
+    final records = <ToolExecutionAuditRecord>[];
+    for (final line in (await file.readAsLines()).reversed) {
+      if (records.length >= limit) break;
+      if (line.trim().isEmpty) continue;
+      try {
+        records.add(
+          ToolExecutionAuditRecord.fromJson(
+            jsonDecode(line) as Map<String, dynamic>,
+          ),
+        );
+      } on FormatException {
+        continue;
+      } on TypeError {
+        continue;
+      } on StateError {
+        continue;
+      }
+    }
+    return records;
+  }
+}
+
+Map<String, dynamic> summarizeToolArguments(
+  Map<String, dynamic> arguments, {
+  Iterable<String> sensitiveArgumentNames = const [],
+}) {
+  final sensitive =
+      sensitiveArgumentNames.map((name) => name.toLowerCase()).toSet();
+  return {
+    for (final entry in arguments.entries)
+      entry.key: _summarizeValue(
+        entry.value,
+        sensitive: sensitive.contains(entry.key.toLowerCase()) ||
+            _looksSensitive(entry.key),
+      ),
+  };
+}
+
+Object? _summarizeValue(Object? value, {required bool sensitive}) {
+  if (value == null) return null;
+  if (sensitive) {
+    return {
+      'type': _valueType(value),
+      'redacted': true,
+      if (value is String) 'length': value.length,
+      if (value is List) 'length': value.length,
+      if (value is Map) 'fieldCount': value.length,
+    };
+  }
+  if (value is bool || value is num) return value;
+  if (value is String) {
+    return {'type': 'string', 'length': value.length, 'redacted': true};
+  }
+  if (value is List) {
+    return {'type': 'list', 'length': value.length, 'redacted': true};
+  }
+  if (value is Map) {
+    return {
+      'type': 'object',
+      'fieldCount': value.length,
+      'redacted': true,
+    };
+  }
+  return {'type': value.runtimeType.toString(), 'redacted': true};
+}
+
+String fingerprintToolCallId(String callId) {
+  return 'sha256:${sha256.convert(utf8.encode(callId))}';
+}
+
+String _valueType(Object? value) {
+  if (value == null) return 'null';
+  if (value is String) return 'string';
+  if (value is bool) return 'boolean';
+  if (value is num) return 'number';
+  if (value is List) return 'list';
+  if (value is Map) return 'object';
+  return value.runtimeType.toString();
+}
+
+bool _looksSensitive(String key) {
+  final normalized = key.toLowerCase().replaceAll(RegExp('[^a-z0-9]'), '');
+  return normalized.contains('apikey') ||
+      normalized.contains('authorization') ||
+      normalized.contains('password') ||
+      normalized.contains('secret') ||
+      normalized.contains('token') ||
+      normalized.contains('credential') ||
+      normalized.contains('cookie') ||
+      normalized.contains('prompt') ||
+      normalized.contains('content') ||
+      normalized.contains('query') ||
+      normalized.contains('value');
+}

--- a/test/built_in_tool_end_to_end_test.dart
+++ b/test/built_in_tool_end_to_end_test.dart
@@ -1,0 +1,158 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:native_tavern/data/database/database.dart';
+import 'package:native_tavern/data/repositories/world_info_repository.dart';
+import 'package:native_tavern/domain/models/built_in_tool.dart';
+import 'package:native_tavern/domain/models/tool_calling.dart';
+import 'package:native_tavern/domain/services/capability_registry.dart';
+import 'package:native_tavern/domain/services/image_generation_service.dart';
+import 'package:native_tavern/domain/services/tool_calling/built_in_tool_service.dart';
+import 'package:native_tavern/domain/services/tool_calling/tool_execution_audit_service.dart';
+import 'package:native_tavern/domain/services/variables_service.dart';
+
+void main() {
+  test('all built-ins execute end to end through security and audit boundaries',
+      () async {
+    final directory =
+        await Directory.systemTemp.createTemp('built_in_tool_e2e_');
+    final database = AppDatabase.forTesting(NativeDatabase.memory());
+    final worldRepository = WorldInfoRepository(database);
+    final variables = VariablesService.instance;
+    const chatId = 'tool-e2e-chat';
+    addTearDown(() async {
+      variables.clearLocalVariables(chatId);
+      await database.close();
+      await directory.delete(recursive: true);
+    });
+
+    variables.setLocalVariable(chatId, 'quest_stage', 'two');
+    final book = await worldRepository.createWorldInfo(
+      name: 'Tool E2E Lore',
+      isGlobal: true,
+    );
+    await worldRepository.addEntry(
+      worldInfoId: book.id,
+      keys: const ['obsidian gate'],
+      content: 'The obsidian gate opens only under a new moon.',
+    );
+
+    final imageGenerator = _EndToEndImageGenerator();
+    final registry = BuiltInToolRegistry.nativeTavern(
+      imageGenerator: imageGenerator,
+      variableReader: VariablesServiceToolVariableReader(variables),
+      worldInfoSource: WorldInfoRepositoryToolWorldInfoSource(worldRepository),
+      random: math.Random(11),
+    );
+    final audit = FileToolExecutionAuditRepository(dataPath: directory.path);
+    final service = BuiltInToolExecutionService(
+      registry: registry,
+      auditRepository: audit,
+    );
+    final permissions = ToolPermissionSnapshot.fromUserSettings(
+      registry.definitions.map((definition) => definition.name),
+    );
+    final capabilities = ToolCapabilitySnapshot.available(
+      const {CapabilityId.imageGeneration},
+    );
+
+    final results = <ToolResultMessage>[];
+    results.add(await service.execute(
+      service.prepare(_call(
+        RollDiceToolExecutor.toolName,
+        const {'count': 2, 'sides': 8},
+      )),
+      permissions: permissions,
+    ));
+    results.add(await service.execute(
+      service.prepare(_call(
+        ReadVariableToolExecutor.toolName,
+        const {
+          'scope': 'local',
+          'chat_id': chatId,
+          'name': 'quest_stage',
+        },
+      )),
+      permissions: permissions,
+    ));
+    results.add(await service.execute(
+      service.prepare(_call(
+        SearchWorldInfoToolExecutor.toolName,
+        const {'query': 'obsidian gate'},
+      )),
+      permissions: permissions,
+    ));
+    results.add(await service.execute(
+      service.prepare(_call(
+        GenerateImageToolExecutor.toolName,
+        const {'prompt': 'private obsidian gate illustration'},
+      )),
+      permissions: permissions,
+      capabilities: capabilities,
+      requestApproval: (_) async => ToolApprovalDecision.approveOnce,
+    ));
+
+    expect(
+      results.every((result) => result.status == ToolResultStatus.succeeded),
+      isTrue,
+    );
+    expect(_output(results[1]), containsPair('value', 'two'));
+    expect(_output(results[2]), containsPair('match_count', 1));
+    expect(_output(results[3]), containsPair('image_count', 1));
+    expect(imageGenerator.callCount, 1);
+
+    final records = await audit.readRecent();
+    expect(records, hasLength(4));
+    expect(
+      records.map((record) => record.toolName).toSet(),
+      registry.definitions.map((definition) => definition.name).toSet(),
+    );
+    final raw = await File(
+      '${directory.path}/audit/tool_executions.jsonl',
+    ).readAsString();
+    expect(raw, isNot(contains('private obsidian gate illustration')));
+    expect(raw, isNot(contains('quest_stage')));
+    expect(raw, isNot(contains('obsidian gate')));
+  });
+}
+
+ToolCall _call(String name, Map<String, dynamic> arguments) {
+  return ToolCall.ready(
+    id: 'e2e_${name}_${arguments.length}',
+    name: name,
+    arguments: arguments,
+    rawArguments: jsonEncode(arguments),
+  );
+}
+
+Map<String, dynamic> _output(ToolResultMessage result) {
+  return result.output! as Map<String, dynamic>;
+}
+
+final class _EndToEndImageGenerator implements ToolImageGenerator {
+  int callCount = 0;
+
+  @override
+  bool get isAvailable => true;
+
+  @override
+  Future<ImageGenResult?> generate(
+    ImageGenRequest request,
+    ToolCancellationToken cancellationToken,
+  ) async {
+    cancellationToken.throwIfCancelled();
+    callCount++;
+    return ImageGenResult(
+      images: [
+        Uint8List.fromList(const [137, 80, 78, 71])
+      ],
+      prompt: request.prompt,
+      seed: 101,
+      format: 'png',
+    );
+  }
+}

--- a/test/built_in_tool_service_test.dart
+++ b/test/built_in_tool_service_test.dart
@@ -1,0 +1,711 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:native_tavern/data/models/world_info.dart';
+import 'package:native_tavern/domain/models/built_in_tool.dart';
+import 'package:native_tavern/domain/models/tool_calling.dart';
+import 'package:native_tavern/domain/services/capability_registry.dart';
+import 'package:native_tavern/domain/services/image_generation_service.dart';
+import 'package:native_tavern/domain/services/tool_calling/built_in_tool_service.dart';
+import 'package:native_tavern/domain/services/tool_calling/tool_execution_audit_service.dart';
+
+void main() {
+  group('built-in tool registry', () {
+    test('declares tools, access levels, capabilities, and data scopes', () {
+      final registry = _registry();
+      final descriptors = {
+        for (final descriptor in registry.descriptors)
+          descriptor.definition.name: descriptor,
+      };
+
+      expect(
+        registry.definitions.map((definition) => definition.name),
+        containsAll(const [
+          GenerateImageToolExecutor.toolName,
+          RollDiceToolExecutor.toolName,
+          ReadVariableToolExecutor.toolName,
+          SearchWorldInfoToolExecutor.toolName,
+        ]),
+      );
+      expect(
+        descriptors[GenerateImageToolExecutor.toolName]?.accessLevel,
+        ToolAccessLevel.externalSideEffect,
+      );
+      expect(
+        descriptors[GenerateImageToolExecutor.toolName]?.requiredCapabilities,
+        {CapabilityId.imageGeneration},
+      );
+      expect(
+        descriptors[GenerateImageToolExecutor.toolName]?.supportsDryRun,
+        isTrue,
+      );
+      expect(
+        descriptors[ReadVariableToolExecutor.toolName]?.dataScopes,
+        contains(ToolDataScope.variableValue),
+      );
+      expect(
+        descriptors[SearchWorldInfoToolExecutor.toolName]?.dataScopes,
+        contains(ToolDataScope.worldInfoContent),
+      );
+      expect(
+        registry.definitions.every(
+          (definition) =>
+              definition.inputSchema['additionalProperties'] == false,
+        ),
+        isTrue,
+      );
+    });
+
+    test('rejects duplicate tool names', () {
+      expect(
+        () => BuiltInToolRegistry([
+          RollDiceToolExecutor(random: math.Random(1)),
+          RollDiceToolExecutor(random: math.Random(2)),
+        ]),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('authorization and argument boundaries', () {
+    test('denies every tool by default and audits the denial', () async {
+      final audit = MemoryToolExecutionAuditRepository();
+      final service = BuiltInToolExecutionService(
+        registry: _registry(),
+        auditRepository: audit,
+      );
+      final plan = service.prepare(_call(
+        RollDiceToolExecutor.toolName,
+        const {'sides': 6},
+      ));
+
+      final result = await service.execute(plan);
+
+      expect(result.status, ToolResultStatus.failed);
+      expect(_errorCode(result), 'permission_denied');
+      final record = (await audit.readRecent()).single;
+      expect(record.result, ToolExecutionOutcome.denied);
+      expect(record.authorizationSource, ToolAuthorizationSource.none);
+    });
+
+    test('rejects unknown fields, path-like IDs, and permission injection', () {
+      final service = BuiltInToolExecutionService(registry: _registry());
+
+      expect(
+        () => service.prepare(_call(
+          GenerateImageToolExecutor.toolName,
+          const {
+            'prompt': 'safe prompt',
+            'api_key': 'sk-do-not-accept',
+          },
+        )),
+        _builtInError('invalid_arguments'),
+      );
+      expect(
+        () => service.prepare(_call(
+          ReadVariableToolExecutor.toolName,
+          const {
+            'scope': 'local',
+            'name': 'hp',
+            'chat_id': '../../settings.json',
+          },
+        )),
+        _builtInError('invalid_arguments'),
+      );
+      expect(
+        () => service.prepare(_call(
+          SearchWorldInfoToolExecutor.toolName,
+          const {
+            'query': 'castle',
+            'permission': 'allow',
+          },
+        )),
+        _builtInError('invalid_arguments'),
+      );
+    });
+
+    test('read-only tools run after an explicit settings grant', () async {
+      final approvals = <ToolExecutionPreview>[];
+      final audit = MemoryToolExecutionAuditRepository();
+      final variables = _FakeVariableReader(
+        globalValues: const {'hp': 12},
+      );
+      final worldInfo = _worldInfo(
+        id: 'global-book',
+        name: 'Places',
+        content: 'The moon castle stands above the silver lake.',
+      );
+      final service = BuiltInToolExecutionService(
+        registry: _registry(
+          variableReader: variables,
+          worldInfoSource: _FakeWorldInfoSource([worldInfo]),
+        ),
+        auditRepository: audit,
+      );
+      final permissions = ToolPermissionSnapshot.fromUserSettings(const {
+        RollDiceToolExecutor.toolName,
+        ReadVariableToolExecutor.toolName,
+        SearchWorldInfoToolExecutor.toolName,
+      });
+
+      final dice = await service.execute(
+        service.prepare(_call(
+          RollDiceToolExecutor.toolName,
+          const {'count': 2, 'sides': 6, 'modifier': 1},
+        )),
+        permissions: permissions,
+        requestApproval: (preview) async {
+          approvals.add(preview);
+          return ToolApprovalDecision.approveOnce;
+        },
+      );
+      final variable = await service.execute(
+        service.prepare(_call(
+          ReadVariableToolExecutor.toolName,
+          const {'scope': 'global', 'name': 'hp'},
+        )),
+        permissions: permissions,
+      );
+      final search = await service.execute(
+        service.prepare(_call(
+          SearchWorldInfoToolExecutor.toolName,
+          const {'query': 'moon castle'},
+        )),
+        permissions: permissions,
+      );
+
+      expect(dice.status, ToolResultStatus.succeeded);
+      expect(_output(dice)['rolls'], hasLength(2));
+      expect(_output(variable), containsPair('value', 12));
+      expect(_output(search)['match_count'], 1);
+      expect(approvals, isEmpty);
+      final records = await audit.readRecent();
+      expect(records, hasLength(3));
+      expect(
+        records.every(
+          (record) =>
+              record.authorizationSource ==
+              ToolAuthorizationSource.userSettings,
+        ),
+        isTrue,
+      );
+    });
+
+    test('write tools require one-time approval and cannot self-authorize',
+        () async {
+      final executor = _WriteToolExecutor();
+      final service = BuiltInToolExecutionService(
+        registry: BuiltInToolRegistry([executor]),
+      );
+      final permissions = ToolPermissionSnapshot.fromUserSettings(
+        const {_WriteToolExecutor.toolName},
+      );
+      final plan = service.prepare(_call(
+        _WriteToolExecutor.toolName,
+        const {'value': 7},
+      ));
+
+      final withoutApproval = await service.execute(
+        plan,
+        permissions: permissions,
+      );
+      expect(withoutApproval.status, ToolResultStatus.failed);
+      expect(_errorCode(withoutApproval), 'approval_required');
+      expect(executor.writeCount, 0);
+
+      final approved = await service.execute(
+        plan,
+        permissions: permissions,
+        requestApproval: (_) async => ToolApprovalDecision.approveOnce,
+      );
+      expect(approved.status, ToolResultStatus.succeeded);
+      expect(executor.writeCount, 1);
+
+      expect(
+        () => service.prepare(_call(
+          _WriteToolExecutor.toolName,
+          const {'value': 8, 'authorized': true},
+        )),
+        _builtInError('invalid_arguments'),
+      );
+    });
+  });
+
+  group('external effects, dry-run, and cancellation', () {
+    test('never invokes image generation without one-time approval', () async {
+      final imageGenerator = _FakeImageGenerator();
+      final audit = MemoryToolExecutionAuditRepository();
+      final service = BuiltInToolExecutionService(
+        registry: _registry(imageGenerator: imageGenerator),
+        auditRepository: audit,
+      );
+      final permissions = ToolPermissionSnapshot.fromUserSettings(
+        const {GenerateImageToolExecutor.toolName},
+      );
+      final capabilities = ToolCapabilitySnapshot.available(
+        const {CapabilityId.imageGeneration},
+      );
+      final plan = service.prepare(_call(
+        GenerateImageToolExecutor.toolName,
+        const {'prompt': 'private portrait prompt'},
+      ));
+
+      final missingApproval = await service.execute(
+        plan,
+        permissions: permissions,
+        capabilities: capabilities,
+      );
+      final denied = await service.execute(
+        plan,
+        permissions: permissions,
+        capabilities: capabilities,
+        requestApproval: (_) async => ToolApprovalDecision.deny,
+      );
+      final cancelled = await service.execute(
+        plan,
+        permissions: permissions,
+        capabilities: capabilities,
+        requestApproval: (_) async => ToolApprovalDecision.cancel,
+      );
+
+      expect(_errorCode(missingApproval), 'approval_required');
+      expect(_errorCode(denied), 'approval_denied');
+      expect(cancelled.status, ToolResultStatus.cancelled);
+      expect(imageGenerator.callCount, 0);
+      expect(
+        (await audit.readRecent()).map((record) => record.result),
+        containsAll(const [
+          ToolExecutionOutcome.denied,
+          ToolExecutionOutcome.cancelled,
+        ]),
+      );
+    });
+
+    test('dry-run previews parameters without capability or external work',
+        () async {
+      final imageGenerator = _FakeImageGenerator(available: false);
+      final audit = MemoryToolExecutionAuditRepository();
+      final service = BuiltInToolExecutionService(
+        registry: _registry(imageGenerator: imageGenerator),
+        auditRepository: audit,
+      );
+      final plan = service.prepare(
+        _call(
+          GenerateImageToolExecutor.toolName,
+          const {
+            'prompt': 'a private scene',
+            'width': 512,
+            'height': 768,
+          },
+        ),
+        dryRun: true,
+      );
+
+      final result = await service.execute(
+        plan,
+        permissions: ToolPermissionSnapshot.fromUserSettings(
+          const {GenerateImageToolExecutor.toolName},
+        ),
+      );
+
+      expect(plan.preview.parameters['prompt'], 'a private scene');
+      expect(plan.preview.requiresConfirmation, isFalse);
+      expect(result.status, ToolResultStatus.succeeded);
+      expect(_output(result), containsPair('would_execute', false));
+      expect(imageGenerator.callCount, 0);
+      final record = (await audit.readRecent()).single;
+      expect(record.result, ToolExecutionOutcome.dryRun);
+      expect(record.authorizationSource, ToolAuthorizationSource.dryRun);
+      expect(jsonEncode(record.toJson()), isNot(contains('a private scene')));
+    });
+
+    test('approved execution succeeds but provider failures stay failed',
+        () async {
+      final successGenerator = _FakeImageGenerator();
+      final successAudit = MemoryToolExecutionAuditRepository();
+      final successService = BuiltInToolExecutionService(
+        registry: _registry(imageGenerator: successGenerator),
+        auditRepository: successAudit,
+      );
+      final permissions = ToolPermissionSnapshot.fromUserSettings(
+        const {GenerateImageToolExecutor.toolName},
+      );
+      final capabilities = ToolCapabilitySnapshot.available(
+        const {CapabilityId.imageGeneration},
+      );
+      final plan = successService.prepare(_call(
+        GenerateImageToolExecutor.toolName,
+        const {'prompt': 'portrait'},
+      ));
+
+      final success = await successService.execute(
+        plan,
+        permissions: permissions,
+        capabilities: capabilities,
+        requestApproval: (_) async => ToolApprovalDecision.approveOnce,
+      );
+      expect(success.status, ToolResultStatus.succeeded);
+      expect(_output(success), containsPair('image_count', 1));
+      expect(successGenerator.callCount, 1);
+      expect(
+        (await successAudit.readRecent()).single.authorizationSource,
+        ToolAuthorizationSource.oneTimeApproval,
+      );
+
+      final failingGenerator = _FakeImageGenerator(
+        error: StateError('provider leaked sk-sensitive-key'),
+      );
+      final failingService = BuiltInToolExecutionService(
+        registry: _registry(imageGenerator: failingGenerator),
+      );
+      final failure = await failingService.execute(
+        failingService.prepare(_call(
+          GenerateImageToolExecutor.toolName,
+          const {'prompt': 'portrait'},
+        )),
+        permissions: permissions,
+        capabilities: capabilities,
+        requestApproval: (_) async => ToolApprovalDecision.approveOnce,
+      );
+      expect(failure.status, ToolResultStatus.failed);
+      expect(_errorCode(failure), 'execution_failed');
+      expect(jsonEncode(failure.output), isNot(contains('sk-sensitive-key')));
+    });
+
+    test('in-flight cancellation never returns a forged success', () async {
+      final blocker = Completer<void>();
+      final started = Completer<void>();
+      final generator = _FakeImageGenerator(
+        blocker: blocker,
+        started: started,
+      );
+      final audit = MemoryToolExecutionAuditRepository();
+      final service = BuiltInToolExecutionService(
+        registry: _registry(imageGenerator: generator),
+        auditRepository: audit,
+      );
+      final controller = ToolCancellationController();
+      final execution = service.execute(
+        service.prepare(_call(
+          GenerateImageToolExecutor.toolName,
+          const {'prompt': 'cancel me'},
+        )),
+        permissions: ToolPermissionSnapshot.fromUserSettings(
+          const {GenerateImageToolExecutor.toolName},
+        ),
+        capabilities: ToolCapabilitySnapshot.available(
+          const {CapabilityId.imageGeneration},
+        ),
+        invocationContext: ToolInvocationContext(
+          maxDepth: 1,
+          cancellationToken: controller.token,
+        ),
+        requestApproval: (_) async => ToolApprovalDecision.approveOnce,
+      );
+
+      await started.future;
+      controller.cancel('private cancellation reason');
+      blocker.complete();
+      final result = await execution;
+
+      expect(result.status, ToolResultStatus.cancelled);
+      expect(_errorCode(result), 'cancelled');
+      expect(jsonEncode(result.output),
+          isNot(contains('private cancellation reason')));
+      expect((await audit.readRecent()).single.result,
+          ToolExecutionOutcome.cancelled);
+    });
+
+    test('image service gateway aborts the underlying HTTP request', () async {
+      final adapter = _BlockingHttpAdapter();
+      final dio = Dio()..httpClientAdapter = adapter;
+      final imageService = ImageGenerationService(dio: dio)
+        ..updateSettings(const ImageGenSettings(
+          enabled: true,
+          provider: ImageGenProvider.pollinations,
+        ));
+      addTearDown(imageService.dispose);
+      final gateway = ImageGenerationServiceToolImageGenerator(imageService);
+      final controller = ToolCancellationController();
+
+      final execution = gateway.generate(
+        const ImageGenRequest(prompt: 'cancel transport'),
+        controller.token,
+      );
+      await adapter.started.future;
+      controller.cancel('user cancelled');
+
+      await expectLater(execution, _protocolError('cancelled'));
+      await expectLater(adapter.cancelled.future, completes);
+    });
+  });
+
+  test('file audit persists redacted structured summaries', () async {
+    final directory = await Directory.systemTemp.createTemp('tool_audit_');
+    addTearDown(() => directory.delete(recursive: true));
+    final repository = FileToolExecutionAuditRepository(
+      dataPath: directory.path,
+    );
+    final service = BuiltInToolExecutionService(
+      registry: _registry(),
+      auditRepository: repository,
+    );
+    final plan = service.prepare(
+      _call(
+        GenerateImageToolExecutor.toolName,
+        const {'prompt': 'secret body with sk-private-key'},
+      ),
+      dryRun: true,
+    );
+
+    await service.execute(
+      plan,
+      permissions: ToolPermissionSnapshot.fromUserSettings(
+        const {GenerateImageToolExecutor.toolName},
+      ),
+    );
+    final raw = await File(
+      '${directory.path}/audit/tool_executions.jsonl',
+    ).readAsString();
+    final record = (await repository.readRecent()).single;
+
+    expect(raw, contains(GenerateImageToolExecutor.toolName));
+    expect(raw, contains('configured:image-generation-provider'));
+    expect(raw, isNot(contains('secret body')));
+    expect(raw, isNot(contains('sk-private-key')));
+    expect(record.parameterSummary['prompt'], containsPair('redacted', true));
+    expect(record.callIdFingerprint, startsWith('sha256:'));
+  });
+}
+
+BuiltInToolRegistry _registry({
+  ToolImageGenerator? imageGenerator,
+  ToolVariableReader? variableReader,
+  ToolWorldInfoSource? worldInfoSource,
+}) {
+  return BuiltInToolRegistry.nativeTavern(
+    imageGenerator: imageGenerator ?? _FakeImageGenerator(),
+    variableReader: variableReader ?? _FakeVariableReader(),
+    worldInfoSource: worldInfoSource ?? const _FakeWorldInfoSource([]),
+    random: math.Random(7),
+  );
+}
+
+ToolCall _call(String name, Map<String, dynamic> arguments) {
+  return ToolCall.ready(
+    id: 'call_${name}_${arguments.length}',
+    name: name,
+    arguments: arguments,
+    rawArguments: jsonEncode(arguments),
+  );
+}
+
+Map<String, dynamic> _output(ToolResultMessage result) {
+  return result.output! as Map<String, dynamic>;
+}
+
+String _errorCode(ToolResultMessage result) {
+  final error = _output(result)['error']! as Map<String, dynamic>;
+  return error['code']! as String;
+}
+
+Matcher _builtInError(String code) {
+  return throwsA(
+    isA<BuiltInToolException>().having(
+      (error) => error.code,
+      'code',
+      code,
+    ),
+  );
+}
+
+Matcher _protocolError(String code) {
+  return throwsA(
+    isA<ToolProtocolException>().having(
+      (error) => error.code,
+      'code',
+      code,
+    ),
+  );
+}
+
+WorldInfo _worldInfo({
+  required String id,
+  required String name,
+  required String content,
+}) {
+  final now = DateTime.utc(2026, 8, 8);
+  return WorldInfo(
+    id: id,
+    name: name,
+    isGlobal: true,
+    createdAt: now,
+    modifiedAt: now,
+    entries: [
+      WorldInfoEntry(
+        id: '$id-entry',
+        worldInfoId: id,
+        keys: const ['moon castle'],
+        content: content,
+        enabled: true,
+      ),
+    ],
+  );
+}
+
+final class _FakeImageGenerator implements ToolImageGenerator {
+  @override
+  final bool isAvailable;
+  final Object? error;
+  final Completer<void>? blocker;
+  final Completer<void>? started;
+  int callCount = 0;
+
+  _FakeImageGenerator({
+    bool available = true,
+    this.error,
+    this.blocker,
+    this.started,
+  }) : isAvailable = available;
+
+  @override
+  Future<ImageGenResult?> generate(
+    ImageGenRequest request,
+    ToolCancellationToken cancellationToken,
+  ) async {
+    callCount++;
+    if (!(started?.isCompleted ?? true)) started?.complete();
+    if (blocker != null) await blocker!.future;
+    if (error != null) throw error!;
+    return ImageGenResult(
+      images: [
+        Uint8List.fromList(const [1, 2, 3])
+      ],
+      prompt: request.prompt,
+      seed: request.seed ?? 42,
+    );
+  }
+}
+
+final class _FakeVariableReader implements ToolVariableReader {
+  final Map<String, Object?> globalValues;
+  final Map<String, Map<String, Object?>> localValues = const {};
+
+  _FakeVariableReader({
+    this.globalValues = const {},
+  });
+
+  @override
+  Future<ToolVariableReadResult> readGlobal(
+    String name, {
+    String? index,
+  }) async {
+    return ToolVariableReadResult(
+      found: globalValues.containsKey(name),
+      value: globalValues[name],
+    );
+  }
+
+  @override
+  Future<ToolVariableReadResult> readLocal(
+    String chatId,
+    String name, {
+    String? index,
+  }) async {
+    return ToolVariableReadResult(
+      found: localValues[chatId]?.containsKey(name) ?? false,
+      value: localValues[chatId]?[name],
+    );
+  }
+}
+
+final class _FakeWorldInfoSource implements ToolWorldInfoSource {
+  final List<WorldInfo> worldInfos;
+
+  const _FakeWorldInfoSource(this.worldInfos);
+
+  @override
+  Future<List<WorldInfo>> readAllowedWorldInfos({
+    String? worldInfoId,
+    String? characterId,
+  }) async {
+    return worldInfos
+        .where(
+          (worldInfo) => worldInfoId == null || worldInfo.id == worldInfoId,
+        )
+        .toList(growable: false);
+  }
+}
+
+final class _WriteToolExecutor extends BuiltInToolExecutor {
+  static const toolName = 'write_test';
+  int writeCount = 0;
+
+  @override
+  BuiltInToolDescriptor get descriptor => BuiltInToolDescriptor(
+        definition: ToolDefinition(
+          name: toolName,
+          description: 'Test a local write permission boundary.',
+          inputSchema: const {
+            'type': 'object',
+            'additionalProperties': false,
+            'properties': {
+              'value': {'type': 'integer'},
+            },
+            'required': ['value'],
+          },
+        ),
+        accessLevel: ToolAccessLevel.write,
+        target: 'local:test-state',
+      );
+
+  @override
+  Map<String, dynamic> validateArguments(Map<String, dynamic> arguments) {
+    if (arguments.length != 1 || arguments['value'] is! int) {
+      throw const BuiltInToolException(
+        'invalid_arguments',
+        'Only an integer value is accepted.',
+      );
+    }
+    return {'value': arguments['value']};
+  }
+
+  @override
+  Future<Object?> execute(
+    Map<String, dynamic> arguments,
+    ToolInvocationContext context,
+  ) async {
+    context.cancellationToken.throwIfCancelled();
+    writeCount++;
+    return {'written': arguments['value']};
+  }
+}
+
+final class _BlockingHttpAdapter implements HttpClientAdapter {
+  final Completer<void> started = Completer<void>();
+  final Completer<void> cancelled = Completer<void>();
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    if (!started.isCompleted) started.complete();
+    await cancelFuture;
+    if (!cancelled.isCompleted) cancelled.complete();
+    throw DioException(
+      requestOptions: options,
+      type: DioExceptionType.cancel,
+      message: 'cancelled',
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}


### PR DESCRIPTION
## Summary

- G05: adds built-in definitions and executors for image generation, local dice rolls, scoped variable reads, and enabled world-info search. Every tool declares its access level, capability requirements, data scopes, strict schema, and trusted target.
- G06: adds default-deny settings permissions, normalized parameter previews, one-time approval for write/external effects, cancellation, image dry-run, capability checks, and structured execution results.
- G06 audit: persists tool name, redacted parameter summary, logical target, authorization source, result, error code, duration, and a hashed call ID. Prompt/query/value bodies, credentials, response URLs, and raw provider errors are not logged.
- Image tool cancellation is bridged to Dio so an in-flight external request is actually aborted. Tool arguments cannot add permissions or address file/config paths.

## Verification

- Changed-file flutter analyze: no issues
- Full flutter test: 275 passed, 2 environment-gated PDFium tests skipped
- Security/E2E coverage includes default deny, read/write boundaries, malicious fields and path IDs, one-time approval, dry-run, provider failure, cancellation, transport abort, redacted file audit, real VariablesService, and real SQLite WorldInfoRepository.

Closes #33