### PR TITLE
feat(data-bank): add local search and management UI

### DIFF
--- a/lib/data/database/database.dart
+++ b/lib/data/database/database.dart
@@ -670,9 +670,14 @@ class AppDatabase extends _$AppDatabase {
       },
       beforeOpen: (details) async {
         await customStatement('PRAGMA foreign_keys = ON');
-        final searchIndexCreated = await _ensureLongTermMemorySearchIndex();
-        if (searchIndexCreated) {
+        final memorySearchIndexCreated =
+            await _ensureLongTermMemorySearchIndex();
+        if (memorySearchIndexCreated) {
           await _rebuildLongTermMemorySearchIndex();
+        }
+        final dataBankSearchIndexCreated = await _ensureDataBankSearchIndex();
+        if (dataBankSearchIndexCreated) {
+          await _rebuildDataBankSearchIndex();
         }
       },
     );
@@ -682,6 +687,75 @@ class AppDatabase extends _$AppDatabase {
   Future<void> rebuildLongTermMemorySearchIndex() async {
     await _ensureLongTermMemorySearchIndex();
     await _rebuildLongTermMemorySearchIndex();
+  }
+
+  /// Recreates the derived Data Bank FTS index from canonical text chunks.
+  Future<void> rebuildDataBankSearchIndex() async {
+    await _ensureDataBankSearchIndex();
+    await _rebuildDataBankSearchIndex();
+  }
+
+  Future<bool> _ensureDataBankSearchIndex() async {
+    final existing = await customSelect(
+      'SELECT 1 AS found FROM sqlite_master '
+      "WHERE type = 'table' AND name = 'data_bank_text_chunks_fts'",
+    ).getSingleOrNull();
+    final created = existing == null;
+
+    await customStatement('''
+      CREATE VIRTUAL TABLE IF NOT EXISTS data_bank_text_chunks_fts USING fts5(
+        id UNINDEXED,
+        text_content,
+        content = 'data_bank_text_chunks',
+        content_rowid = 'rowid',
+        tokenize = 'unicode61 remove_diacritics 2'
+      )
+    ''');
+    await _createDataBankSearchTriggers();
+    return created;
+  }
+
+  Future<void> _createDataBankSearchTriggers() async {
+    const statements = [
+      '''
+        CREATE TRIGGER IF NOT EXISTS data_bank_chunk_fts_insert
+        AFTER INSERT ON data_bank_text_chunks
+        BEGIN
+          INSERT INTO data_bank_text_chunks_fts(rowid, id, text_content)
+          VALUES (NEW.rowid, NEW.id, NEW.text_content);
+        END
+      ''',
+      '''
+        CREATE TRIGGER IF NOT EXISTS data_bank_chunk_fts_delete
+        AFTER DELETE ON data_bank_text_chunks
+        BEGIN
+          INSERT INTO data_bank_text_chunks_fts(
+            data_bank_text_chunks_fts, rowid, id, text_content
+          ) VALUES ('delete', OLD.rowid, OLD.id, OLD.text_content);
+        END
+      ''',
+      '''
+        CREATE TRIGGER IF NOT EXISTS data_bank_chunk_fts_update
+        AFTER UPDATE OF id, text_content ON data_bank_text_chunks
+        BEGIN
+          INSERT INTO data_bank_text_chunks_fts(
+            data_bank_text_chunks_fts, rowid, id, text_content
+          ) VALUES ('delete', OLD.rowid, OLD.id, OLD.text_content);
+          INSERT INTO data_bank_text_chunks_fts(rowid, id, text_content)
+          VALUES (NEW.rowid, NEW.id, NEW.text_content);
+        END
+      ''',
+    ];
+    for (final statement in statements) {
+      await customStatement(statement);
+    }
+  }
+
+  Future<void> _rebuildDataBankSearchIndex() {
+    return customStatement(
+      'INSERT INTO data_bank_text_chunks_fts(data_bank_text_chunks_fts) '
+      "VALUES ('rebuild')",
+    );
   }
 
   Future<bool> _ensureLongTermMemorySearchIndex() async {

--- a/lib/data/repositories/drift_data_bank_repository.dart
+++ b/lib/data/repositories/drift_data_bank_repository.dart
@@ -5,14 +5,7 @@ import 'package:native_tavern/data/database/database.dart';
 import 'package:native_tavern/data/models/data_bank.dart';
 import 'package:native_tavern/domain/repositories/data_bank_repository.dart';
 
-final class DriftDataBankRepository
-    implements
-        DataBankDocumentRepository,
-        DataBankVersionRepository,
-        DataBankSectionRepository,
-        DataBankChunkRepository,
-        DataBankBindingRepository,
-        DataBankLifecycleRepository {
+final class DriftDataBankRepository implements DataBankRepository {
   const DriftDataBankRepository(this._database);
 
   final AppDatabase _database;
@@ -212,6 +205,127 @@ final class DriftDataBankRepository
   }
 
   @override
+  Future<List<DataBankSearchResult>> search(
+    String query, {
+    int topK = 20,
+    DataBankSearchFilter filter = const DataBankSearchFilter(),
+  }) async {
+    if (topK <= 0) {
+      throw RangeError.range(topK, 1, null, 'topK');
+    }
+    final matchQuery = _plainTextFtsQuery(query);
+    if (matchQuery == null) return const [];
+
+    final conditions = <String>[
+      'data_bank_text_chunks_fts MATCH ?',
+      'd.current_version_id = v.id',
+      'd.is_placeholder = 0',
+      'd.processing_state = ?',
+      'd.index_state = ?',
+    ];
+    final variables = <Variable<Object>>[
+      Variable<String>(matchQuery),
+      Variable<String>(DataBankProcessingState.ready.name),
+      Variable<String>(DataBankIndexState.indexed.name),
+    ];
+
+    if (filter.documentIds.isNotEmpty) {
+      final ids = filter.documentIds.toList()..sort();
+      conditions.add('d.id IN (${List.filled(ids.length, '?').join(', ')})');
+      variables.addAll(ids.map(Variable<String>.new));
+    }
+    if (!filter.includeUnbound) {
+      final scopes = <String>[];
+      if (filter.includeGlobal) {
+        scopes.add("b.scope = 'global'");
+      }
+      if (filter.characterId != null) {
+        scopes.add("(b.scope = 'character' AND b.character_id = ?)");
+        variables.add(Variable<String>(filter.characterId!));
+      }
+      if (filter.chatId != null) {
+        scopes.add("(b.scope = 'chat' AND b.chat_id = ?)");
+        variables.add(Variable<String>(filter.chatId!));
+      }
+      if (scopes.isEmpty) return const [];
+      conditions.add('''
+        EXISTS (
+          SELECT 1 FROM data_bank_bindings AS b
+          WHERE b.document_id = d.id
+            AND b.enabled = 1
+            AND (${scopes.join(' OR ')})
+        )
+      ''');
+    }
+    variables.add(Variable<int>(topK));
+
+    final rows = await _database
+        .customSelect(
+          '''
+        SELECT
+          c.id AS chunk_id,
+          c.document_version_id,
+          c.section_id,
+          c.ordinal,
+          c.text_content,
+          c.locator_json,
+          d.id AS document_id,
+          v.original_file_name,
+          bm25(data_bank_text_chunks_fts) AS rank,
+          snippet(data_bank_text_chunks_fts, 1, '', '', ' ... ', 24)
+            AS match_snippet
+        FROM data_bank_text_chunks_fts
+        JOIN data_bank_text_chunks AS c
+          ON c.rowid = data_bank_text_chunks_fts.rowid
+        JOIN data_bank_document_versions AS v
+          ON v.id = c.document_version_id
+        JOIN data_bank_documents AS d
+          ON d.id = v.document_id
+        WHERE ${conditions.join(' AND ')}
+        ORDER BY bm25(data_bank_text_chunks_fts) ASC,
+                 d.updated_at DESC,
+                 c.ordinal ASC,
+                 c.id ASC
+        LIMIT ?
+      ''',
+          variables: variables,
+          readsFrom: {
+            _database.dataBankTextChunks,
+            _database.dataBankDocumentVersions,
+            _database.dataBankDocuments,
+            _database.dataBankBindings,
+          },
+        )
+        .get();
+
+    return rows.map((row) {
+      final chunk = DataBankTextChunk(
+        id: row.read<String>('chunk_id'),
+        documentVersionId: row.read<String>('document_version_id'),
+        sectionId: row.readNullable<String>('section_id'),
+        ordinal: row.read<int>('ordinal'),
+        text: row.read<String>('text_content'),
+        locator: DataBankSourceLocator.fromJson(
+          _decodeMap(row.read<String>('locator_json')),
+        ),
+      );
+      final documentId = row.read<String>('document_id');
+      return DataBankSearchResult(
+        chunk: chunk,
+        citation: chunk.toCitation(documentId),
+        documentName: row.read<String>('original_file_name'),
+        snippet: row.read<String>('match_snippet'),
+        rank: row.read<double>('rank'),
+      );
+    }).toList(growable: false);
+  }
+
+  @override
+  Future<void> rebuildSearchIndex() {
+    return _database.rebuildDataBankSearchIndex();
+  }
+
+  @override
   Future<List<DataBankBinding>> listBindingsForDocument(
     String documentId, {
     bool includeDisabled = false,
@@ -398,16 +512,21 @@ final class DriftDataBankRepository
 
   @override
   Future<void> setDocumentEnabled(String documentId, bool enabled) async {
-    final document = await _requireDocument(documentId);
-    if (document.processingState == DataBankProcessingState.deleted) {
-      throw StateError('Deleted documents cannot be enabled or disabled.');
-    }
-    if (enabled == document.isEnabled) return;
-    final next = enabled
-        ? DataBankProcessingState.pending
-        : DataBankProcessingState.disabled;
-    document.processingState.validateTransitionTo(next);
-    await saveDocument(_transitionedDocument(document, next, null));
+    await _database.transaction(() async {
+      final document = await _requireDocument(documentId);
+      final version = await _requireVersion(document.currentVersionId);
+      if (document.processingState == DataBankProcessingState.deleted) {
+        throw StateError('Deleted documents cannot be enabled or disabled.');
+      }
+      if (enabled == document.isEnabled) return;
+      final next = enabled
+          ? DataBankProcessingState.pending
+          : DataBankProcessingState.disabled;
+      document.processingState.validateTransitionTo(next);
+      version.processingState.validateTransitionTo(next);
+      await _writeVersion(_transitionedVersion(version, next, null));
+      await saveDocument(_transitionedDocument(document, next, null));
+    });
   }
 
   @override
@@ -417,12 +536,188 @@ final class DriftDataBankRepository
       DataBankProcessingState.deleted,
     );
     await saveDocument(
-      _transitionedDocument(
-        document,
-        DataBankProcessingState.deleted,
-        null,
-      ),
+      _transitionedDocument(document, DataBankProcessingState.deleted, null),
     );
+  }
+
+  @override
+  Future<DataBankDocumentVersion?> findVersionByContentHash(
+    DataBankContentHash contentHash,
+  ) async {
+    final query = _database.select(_database.dataBankDocumentVersions).join([
+      innerJoin(
+        _database.dataBankDocuments,
+        _database.dataBankDocuments.id.equalsExp(
+          _database.dataBankDocumentVersions.documentId,
+        ),
+      ),
+    ])
+      ..where(
+        _database.dataBankDocumentVersions.hashAlgorithm.equals(
+              contentHash.algorithm.name,
+            ) &
+            _database.dataBankDocumentVersions.hashDigest.equals(
+              contentHash.digest,
+            ) &
+            _database.dataBankDocuments.processingState.isNotValue(
+              DataBankProcessingState.deleted.name,
+            ) &
+            _database.dataBankDocuments.isPlaceholder.equals(false),
+      )
+      ..orderBy([
+        OrderingTerm.asc(_database.dataBankDocumentVersions.importedAt),
+        OrderingTerm.asc(_database.dataBankDocumentVersions.id),
+      ])
+      ..limit(1);
+    final row = await query.getSingleOrNull();
+    return row == null
+        ? null
+        : _versionFromRow(row.readTable(_database.dataBankDocumentVersions));
+  }
+
+  @override
+  Future<void> createPendingDocument({
+    required DataBankDocument document,
+    required DataBankDocumentVersion version,
+    required DataBankBinding initialBinding,
+  }) async {
+    if (document.currentVersionId != version.id ||
+        document.id != version.documentId ||
+        initialBinding.documentId != document.id ||
+        document.processingState != DataBankProcessingState.pending ||
+        version.processingState != DataBankProcessingState.pending) {
+      throw ArgumentError('The pending Data Bank import is inconsistent.');
+    }
+    await _database.transaction(() async {
+      await saveVersion(version);
+      await saveDocument(document);
+      await saveBinding(initialBinding);
+    });
+  }
+
+  @override
+  Future<void> beginProcessing({
+    required String documentId,
+    required String versionId,
+    required DateTime startedAt,
+  }) async {
+    await _database.transaction(() async {
+      final document = await _requireDocument(documentId);
+      final version = await _requireVersion(versionId);
+      if (document.currentVersionId != versionId ||
+          version.documentId != documentId) {
+        throw ArgumentError('Only the current version can be processed.');
+      }
+      if (document.processingState == DataBankProcessingState.processing &&
+          version.processingState == DataBankProcessingState.processing) {
+        return;
+      }
+      if (document.processingState != DataBankProcessingState.pending ||
+          version.processingState != DataBankProcessingState.pending) {
+        throw StateError(
+          'The Data Bank document is not queued for processing.',
+        );
+      }
+      await _writeVersion(
+        _copyVersion(
+          version,
+          processingState: DataBankProcessingState.processing,
+          indexState: DataBankIndexState.indexing,
+        ),
+      );
+      await saveDocument(
+        _copyDocument(
+          document,
+          processingState: DataBankProcessingState.processing,
+          indexState: DataBankIndexState.indexing,
+          updatedAt: startedAt,
+        ),
+      );
+    });
+  }
+
+  @override
+  Future<void> completeProcessing({
+    required String documentId,
+    required String versionId,
+    required List<DataBankSection> sections,
+    required List<DataBankTextChunk> chunks,
+    required DateTime completedAt,
+  }) async {
+    await _database.transaction(() async {
+      final document = await _requireDocument(documentId);
+      final version = await _requireVersion(versionId);
+      if (document.currentVersionId != versionId ||
+          version.documentId != documentId ||
+          sections.any((entry) => entry.documentVersionId != versionId) ||
+          chunks.any((entry) => entry.documentVersionId != versionId)) {
+        throw ArgumentError(
+          'Processed Data Bank content has invalid ownership.',
+        );
+      }
+      if (document.processingState != DataBankProcessingState.processing ||
+          version.processingState != DataBankProcessingState.processing) {
+        throw StateError('The Data Bank document is not being processed.');
+      }
+      await replaceSections(versionId, sections);
+      await replaceChunks(versionId, chunks);
+      await _writeVersion(
+        _copyVersion(
+          version,
+          processingState: DataBankProcessingState.ready,
+          indexState: DataBankIndexState.indexed,
+        ),
+      );
+      await saveDocument(
+        _copyDocument(
+          document,
+          processingState: DataBankProcessingState.ready,
+          indexState: DataBankIndexState.indexed,
+          updatedAt: completedAt,
+        ),
+      );
+    });
+  }
+
+  @override
+  Future<void> failProcessing({
+    required String documentId,
+    required String versionId,
+    required DataBankFailure failure,
+  }) async {
+    await _database.transaction(() async {
+      final document = await _requireDocument(documentId);
+      final version = await _requireVersion(versionId);
+      if (document.currentVersionId != versionId ||
+          version.documentId != documentId) {
+        throw ArgumentError('Only the current version can fail processing.');
+      }
+      await _writeVersion(
+        _copyVersion(
+          version,
+          processingState: DataBankProcessingState.failed,
+          indexState: DataBankIndexState.failed,
+          failure: failure,
+        ),
+      );
+      await saveDocument(
+        _copyDocument(
+          document,
+          processingState: DataBankProcessingState.failed,
+          indexState: DataBankIndexState.failed,
+          failure: failure,
+          updatedAt: failure.occurredAt,
+        ),
+      );
+    });
+  }
+
+  @override
+  Future<void> purgeDocument(String documentId) async {
+    await (_database.delete(
+      _database.dataBankDocuments,
+    )..where((table) => table.id.equals(documentId)))
+        .go();
   }
 
   Future<void> _writeVersion(DataBankDocumentVersion version) async {
@@ -576,6 +871,25 @@ DataBankDocument _transitionedDocument(
   );
 }
 
+DataBankDocument _copyDocument(
+  DataBankDocument document, {
+  required DataBankProcessingState processingState,
+  required DataBankIndexState indexState,
+  DataBankFailure? failure,
+  DateTime? updatedAt,
+}) {
+  return DataBankDocument(
+    id: document.id,
+    currentVersionId: document.currentVersionId,
+    processingState: processingState,
+    indexState: indexState,
+    failure: failure,
+    reprocessing: document.reprocessing,
+    createdAt: document.createdAt,
+    updatedAt: updatedAt ?? document.updatedAt,
+  );
+}
+
 DataBankDocumentVersion _transitionedVersion(
   DataBankDocumentVersion version,
   DataBankProcessingState to,
@@ -593,6 +907,29 @@ DataBankDocumentVersion _transitionedVersion(
     importedAt: version.importedAt,
     processingState: to,
     indexState: _indexStateAfterTransition(version.indexState, to),
+    failure: failure,
+    reprocessing: version.reprocessing,
+  );
+}
+
+DataBankDocumentVersion _copyVersion(
+  DataBankDocumentVersion version, {
+  required DataBankProcessingState processingState,
+  required DataBankIndexState indexState,
+  DataBankFailure? failure,
+}) {
+  return DataBankDocumentVersion(
+    id: version.id,
+    documentId: version.documentId,
+    versionNumber: version.versionNumber,
+    supersedesVersionId: version.supersedesVersionId,
+    originalFileName: version.originalFileName,
+    mediaType: version.mediaType,
+    byteSize: version.byteSize,
+    contentHash: version.contentHash,
+    importedAt: version.importedAt,
+    processingState: processingState,
+    indexState: indexState,
     failure: failure,
     reprocessing: version.reprocessing,
   );
@@ -633,4 +970,13 @@ T _enumByName<T extends Enum>(Iterable<T> values, String name) {
     (value) => value.name == name,
     orElse: () => throw StateError('Unsupported persisted enum value: $name'),
   );
+}
+
+String? _plainTextFtsQuery(String input) {
+  final tokens = RegExp(
+    r'[\p{L}\p{N}]+',
+    unicode: true,
+  ).allMatches(input).map((match) => match.group(0)!).toList();
+  if (tokens.isEmpty) return null;
+  return tokens.map((token) => '"$token"*').join(' AND ');
 }

--- a/lib/domain/repositories/data_bank_repository.dart
+++ b/lib/domain/repositories/data_bank_repository.dart
@@ -1,5 +1,46 @@
 import 'package:native_tavern/data/models/data_bank.dart';
 
+/// Binding-aware filters for local Data Bank retrieval.
+final class DataBankSearchFilter {
+  final Set<String> documentIds;
+  final String? characterId;
+  final String? chatId;
+  final bool includeGlobal;
+  final bool includeUnbound;
+
+  const DataBankSearchFilter({
+    this.documentIds = const <String>{},
+    this.characterId,
+    this.chatId,
+    this.includeGlobal = true,
+    this.includeUnbound = true,
+  });
+
+  const DataBankSearchFilter.forContext({
+    this.characterId,
+    this.chatId,
+    this.includeGlobal = true,
+    this.documentIds = const <String>{},
+  }) : includeUnbound = false;
+}
+
+/// One FTS match with enough provenance to render and verify a citation.
+final class DataBankSearchResult {
+  final DataBankTextChunk chunk;
+  final DataBankCitation citation;
+  final String documentName;
+  final String snippet;
+  final double rank;
+
+  const DataBankSearchResult({
+    required this.chunk,
+    required this.citation,
+    required this.documentName,
+    required this.snippet,
+    required this.rank,
+  });
+}
+
 /// Persistence boundary for Data Bank document metadata.
 abstract interface class DataBankDocumentRepository {
   Future<DataBankDocument?> getDocument(String documentId);
@@ -38,6 +79,18 @@ abstract interface class DataBankChunkRepository {
     String documentVersionId,
     List<DataBankTextChunk> chunks,
   );
+}
+
+/// Local full-text retrieval over the canonical chunk records.
+abstract interface class DataBankSearchRepository {
+  Future<List<DataBankSearchResult>> search(
+    String query, {
+    int topK = 20,
+    DataBankSearchFilter filter = const DataBankSearchFilter(),
+  });
+
+  /// Recreates the derived FTS index from canonical chunk records.
+  Future<void> rebuildSearchIndex();
 }
 
 /// Persistence boundary for global, character, and chat bindings.
@@ -96,3 +149,51 @@ abstract interface class DataBankLifecycleRepository {
 
   Future<void> markDocumentDeleted(String documentId);
 }
+
+/// Atomic persistence operations used by the Data Bank management workflow.
+abstract interface class DataBankManagementRepository {
+  Future<DataBankDocumentVersion?> findVersionByContentHash(
+    DataBankContentHash contentHash,
+  );
+
+  Future<void> createPendingDocument({
+    required DataBankDocument document,
+    required DataBankDocumentVersion version,
+    required DataBankBinding initialBinding,
+  });
+
+  Future<void> beginProcessing({
+    required String documentId,
+    required String versionId,
+    required DateTime startedAt,
+  });
+
+  Future<void> completeProcessing({
+    required String documentId,
+    required String versionId,
+    required List<DataBankSection> sections,
+    required List<DataBankTextChunk> chunks,
+    required DateTime completedAt,
+  });
+
+  Future<void> failProcessing({
+    required String documentId,
+    required String versionId,
+    required DataBankFailure failure,
+  });
+
+  /// Permanently removes the document and all database-owned descendants.
+  Future<void> purgeDocument(String documentId);
+}
+
+/// Complete persistence surface used by production Data Bank workflows.
+abstract interface class DataBankRepository
+    implements
+        DataBankDocumentRepository,
+        DataBankVersionRepository,
+        DataBankSectionRepository,
+        DataBankChunkRepository,
+        DataBankSearchRepository,
+        DataBankBindingRepository,
+        DataBankLifecycleRepository,
+        DataBankManagementRepository {}

--- a/lib/domain/services/data_bank_library_service.dart
+++ b/lib/domain/services/data_bank_library_service.dart
@@ -1,0 +1,631 @@
+// Managed document files are user-triggered and intentionally asynchronous.
+// ignore_for_file: avoid_slow_async_io
+
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:native_tavern/data/models/data_bank.dart';
+import 'package:native_tavern/domain/repositories/data_bank_repository.dart';
+import 'package:native_tavern/domain/services/data_bank_ingestion_service.dart';
+import 'package:path/path.dart' as path;
+import 'package:uuid/uuid.dart';
+
+typedef DataBankClock = DateTime Function();
+typedef DataBankIdFactory = String Function();
+
+final class DataBankDuplicateDocumentException implements Exception {
+  final String existingDocumentId;
+
+  const DataBankDuplicateDocumentException(this.existingDocumentId);
+
+  @override
+  String toString() => 'This file is already in the Data Bank.';
+}
+
+final class DataBankLibraryEntry {
+  final DataBankDocument document;
+  final DataBankDocumentVersion version;
+  final List<DataBankBinding> bindings;
+  final int chunkCount;
+  final List<String> managedPaths;
+
+  const DataBankLibraryEntry({
+    required this.document,
+    required this.version,
+    required this.bindings,
+    required this.chunkCount,
+    required this.managedPaths,
+  });
+}
+
+final class DataBankDocumentPreview {
+  final DataBankDocument document;
+  final DataBankDocumentVersion version;
+  final List<DataBankSection> sections;
+  final List<DataBankTextChunk> chunks;
+
+  const DataBankDocumentPreview({
+    required this.document,
+    required this.version,
+    required this.sections,
+    required this.chunks,
+  });
+}
+
+final class DataBankDeletionPreview {
+  final String documentId;
+  final String documentName;
+  final int versionCount;
+  final int chunkCount;
+  final int bindingCount;
+  final List<String> managedPaths;
+
+  const DataBankDeletionPreview({
+    required this.documentId,
+    required this.documentName,
+    required this.versionCount,
+    required this.chunkCount,
+    required this.bindingCount,
+    required this.managedPaths,
+  });
+}
+
+abstract interface class DataBankLibraryOperations {
+  Future<List<DataBankLibraryEntry>> listDocuments();
+
+  Future<DataBankLibraryEntry> importDocument(
+    File source, {
+    DataBankProgressCallback? onProgress,
+  });
+
+  Future<DataBankLibraryEntry> retryDocument(
+    String documentId, {
+    DataBankProgressCallback? onProgress,
+  });
+
+  Future<void> setDocumentEnabled(String documentId, bool enabled);
+
+  Future<void> rebuildSearchIndex();
+
+  Future<List<DataBankSearchResult>> search(
+    String query, {
+    int topK = 20,
+    DataBankSearchFilter filter = const DataBankSearchFilter(),
+  });
+
+  Future<DataBankDocumentPreview> previewDocument(String documentId);
+
+  Future<DataBankBinding> saveBinding({
+    required String documentId,
+    required DataBankBindingScope scope,
+    String? targetId,
+    bool enabled = true,
+  });
+
+  Future<void> removeBinding(String bindingId);
+
+  Future<DataBankDeletionPreview> previewDeletion(String documentId);
+
+  Future<void> deleteDocument(String documentId);
+
+  Future<void> recoverInterruptedImports();
+}
+
+final class DataBankManagedSource {
+  final File file;
+  final int byteSize;
+  final DataBankContentHash contentHash;
+
+  const DataBankManagedSource({
+    required this.file,
+    required this.byteSize,
+    required this.contentHash,
+  });
+}
+
+abstract interface class DataBankManagedFileStore {
+  Future<DataBankManagedSource> storeSource({
+    required File source,
+    required String documentId,
+    required String versionId,
+  });
+
+  Future<File?> sourceFor({
+    required String documentId,
+    required String versionId,
+  });
+
+  Future<List<String>> listManagedPaths(String documentId);
+
+  Future<DataBankStagedFileDeletion> stageDeletion(String documentId);
+
+  Future<void> cleanTrash();
+}
+
+final class DataBankStagedFileDeletion {
+  final Directory? _original;
+  final Directory? _staged;
+  bool _settled = false;
+
+  DataBankStagedFileDeletion._(this._original, this._staged);
+
+  Future<void> commit() async {
+    if (_settled) return;
+    _settled = true;
+    if (_staged != null && await _staged.exists()) {
+      await _staged.delete(recursive: true);
+    }
+  }
+
+  Future<void> restore() async {
+    if (_settled) return;
+    _settled = true;
+    if (_original != null &&
+        _staged != null &&
+        await _staged.exists() &&
+        !await _original.exists()) {
+      await _staged.rename(_original.path);
+    }
+  }
+}
+
+final class FileDataBankManagedFileStore implements DataBankManagedFileStore {
+  final Directory root;
+  final DataBankIdFactory _idFactory;
+
+  FileDataBankManagedFileStore({
+    required this.root,
+    DataBankIdFactory? idFactory,
+  }) : _idFactory = idFactory ?? const Uuid().v4;
+
+  @override
+  Future<DataBankManagedSource> storeSource({
+    required File source,
+    required String documentId,
+    required String versionId,
+  }) async {
+    if (!await source.exists()) {
+      throw DataBankIngestionException(
+        DataBankIngestionFailureCode.sourceNotFound,
+        'Source file does not exist: ${source.path}',
+      );
+    }
+    final versionDirectory = Directory(
+      path.join(root.path, documentId, versionId),
+    );
+    await versionDirectory.create(recursive: true);
+    final extension = path.extension(source.path).toLowerCase();
+    final destination = File(
+      path.join(versionDirectory.path, 'source$extension'),
+    );
+    final temporary = File('${destination.path}.importing');
+    try {
+      await source.openRead().pipe(temporary.openWrite());
+      if (await destination.exists()) await destination.delete();
+      await temporary.rename(destination.path);
+      final digest = await sha256.bind(destination.openRead()).first;
+      return DataBankManagedSource(
+        file: destination,
+        byteSize: await destination.length(),
+        contentHash: DataBankContentHash(
+          algorithm: DataBankHashAlgorithm.sha256,
+          digest: digest.toString(),
+        ),
+      );
+    } catch (_) {
+      if (await temporary.exists()) await temporary.delete();
+      rethrow;
+    }
+  }
+
+  @override
+  Future<File?> sourceFor({
+    required String documentId,
+    required String versionId,
+  }) async {
+    final directory = Directory(path.join(root.path, documentId, versionId));
+    if (!await directory.exists()) return null;
+    await for (final entry in directory.list()) {
+      if (entry is File &&
+          path.basename(entry.path).startsWith('source') &&
+          !entry.path.endsWith('.importing')) {
+        return entry;
+      }
+    }
+    return null;
+  }
+
+  @override
+  Future<List<String>> listManagedPaths(String documentId) async {
+    final directory = Directory(path.join(root.path, documentId));
+    if (!await directory.exists()) return const [];
+    final paths = <String>[];
+    await for (final entry in directory.list(recursive: true)) {
+      if (entry is File) paths.add(entry.path);
+    }
+    paths.sort();
+    return paths;
+  }
+
+  @override
+  Future<DataBankStagedFileDeletion> stageDeletion(String documentId) async {
+    final original = Directory(path.join(root.path, documentId));
+    if (!await original.exists()) {
+      return DataBankStagedFileDeletion._(null, null);
+    }
+    final trash = Directory(path.join(root.path, '.trash'));
+    await trash.create(recursive: true);
+    final staged = Directory(
+      path.join(trash.path, '$documentId-${_idFactory()}'),
+    );
+    await original.rename(staged.path);
+    return DataBankStagedFileDeletion._(original, staged);
+  }
+
+  @override
+  Future<void> cleanTrash() async {
+    final trash = Directory(path.join(root.path, '.trash'));
+    if (!await trash.exists()) return;
+    await for (final entry in trash.list()) {
+      await entry.delete(recursive: true);
+    }
+  }
+}
+
+final class DataBankLibraryService implements DataBankLibraryOperations {
+  final DataBankRepository _repository;
+  final DataBankIngestionService _ingestion;
+  final DataBankManagedFileStore _files;
+  final DataBankClock _clock;
+  final DataBankIdFactory _idFactory;
+
+  DataBankLibraryService({
+    required DataBankRepository repository,
+    required DataBankManagedFileStore files,
+    DataBankIngestionService? ingestion,
+    DataBankClock? clock,
+    DataBankIdFactory? idFactory,
+  })  : _repository = repository,
+        _files = files,
+        _ingestion = ingestion ?? DataBankIngestionService(),
+        _clock = clock ?? (() => DateTime.now().toUtc()),
+        _idFactory = idFactory ?? const Uuid().v4;
+
+  @override
+  Future<List<DataBankLibraryEntry>> listDocuments() async {
+    final entries = <DataBankLibraryEntry>[];
+    for (final document in await _repository.listDocuments()) {
+      entries.add(await _entryFor(document));
+    }
+    entries.sort((left, right) {
+      final updated = right.document.updatedAt.compareTo(
+        left.document.updatedAt,
+      );
+      if (updated != 0) return updated;
+      return left.version.originalFileName.compareTo(
+        right.version.originalFileName,
+      );
+    });
+    return entries;
+  }
+
+  @override
+  Future<DataBankLibraryEntry> importDocument(
+    File source, {
+    DataBankProgressCallback? onProgress,
+  }) async {
+    final mediaType = _mediaTypeFor(source.path);
+    final documentId = _idFactory();
+    final versionId = _idFactory();
+    final managed = await _files.storeSource(
+      source: source,
+      documentId: documentId,
+      versionId: versionId,
+    );
+    var persisted = false;
+    try {
+      final duplicate = await _repository.findVersionByContentHash(
+        managed.contentHash,
+      );
+      if (duplicate != null) {
+        final deletion = await _files.stageDeletion(documentId);
+        await deletion.commit();
+        throw DataBankDuplicateDocumentException(duplicate.documentId);
+      }
+
+      final now = _clock().toUtc();
+      final version = DataBankDocumentVersion(
+        id: versionId,
+        documentId: documentId,
+        versionNumber: 1,
+        originalFileName: path.basename(source.path),
+        mediaType: mediaType,
+        byteSize: managed.byteSize,
+        contentHash: managed.contentHash,
+        importedAt: now,
+      );
+      final document = DataBankDocument(
+        id: documentId,
+        currentVersionId: versionId,
+        createdAt: now,
+        updatedAt: now,
+      );
+      final binding = DataBankBinding(
+        id: _idFactory(),
+        documentId: documentId,
+        scope: DataBankBindingScope.global,
+        createdAt: now,
+        updatedAt: now,
+      );
+      await _repository.createPendingDocument(
+        document: document,
+        version: version,
+        initialBinding: binding,
+      );
+      persisted = true;
+      return _process(document, version, managed.file, onProgress: onProgress);
+    } catch (_) {
+      if (!persisted) {
+        final deletion = await _files.stageDeletion(documentId);
+        await deletion.commit();
+      }
+      rethrow;
+    }
+  }
+
+  @override
+  Future<DataBankLibraryEntry> retryDocument(
+    String documentId, {
+    DataBankProgressCallback? onProgress,
+  }) async {
+    var document = await _requireDocument(documentId);
+    final version = await _requireVersion(document.currentVersionId);
+    if (document.processingState == DataBankProcessingState.disabled) {
+      await _repository.setDocumentEnabled(documentId, true);
+      document = await _requireDocument(documentId);
+    } else if (document.processingState == DataBankProcessingState.ready ||
+        document.processingState == DataBankProcessingState.failed) {
+      await _repository.requestReprocessing(
+        documentId: documentId,
+        versionId: version.id,
+        reason: 'User requested rebuild',
+        requestedAt: _clock().toUtc(),
+      );
+      document = await _requireDocument(documentId);
+    }
+    final source = await _files.sourceFor(
+      documentId: documentId,
+      versionId: version.id,
+    );
+    if (source == null) {
+      const error = DataBankIngestionException(
+        DataBankIngestionFailureCode.sourceNotFound,
+        'The managed source file is missing.',
+      );
+      await _recordFailure(documentId, version.id, error);
+      throw error;
+    }
+    return _process(document, version, source, onProgress: onProgress);
+  }
+
+  Future<DataBankLibraryEntry> _process(
+    DataBankDocument document,
+    DataBankDocumentVersion version,
+    File source, {
+    DataBankProgressCallback? onProgress,
+  }) async {
+    try {
+      await _repository.beginProcessing(
+        documentId: document.id,
+        versionId: version.id,
+        startedAt: _clock().toUtc(),
+      );
+      final result = await _ingestion.ingest(
+        DataBankIngestionRequest(
+          sourceFile: source,
+          documentVersionId: version.id,
+          mediaType: version.mediaType,
+          onProgress: onProgress,
+        ),
+      );
+      await _repository.completeProcessing(
+        documentId: document.id,
+        versionId: version.id,
+        sections: result.sections,
+        chunks: result.chunks,
+        completedAt: _clock().toUtc(),
+      );
+      return _entryFor(await _requireDocument(document.id));
+    } catch (error) {
+      await _recordFailure(document.id, version.id, error);
+      rethrow;
+    }
+  }
+
+  Future<void> _recordFailure(
+    String documentId,
+    String versionId,
+    Object error,
+  ) async {
+    final code = error is DataBankIngestionException
+        ? error.code.name
+        : 'processingFailed';
+    final message = error is DataBankIngestionException
+        ? error.message
+        : 'The document could not be processed.';
+    await _repository.failProcessing(
+      documentId: documentId,
+      versionId: versionId,
+      failure: DataBankFailure(
+        code: code,
+        message: message,
+        occurredAt: _clock().toUtc(),
+        retryable: error is! DataBankIngestionException ||
+            error.code == DataBankIngestionFailureCode.ioFailure ||
+            error.code == DataBankIngestionFailureCode.sourceNotFound ||
+            error.code == DataBankIngestionFailureCode.cancelled,
+      ),
+    );
+  }
+
+  @override
+  Future<void> setDocumentEnabled(String documentId, bool enabled) async {
+    final document = await _requireDocument(documentId);
+    if (enabled == document.isEnabled) return;
+    await _repository.setDocumentEnabled(documentId, enabled);
+    if (enabled) await retryDocument(documentId);
+  }
+
+  @override
+  Future<void> rebuildSearchIndex() => _repository.rebuildSearchIndex();
+
+  @override
+  Future<List<DataBankSearchResult>> search(
+    String query, {
+    int topK = 20,
+    DataBankSearchFilter filter = const DataBankSearchFilter(),
+  }) {
+    return _repository.search(query, topK: topK, filter: filter);
+  }
+
+  @override
+  Future<DataBankDocumentPreview> previewDocument(String documentId) async {
+    final document = await _requireDocument(documentId);
+    final version = await _requireVersion(document.currentVersionId);
+    return DataBankDocumentPreview(
+      document: document,
+      version: version,
+      sections: await _repository.listSections(version.id),
+      chunks: await _repository.listChunks(version.id),
+    );
+  }
+
+  @override
+  Future<DataBankBinding> saveBinding({
+    required String documentId,
+    required DataBankBindingScope scope,
+    String? targetId,
+    bool enabled = true,
+  }) async {
+    await _requireDocument(documentId);
+    final matching = (await _repository.listBindingsForDocument(
+      documentId,
+      includeDisabled: true,
+    ))
+        .where(
+          (binding) => binding.scope == scope && binding.targetId == targetId,
+        )
+        .toList(growable: false);
+    final existing = matching.isEmpty ? null : matching.first;
+    final now = _clock().toUtc();
+    final binding = DataBankBinding(
+      id: existing?.id ?? _idFactory(),
+      documentId: documentId,
+      scope: scope,
+      characterId: scope == DataBankBindingScope.character ? targetId : null,
+      chatId: scope == DataBankBindingScope.chat ? targetId : null,
+      enabled: enabled,
+      createdAt: existing?.createdAt ?? now,
+      updatedAt: now,
+    );
+    await _repository.saveBinding(binding);
+    return binding;
+  }
+
+  @override
+  Future<void> removeBinding(String bindingId) {
+    return _repository.deleteBinding(bindingId);
+  }
+
+  @override
+  Future<DataBankDeletionPreview> previewDeletion(String documentId) async {
+    final entry = await _entryFor(await _requireDocument(documentId));
+    final versions = await _repository.listVersions(documentId);
+    var chunks = 0;
+    for (final version in versions) {
+      chunks += (await _repository.listChunks(version.id)).length;
+    }
+    return DataBankDeletionPreview(
+      documentId: documentId,
+      documentName: entry.version.originalFileName,
+      versionCount: versions.length,
+      chunkCount: chunks,
+      bindingCount: entry.bindings.length,
+      managedPaths: entry.managedPaths,
+    );
+  }
+
+  @override
+  Future<void> deleteDocument(String documentId) async {
+    await _requireDocument(documentId);
+    final staged = await _files.stageDeletion(documentId);
+    try {
+      await _repository.purgeDocument(documentId);
+    } catch (_) {
+      await staged.restore();
+      rethrow;
+    }
+    await staged.commit();
+  }
+
+  @override
+  Future<void> recoverInterruptedImports() async {
+    try {
+      await _files.cleanTrash();
+    } on FileSystemException {
+      // Trash cleanup is best-effort and must not hide the document library.
+    }
+    final documents = await _repository.listDocuments();
+    for (final document in documents.where(
+      (entry) =>
+          entry.processingState == DataBankProcessingState.pending ||
+          entry.processingState == DataBankProcessingState.processing,
+    )) {
+      try {
+        await retryDocument(document.id);
+      } catch (_) {
+        // The retry records a visible failure and the remaining imports continue.
+      }
+    }
+  }
+
+  Future<DataBankLibraryEntry> _entryFor(DataBankDocument document) async {
+    final version = await _requireVersion(document.currentVersionId);
+    return DataBankLibraryEntry(
+      document: document,
+      version: version,
+      bindings: await _repository.listBindingsForDocument(
+        document.id,
+        includeDisabled: true,
+      ),
+      chunkCount: (await _repository.listChunks(version.id)).length,
+      managedPaths: await _files.listManagedPaths(document.id),
+    );
+  }
+
+  Future<DataBankDocument> _requireDocument(String id) async {
+    final document = await _repository.getDocument(id);
+    if (document == null) throw StateError('Document $id does not exist.');
+    return document;
+  }
+
+  Future<DataBankDocumentVersion> _requireVersion(String id) async {
+    final version = await _repository.getVersion(id);
+    if (version == null) throw StateError('Version $id does not exist.');
+    return version;
+  }
+}
+
+String _mediaTypeFor(String filePath) {
+  return switch (path.extension(filePath).toLowerCase()) {
+    '.txt' => 'text/plain',
+    '.md' || '.markdown' => 'text/markdown',
+    '.html' || '.htm' => 'text/html',
+    '.pdf' => 'application/pdf',
+    '.epub' => 'application/epub+zip',
+    final extension => throw DataBankIngestionException(
+        DataBankIngestionFailureCode.unsupportedFormat,
+        'Unsupported document format: $extension',
+      ),
+  };
+}

--- a/lib/presentation/controllers/data_bank_library_controller.dart
+++ b/lib/presentation/controllers/data_bank_library_controller.dart
@@ -1,0 +1,185 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:native_tavern/data/models/data_bank.dart';
+import 'package:native_tavern/domain/repositories/data_bank_repository.dart';
+import 'package:native_tavern/domain/services/data_bank_ingestion_service.dart';
+import 'package:native_tavern/domain/services/data_bank_library_service.dart';
+
+class DataBankLibraryController extends ChangeNotifier {
+  final DataBankLibraryOperations operations;
+
+  DataBankLibraryController(this.operations);
+
+  List<DataBankLibraryEntry> _documents = const [];
+  List<DataBankSearchResult> _searchResults = const [];
+  bool _loading = false;
+  bool _working = false;
+  Object? _error;
+  DataBankIngestionProgress? _progress;
+  String _searchQuery = '';
+
+  List<DataBankLibraryEntry> get documents => _documents;
+  List<DataBankSearchResult> get searchResults => _searchResults;
+  bool get loading => _loading;
+  bool get working => _working;
+  Object? get error => _error;
+  DataBankIngestionProgress? get progress => _progress;
+  String get searchQuery => _searchQuery;
+  bool get showingSearch => _searchQuery.trim().isNotEmpty;
+
+  double? get overallProgress {
+    final current = _progress;
+    if (current == null) return null;
+    final phase = switch (current.phase) {
+      DataBankIngestionPhase.staging => 0,
+      DataBankIngestionPhase.parsing => 1,
+      DataBankIngestionPhase.chunking => 2,
+      DataBankIngestionPhase.completed => 3,
+    };
+    return ((phase + current.fraction) / 4).clamp(0, 1).toDouble();
+  }
+
+  Future<void> initialize() async {
+    if (_loading) return;
+    _loading = true;
+    _error = null;
+    notifyListeners();
+    try {
+      await operations.recoverInterruptedImports();
+      _documents = await operations.listDocuments();
+    } catch (error) {
+      _error = error;
+    } finally {
+      _loading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> reload() async {
+    _loading = true;
+    _error = null;
+    notifyListeners();
+    try {
+      _documents = await operations.listDocuments();
+      if (showingSearch) await _runSearch();
+    } catch (error) {
+      _error = error;
+    } finally {
+      _loading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> importDocument(File source) async {
+    await _run(() async {
+      await operations.importDocument(
+        source,
+        onProgress: (progress) {
+          _progress = progress;
+          notifyListeners();
+        },
+      );
+    });
+  }
+
+  Future<void> retryDocument(String documentId) async {
+    await _run(() async {
+      await operations.retryDocument(
+        documentId,
+        onProgress: (progress) {
+          _progress = progress;
+          notifyListeners();
+        },
+      );
+    });
+  }
+
+  Future<void> setDocumentEnabled(String documentId, bool enabled) {
+    return _run(() => operations.setDocumentEnabled(documentId, enabled));
+  }
+
+  Future<void> rebuildSearchIndex() {
+    return _run(operations.rebuildSearchIndex);
+  }
+
+  Future<void> search(String query) async {
+    _searchQuery = query;
+    _error = null;
+    if (!showingSearch) {
+      _searchResults = const [];
+      notifyListeners();
+      return;
+    }
+    _working = true;
+    notifyListeners();
+    try {
+      await _runSearch();
+    } catch (error) {
+      _error = error;
+    } finally {
+      _working = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> _runSearch() async {
+    _searchResults = await operations.search(_searchQuery, topK: 50);
+  }
+
+  Future<DataBankDocumentPreview> previewDocument(String documentId) {
+    return operations.previewDocument(documentId);
+  }
+
+  Future<DataBankDeletionPreview> previewDeletion(String documentId) {
+    return operations.previewDeletion(documentId);
+  }
+
+  Future<void> deleteDocument(String documentId) {
+    return _run(() => operations.deleteDocument(documentId));
+  }
+
+  Future<void> saveBinding({
+    required String documentId,
+    required DataBankBindingScope scope,
+    String? targetId,
+  }) {
+    return _run(
+      () => operations.saveBinding(
+        documentId: documentId,
+        scope: scope,
+        targetId: targetId,
+      ),
+    );
+  }
+
+  Future<void> removeBinding(String bindingId) {
+    return _run(() => operations.removeBinding(bindingId));
+  }
+
+  void clearError() {
+    if (_error == null) return;
+    _error = null;
+    notifyListeners();
+  }
+
+  Future<void> _run(Future<void> Function() operation) async {
+    if (_working) return;
+    _working = true;
+    _error = null;
+    _progress = null;
+    notifyListeners();
+    try {
+      await operation();
+      _documents = await operations.listDocuments();
+      if (showingSearch) await _runSearch();
+    } catch (error) {
+      _error = error;
+      rethrow;
+    } finally {
+      _working = false;
+      _progress = null;
+      notifyListeners();
+    }
+  }
+}

--- a/lib/presentation/providers/data_bank_providers.dart
+++ b/lib/presentation/providers/data_bank_providers.dart
@@ -1,0 +1,27 @@
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:native_tavern/core/services/initialization_service.dart';
+import 'package:native_tavern/data/repositories/drift_data_bank_repository.dart';
+import 'package:native_tavern/domain/repositories/data_bank_repository.dart';
+import 'package:native_tavern/domain/services/data_bank_library_service.dart';
+import 'package:path/path.dart' as path;
+
+final dataBankRepositoryProvider = Provider<DataBankRepository>((ref) {
+  return DriftDataBankRepository(ref.watch(databaseProvider));
+});
+
+final dataBankManagedFileStoreProvider =
+    Provider<DataBankManagedFileStore>((ref) {
+  return FileDataBankManagedFileStore(
+    root: Directory(path.join(ref.watch(dataPathProvider), 'data_bank')),
+  );
+});
+
+final dataBankLibraryServiceProvider =
+    Provider<DataBankLibraryOperations>((ref) {
+  return DataBankLibraryService(
+    repository: ref.watch(dataBankRepositoryProvider),
+    files: ref.watch(dataBankManagedFileStoreProvider),
+  );
+});

--- a/lib/presentation/screens/data_bank/data_bank_screen.dart
+++ b/lib/presentation/screens/data_bank/data_bank_screen.dart
@@ -1,0 +1,895 @@
+// File selection is user-triggered and intentionally asynchronous.
+// ignore_for_file: avoid_slow_async_io
+
+import 'dart:io';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:native_tavern/data/models/data_bank.dart';
+import 'package:native_tavern/data/repositories/character_repository.dart';
+import 'package:native_tavern/data/repositories/chat_repository.dart';
+import 'package:native_tavern/domain/repositories/data_bank_repository.dart';
+import 'package:native_tavern/domain/services/data_bank_library_service.dart';
+import 'package:native_tavern/presentation/controllers/data_bank_library_controller.dart';
+import 'package:native_tavern/presentation/providers/data_bank_providers.dart';
+
+abstract interface class DataBankFileGateway {
+  Future<File?> pickDocument();
+}
+
+final class PlatformDataBankFileGateway implements DataBankFileGateway {
+  const PlatformDataBankFileGateway();
+
+  @override
+  Future<File?> pickDocument() async {
+    final result = await FilePicker.platform.pickFiles(
+      type: FileType.custom,
+      allowedExtensions: const [
+        'txt',
+        'md',
+        'markdown',
+        'html',
+        'htm',
+        'pdf',
+        'epub',
+      ],
+      allowMultiple: false,
+      withData: false,
+    );
+    if (result == null || result.files.isEmpty) return null;
+    final selectedPath = result.files.single.path;
+    if (selectedPath == null) {
+      throw const FileSystemException(
+          'The selected document could not be read.');
+    }
+    return File(selectedPath);
+  }
+}
+
+final class DataBankBindingTarget {
+  final String id;
+  final String label;
+
+  const DataBankBindingTarget({required this.id, required this.label});
+}
+
+abstract interface class DataBankBindingTargetGateway {
+  Future<List<DataBankBindingTarget>> listCharacters();
+
+  Future<List<DataBankBindingTarget>> listChats();
+}
+
+final class RepositoryDataBankBindingTargetGateway
+    implements DataBankBindingTargetGateway {
+  final CharacterRepository _characters;
+  final ChatRepository _chats;
+
+  const RepositoryDataBankBindingTargetGateway(
+    this._characters,
+    this._chats,
+  );
+
+  @override
+  Future<List<DataBankBindingTarget>> listCharacters() async {
+    final targets = (await _characters.getAllCharacters())
+        .map(
+          (character) => DataBankBindingTarget(
+            id: character.id,
+            label: character.name,
+          ),
+        )
+        .toList();
+    targets.sort((left, right) => left.label.compareTo(right.label));
+    return targets;
+  }
+
+  @override
+  Future<List<DataBankBindingTarget>> listChats() async {
+    return (await _chats.getAllChats())
+        .map(
+          (chat) => DataBankBindingTarget(id: chat.id, label: chat.title),
+        )
+        .toList(growable: false);
+  }
+}
+
+class DataBankScreen extends ConsumerStatefulWidget {
+  final DataBankLibraryController? controller;
+  final DataBankFileGateway fileGateway;
+  final DataBankBindingTargetGateway? bindingTargetGateway;
+
+  const DataBankScreen({
+    super.key,
+    this.controller,
+    this.fileGateway = const PlatformDataBankFileGateway(),
+    this.bindingTargetGateway,
+  });
+
+  @override
+  ConsumerState<DataBankScreen> createState() => _DataBankScreenState();
+}
+
+class _DataBankScreenState extends ConsumerState<DataBankScreen> {
+  late final DataBankLibraryController _controller;
+  late final bool _ownsController;
+  final _searchController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _ownsController = widget.controller == null;
+    _controller = widget.controller ??
+        DataBankLibraryController(ref.read(dataBankLibraryServiceProvider));
+    _controller.addListener(_refresh);
+    _controller.initialize();
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    _controller.removeListener(_refresh);
+    if (_ownsController) _controller.dispose();
+    super.dispose();
+  }
+
+  void _refresh() {
+    if (mounted) setState(() {});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Data Bank'),
+        actions: [
+          IconButton(
+            key: const Key('data-bank-rebuild-index'),
+            tooltip: 'Rebuild search index',
+            onPressed: _controller.working ? null : _rebuildIndex,
+            icon: const Icon(Icons.manage_search_outlined),
+          ),
+          IconButton(
+            key: const Key('data-bank-import'),
+            tooltip: 'Import document',
+            onPressed: _controller.working ? null : _importDocument,
+            icon: const Icon(Icons.note_add_outlined),
+          ),
+        ],
+      ),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
+            child: SearchBar(
+              key: const Key('data-bank-search'),
+              controller: _searchController,
+              hintText: 'Search documents',
+              leading: const Icon(Icons.search),
+              trailing: [
+                if (_controller.showingSearch)
+                  IconButton(
+                    tooltip: 'Clear search',
+                    onPressed: () {
+                      _searchController.clear();
+                      _controller.search('');
+                    },
+                    icon: const Icon(Icons.close),
+                  ),
+              ],
+              onSubmitted: _controller.search,
+            ),
+          ),
+          if (_controller.overallProgress case final progress?)
+            LinearProgressIndicator(
+              key: const Key('data-bank-import-progress'),
+              value: progress,
+            ),
+          if (_controller.error case final error?)
+            _ErrorBanner(
+              message: _friendlyError(error),
+              onDismiss: _controller.clearError,
+            ),
+          Expanded(child: _buildContent()),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildContent() {
+    if (_controller.loading && _controller.documents.isEmpty) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    if (_controller.showingSearch) {
+      if (_controller.searchResults.isEmpty) {
+        return const _EmptyState(
+          key: Key('data-bank-no-results'),
+          icon: Icons.search_off_outlined,
+          title: 'No matches',
+        );
+      }
+      return RefreshIndicator(
+        onRefresh: () => _controller.search(_searchController.text),
+        child: ListView.separated(
+          key: const Key('data-bank-search-results'),
+          padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
+          itemCount: _controller.searchResults.length,
+          separatorBuilder: (_, __) => const SizedBox(height: 8),
+          itemBuilder: (context, index) =>
+              _SearchResultTile(result: _controller.searchResults[index]),
+        ),
+      );
+    }
+    if (_controller.documents.isEmpty) {
+      return _EmptyState(
+        key: const Key('data-bank-empty'),
+        icon: Icons.library_books_outlined,
+        title: 'No documents',
+        action: FilledButton.icon(
+          onPressed: _controller.working ? null : _importDocument,
+          icon: const Icon(Icons.note_add_outlined),
+          label: const Text('Import'),
+        ),
+      );
+    }
+    return RefreshIndicator(
+      onRefresh: _controller.reload,
+      child: ListView.separated(
+        key: const Key('data-bank-document-list'),
+        padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
+        itemCount: _controller.documents.length,
+        separatorBuilder: (_, __) => const SizedBox(height: 8),
+        itemBuilder: (context, index) {
+          final entry = _controller.documents[index];
+          return _DocumentCard(
+            key: ValueKey(entry.document.id),
+            entry: entry,
+            busy: _controller.working,
+            onToggle: (enabled) => _run(
+              () => _controller.setDocumentEnabled(
+                entry.document.id,
+                enabled,
+              ),
+            ),
+            onPreview: () => _showPreview(entry.document.id),
+            onBindings: () => _showBindings(entry),
+            onRetry: () =>
+                _run(() => _controller.retryDocument(entry.document.id)),
+            onDelete: () => _confirmDelete(entry.document.id),
+          );
+        },
+      ),
+    );
+  }
+
+  Future<void> _importDocument() async {
+    await _run(() async {
+      final file = await widget.fileGateway.pickDocument();
+      if (file != null) await _controller.importDocument(file);
+    });
+  }
+
+  Future<void> _rebuildIndex() async {
+    await _run(() async {
+      await _controller.rebuildSearchIndex();
+      _showMessage('Search index rebuilt');
+    });
+  }
+
+  Future<void> _showPreview(String documentId) async {
+    await _run(() async {
+      final preview = await _controller.previewDocument(documentId);
+      if (!mounted) return;
+      await showModalBottomSheet<void>(
+        context: context,
+        isScrollControlled: true,
+        showDragHandle: true,
+        builder: (context) => _PreviewSheet(preview: preview),
+      );
+    });
+  }
+
+  Future<void> _showBindings(DataBankLibraryEntry entry) async {
+    await _run(() async {
+      final gateway = widget.bindingTargetGateway ??
+          RepositoryDataBankBindingTargetGateway(
+            ref.read(characterRepositoryProvider),
+            ref.read(chatRepositoryProvider),
+          );
+      final targets = await Future.wait([
+        gateway.listCharacters(),
+        gateway.listChats(),
+      ]);
+      if (!mounted) return;
+      await showDialog<void>(
+        context: context,
+        builder: (context) => _BindingsDialog(
+          entry: entry,
+          characterTargets: targets[0],
+          chatTargets: targets[1],
+          onSave: ({required scope, targetId}) async {
+            await _controller.saveBinding(
+              documentId: entry.document.id,
+              scope: scope,
+              targetId: targetId,
+            );
+          },
+          onDelete: _controller.removeBinding,
+        ),
+      );
+    });
+  }
+
+  Future<void> _confirmDelete(String documentId) async {
+    await _run(() async {
+      final preview = await _controller.previewDeletion(documentId);
+      if (!mounted) return;
+      final confirmed = await showDialog<bool>(
+        context: context,
+        builder: (context) => AlertDialog(
+          title: Text('Delete ${preview.documentName}?'),
+          content: Text(
+            '${preview.versionCount} version(s), ${preview.chunkCount} chunk(s), '
+            '${preview.bindingCount} binding(s), and '
+            '${preview.managedPaths.length} managed file(s) will be removed.',
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context, false),
+              child: const Text('Cancel'),
+            ),
+            FilledButton(
+              key: const Key('data-bank-confirm-delete'),
+              onPressed: () => Navigator.pop(context, true),
+              child: const Text('Delete'),
+            ),
+          ],
+        ),
+      );
+      if (confirmed == true) await _controller.deleteDocument(documentId);
+    });
+  }
+
+  Future<void> _run(Future<void> Function() operation) async {
+    try {
+      await operation();
+    } catch (error) {
+      _showMessage(_friendlyError(error));
+    }
+  }
+
+  void _showMessage(String message) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context)
+      ..hideCurrentSnackBar()
+      ..showSnackBar(SnackBar(content: Text(message)));
+  }
+}
+
+class _DocumentCard extends StatelessWidget {
+  final DataBankLibraryEntry entry;
+  final bool busy;
+  final ValueChanged<bool> onToggle;
+  final VoidCallback onPreview;
+  final VoidCallback onBindings;
+  final VoidCallback onRetry;
+  final VoidCallback onDelete;
+
+  const _DocumentCard({
+    super.key,
+    required this.entry,
+    required this.busy,
+    required this.onToggle,
+    required this.onPreview,
+    required this.onBindings,
+    required this.onRetry,
+    required this.onDelete,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final document = entry.document;
+    final processing =
+        document.processingState == DataBankProcessingState.pending ||
+            document.processingState == DataBankProcessingState.processing;
+    final failed = document.processingState == DataBankProcessingState.failed;
+    final disabled =
+        document.processingState == DataBankProcessingState.disabled;
+    return Card(
+      margin: EdgeInsets.zero,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(12, 12, 8, 8),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Padding(
+                  padding: EdgeInsets.only(top: 4),
+                  child: Icon(Icons.description_outlined),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        entry.version.originalFileName,
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                        style: Theme.of(context).textTheme.titleMedium,
+                      ),
+                      const SizedBox(height: 3),
+                      Text(
+                        '${_formatBytes(entry.version.byteSize)}  |  '
+                        '${entry.chunkCount} chunks  |  '
+                        '${entry.bindings.length} bindings',
+                        style: Theme.of(context).textTheme.bodySmall,
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(width: 8),
+                _StatusBadge(state: document.processingState),
+                Switch(
+                  key: ValueKey('data-bank-toggle-${document.id}'),
+                  value: document.isEnabled,
+                  onChanged: busy || processing ? null : onToggle,
+                ),
+              ],
+            ),
+            if (processing) ...[
+              const SizedBox(height: 8),
+              const LinearProgressIndicator(),
+            ],
+            if (failed) ...[
+              const SizedBox(height: 8),
+              Text(
+                document.failure?.message ?? 'Processing failed',
+                style: TextStyle(color: Theme.of(context).colorScheme.error),
+              ),
+            ],
+            if (entry.bindings.isNotEmpty) ...[
+              const SizedBox(height: 8),
+              Wrap(
+                spacing: 6,
+                runSpacing: 6,
+                children: entry.bindings
+                    .map(
+                      (binding) => Chip(
+                        visualDensity: VisualDensity.compact,
+                        avatar: Icon(_bindingIcon(binding.scope), size: 16),
+                        label: Text(_bindingLabel(binding)),
+                      ),
+                    )
+                    .toList(growable: false),
+              ),
+            ],
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                IconButton(
+                  tooltip: 'Preview',
+                  onPressed: busy || entry.chunkCount == 0 ? null : onPreview,
+                  icon: const Icon(Icons.visibility_outlined),
+                ),
+                IconButton(
+                  tooltip: 'Manage bindings',
+                  onPressed: busy ? null : onBindings,
+                  icon: const Icon(Icons.link_outlined),
+                ),
+                IconButton(
+                  key: ValueKey('data-bank-retry-${document.id}'),
+                  tooltip: failed ? 'Retry' : 'Rebuild document',
+                  onPressed: busy || disabled || processing ? null : onRetry,
+                  icon: Icon(failed ? Icons.refresh : Icons.replay_outlined),
+                ),
+                IconButton(
+                  key: ValueKey('data-bank-delete-${document.id}'),
+                  tooltip: 'Delete',
+                  onPressed: busy ? null : onDelete,
+                  icon: const Icon(Icons.delete_outline),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SearchResultTile extends StatelessWidget {
+  final DataBankSearchResult result;
+
+  const _SearchResultTile({required this.result});
+
+  @override
+  Widget build(BuildContext context) {
+    final locator = result.citation.locator;
+    final source = [
+      result.documentName,
+      if (locator.chapter != null) locator.chapter!,
+      if (locator.pageStart != null)
+        locator.pageEnd == null || locator.pageEnd == locator.pageStart
+            ? 'p. ${locator.pageStart}'
+            : 'pp. ${locator.pageStart}-${locator.pageEnd}',
+    ].join('  |  ');
+    return Card(
+      margin: EdgeInsets.zero,
+      child: ListTile(
+        leading: const Icon(Icons.find_in_page_outlined),
+        title:
+            Text(result.snippet, maxLines: 4, overflow: TextOverflow.ellipsis),
+        subtitle: Text(source, maxLines: 2, overflow: TextOverflow.ellipsis),
+      ),
+    );
+  }
+}
+
+class _PreviewSheet extends StatelessWidget {
+  final DataBankDocumentPreview preview;
+
+  const _PreviewSheet({required this.preview});
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: SizedBox(
+        height: MediaQuery.sizeOf(context).height * 0.82,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 0, 12, 12),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      preview.version.originalFileName,
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      style: Theme.of(context).textTheme.titleLarge,
+                    ),
+                  ),
+                  IconButton(
+                    tooltip: 'Close',
+                    onPressed: () => Navigator.pop(context),
+                    icon: const Icon(Icons.close),
+                  ),
+                ],
+              ),
+            ),
+            const Divider(height: 1),
+            Expanded(
+              child: ListView.separated(
+                key: const Key('data-bank-preview-chunks'),
+                padding: const EdgeInsets.all(16),
+                itemCount: preview.chunks.length,
+                separatorBuilder: (_, __) => const Divider(height: 24),
+                itemBuilder: (context, index) {
+                  final chunk = preview.chunks[index];
+                  final locator = chunk.locator;
+                  return Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        _locatorLabel(locator, index),
+                        style: Theme.of(context).textTheme.labelLarge,
+                      ),
+                      const SizedBox(height: 6),
+                      SelectableText(chunk.text),
+                    ],
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+typedef _SaveBinding = Future<void> Function({
+  required DataBankBindingScope scope,
+  String? targetId,
+});
+
+class _BindingsDialog extends StatefulWidget {
+  final DataBankLibraryEntry entry;
+  final List<DataBankBindingTarget> characterTargets;
+  final List<DataBankBindingTarget> chatTargets;
+  final _SaveBinding onSave;
+  final Future<void> Function(String bindingId) onDelete;
+
+  const _BindingsDialog({
+    required this.entry,
+    required this.characterTargets,
+    required this.chatTargets,
+    required this.onSave,
+    required this.onDelete,
+  });
+
+  @override
+  State<_BindingsDialog> createState() => _BindingsDialogState();
+}
+
+class _BindingsDialogState extends State<_BindingsDialog> {
+  late List<DataBankBinding> _bindings;
+  DataBankBindingScope _scope = DataBankBindingScope.global;
+  String? _targetId;
+  bool _working = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _bindings = List.of(widget.entry.bindings);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final needsTarget = _scope != DataBankBindingScope.global;
+    final availableTargets = switch (_scope) {
+      DataBankBindingScope.global => const <DataBankBindingTarget>[],
+      DataBankBindingScope.character => widget.characterTargets,
+      DataBankBindingScope.chat => widget.chatTargets,
+    };
+    return AlertDialog(
+      title: const Text('Bindings'),
+      content: SizedBox(
+        width: 420,
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              for (final binding in _bindings)
+                ListTile(
+                  contentPadding: EdgeInsets.zero,
+                  leading: Icon(_bindingIcon(binding.scope)),
+                  title: Text(_bindingLabel(binding)),
+                  trailing: IconButton(
+                    tooltip: 'Remove binding',
+                    onPressed: _working ? null : () => _remove(binding),
+                    icon: const Icon(Icons.delete_outline),
+                  ),
+                ),
+              const Divider(),
+              DropdownButtonFormField<DataBankBindingScope>(
+                key: const Key('data-bank-binding-scope'),
+                initialValue: _scope,
+                decoration: const InputDecoration(labelText: 'Scope'),
+                items: DataBankBindingScope.values
+                    .map(
+                      (scope) => DropdownMenuItem(
+                        value: scope,
+                        child: Text(_scopeLabel(scope)),
+                      ),
+                    )
+                    .toList(growable: false),
+                onChanged: _working
+                    ? null
+                    : (scope) => setState(() {
+                          _scope = scope ?? DataBankBindingScope.global;
+                          _targetId = null;
+                        }),
+              ),
+              if (needsTarget) ...[
+                const SizedBox(height: 12),
+                DropdownButtonFormField<String>(
+                  key: ValueKey('data-bank-binding-target-${_scope.name}'),
+                  initialValue: _targetId,
+                  decoration: InputDecoration(
+                    labelText: _scope == DataBankBindingScope.character
+                        ? 'Character'
+                        : 'Chat',
+                  ),
+                  items: availableTargets
+                      .map(
+                        (target) => DropdownMenuItem(
+                          value: target.id,
+                          child: Text(
+                            target.label,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
+                      )
+                      .toList(growable: false),
+                  onChanged: _working
+                      ? null
+                      : (targetId) => setState(() => _targetId = targetId),
+                ),
+              ],
+              const SizedBox(height: 16),
+              FilledButton.icon(
+                key: const Key('data-bank-add-binding'),
+                onPressed: _working || (needsTarget && _targetId == null)
+                    ? null
+                    : _save,
+                icon: const Icon(Icons.add_link),
+                label: const Text('Add binding'),
+              ),
+            ],
+          ),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: _working ? null : () => Navigator.pop(context),
+          child: const Text('Done'),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _save() async {
+    if (_scope != DataBankBindingScope.global && _targetId == null) return;
+    setState(() => _working = true);
+    try {
+      await widget.onSave(
+        scope: _scope,
+        targetId: _scope == DataBankBindingScope.global ? null : _targetId,
+      );
+      if (!mounted) return;
+      Navigator.pop(context);
+    } finally {
+      if (mounted) setState(() => _working = false);
+    }
+  }
+
+  Future<void> _remove(DataBankBinding binding) async {
+    setState(() => _working = true);
+    try {
+      await widget.onDelete(binding.id);
+      if (mounted) setState(() => _bindings.remove(binding));
+    } finally {
+      if (mounted) setState(() => _working = false);
+    }
+  }
+}
+
+class _StatusBadge extends StatelessWidget {
+  final DataBankProcessingState state;
+
+  const _StatusBadge({required this.state});
+
+  @override
+  Widget build(BuildContext context) {
+    final color = switch (state) {
+      DataBankProcessingState.ready => Colors.green,
+      DataBankProcessingState.failed => Theme.of(context).colorScheme.error,
+      DataBankProcessingState.disabled => Colors.grey,
+      DataBankProcessingState.pending ||
+      DataBankProcessingState.processing =>
+        Theme.of(context).colorScheme.primary,
+      DataBankProcessingState.deleted => Colors.grey,
+    };
+    return Semantics(
+      label: 'Status: ${state.name}',
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+        decoration: BoxDecoration(
+          color: color.withValues(alpha: 0.12),
+          borderRadius: BorderRadius.circular(6),
+        ),
+        child: Text(
+          _stateLabel(state),
+          style: Theme.of(context).textTheme.labelSmall?.copyWith(color: color),
+        ),
+      ),
+    );
+  }
+}
+
+class _ErrorBanner extends StatelessWidget {
+  final String message;
+  final VoidCallback onDismiss;
+
+  const _ErrorBanner({required this.message, required this.onDismiss});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialBanner(
+      content: Text(message),
+      leading: Icon(
+        Icons.error_outline,
+        color: Theme.of(context).colorScheme.error,
+      ),
+      actions: [
+        IconButton(
+          tooltip: 'Dismiss',
+          onPressed: onDismiss,
+          icon: const Icon(Icons.close),
+        ),
+      ],
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  final IconData icon;
+  final String title;
+  final Widget? action;
+
+  const _EmptyState({
+    super.key,
+    required this.icon,
+    required this.title,
+    this.action,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, size: 48, color: Theme.of(context).colorScheme.outline),
+            const SizedBox(height: 12),
+            Text(title, style: Theme.of(context).textTheme.titleMedium),
+            if (action != null) ...[
+              const SizedBox(height: 16),
+              action!,
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+String _stateLabel(DataBankProcessingState state) => switch (state) {
+      DataBankProcessingState.pending => 'Pending',
+      DataBankProcessingState.processing => 'Processing',
+      DataBankProcessingState.ready => 'Ready',
+      DataBankProcessingState.failed => 'Failed',
+      DataBankProcessingState.disabled => 'Disabled',
+      DataBankProcessingState.deleted => 'Deleted',
+    };
+
+IconData _bindingIcon(DataBankBindingScope scope) => switch (scope) {
+      DataBankBindingScope.global => Icons.public,
+      DataBankBindingScope.character => Icons.person_outline,
+      DataBankBindingScope.chat => Icons.chat_bubble_outline,
+    };
+
+String _scopeLabel(DataBankBindingScope scope) => switch (scope) {
+      DataBankBindingScope.global => 'Global',
+      DataBankBindingScope.character => 'Character',
+      DataBankBindingScope.chat => 'Chat',
+    };
+
+String _bindingLabel(DataBankBinding binding) {
+  final scope = _scopeLabel(binding.scope);
+  final target = binding.targetId;
+  return target == null ? scope : '$scope: $target';
+}
+
+String _locatorLabel(DataBankSourceLocator locator, int index) {
+  final parts = <String>[
+    if (locator.chapter != null) locator.chapter!,
+    if (locator.pageStart != null)
+      locator.pageEnd == null || locator.pageEnd == locator.pageStart
+          ? 'Page ${locator.pageStart}'
+          : 'Pages ${locator.pageStart}-${locator.pageEnd}',
+  ];
+  return parts.isEmpty ? 'Chunk ${index + 1}' : parts.join('  |  ');
+}
+
+String _formatBytes(int bytes) {
+  if (bytes < 1024) return '$bytes B';
+  final kib = bytes / 1024;
+  if (kib < 1024) return '${kib.toStringAsFixed(1)} KiB';
+  return '${(kib / 1024).toStringAsFixed(1)} MiB';
+}
+
+String _friendlyError(Object error) {
+  if (error is DataBankDuplicateDocumentException) {
+    return 'This document is already in the Data Bank.';
+  }
+  return error.toString().replaceFirst(RegExp(r'^[^:]+:\s*'), '');
+}

--- a/test/data_bank_fts_repository_test.dart
+++ b/test/data_bank_fts_repository_test.dart
@@ -1,0 +1,272 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:native_tavern/data/database/database.dart';
+import 'package:native_tavern/data/models/data_bank.dart';
+import 'package:native_tavern/data/repositories/drift_data_bank_repository.dart';
+import 'package:native_tavern/domain/repositories/data_bank_repository.dart';
+
+void main() {
+  late AppDatabase database;
+  late DriftDataBankRepository repository;
+  final now = DateTime.utc(2026, 8, 8, 12);
+
+  setUp(() async {
+    database = AppDatabase.forTesting(NativeDatabase.memory());
+    await database.customSelect('SELECT 1').get();
+    await _seedOwners(database);
+    repository = DriftDataBankRepository(database);
+  });
+
+  tearDown(() => database.close());
+
+  test('FTS returns stable citation-bearing results and treats input as text',
+      () async {
+    await _createReadyDocument(
+      repository,
+      id: 'harbor',
+      content: 'Ships enter the eastern harbor channel before dawn.',
+      binding: DataBankBindingScope.global,
+      now: now,
+    );
+
+    final matches = await repository.search('eastern harbor');
+
+    expect(matches, hasLength(1));
+    expect(matches.single.documentName, 'harbor.md');
+    expect(matches.single.snippet, contains('eastern'));
+    expect(matches.single.citation.documentId, 'harbor');
+    expect(matches.single.citation.locator.chapter, 'Reference');
+    expect(
+      await repository.search('eastern OR absent'),
+      isEmpty,
+    );
+    expect(await repository.search('" ) ( *'), isEmpty);
+    await expectLater(repository.search('harbor', topK: 0), throwsRangeError);
+  });
+
+  test(
+      'binding filters include only applicable global, character, and chat data',
+      () async {
+    await _createReadyDocument(
+      repository,
+      id: 'global',
+      content: 'shared compass reference',
+      binding: DataBankBindingScope.global,
+      now: now,
+    );
+    await _createReadyDocument(
+      repository,
+      id: 'character-a',
+      content: 'shared compass reference',
+      binding: DataBankBindingScope.character,
+      targetId: 'character-1',
+      now: now,
+    );
+    await _createReadyDocument(
+      repository,
+      id: 'character-b',
+      content: 'shared compass reference',
+      binding: DataBankBindingScope.character,
+      targetId: 'character-2',
+      now: now,
+    );
+    await _createReadyDocument(
+      repository,
+      id: 'chat',
+      content: 'shared compass reference',
+      binding: DataBankBindingScope.chat,
+      targetId: 'chat-1',
+      now: now,
+    );
+
+    final matches = await repository.search(
+      'compass',
+      filter: const DataBankSearchFilter.forContext(
+        characterId: 'character-1',
+        chatId: 'chat-1',
+      ),
+    );
+
+    expect(
+      matches.map((result) => result.citation.documentId).toSet(),
+      {'global', 'character-a', 'chat'},
+    );
+    expect(
+      await repository.search(
+        'compass',
+        filter: const DataBankSearchFilter.forContext(
+          includeGlobal: false,
+          characterId: 'missing-character',
+        ),
+      ),
+      isEmpty,
+    );
+  });
+
+  test('chunk replacement, disable, rebuild, and purge stay synchronized',
+      () async {
+    final versionId = await _createReadyDocument(
+      repository,
+      id: 'lifecycle',
+      content: 'recoverable archive marker',
+      binding: DataBankBindingScope.global,
+      now: now,
+    );
+    expect(await repository.search('archive'), hasLength(1));
+
+    await repository.replaceChunks(versionId, [
+      _chunk(
+        documentId: 'lifecycle',
+        versionId: versionId,
+        content: 'replacement library marker',
+      ),
+    ]);
+    expect(await repository.search('archive'), isEmpty);
+    expect(await repository.search('library'), hasLength(1));
+
+    await repository.setDocumentEnabled('lifecycle', false);
+    expect(await repository.search('library'), isEmpty);
+
+    await repository.setDocumentEnabled('lifecycle', true);
+    await repository.beginProcessing(
+      documentId: 'lifecycle',
+      versionId: versionId,
+      startedAt: now.add(const Duration(minutes: 1)),
+    );
+    await repository.completeProcessing(
+      documentId: 'lifecycle',
+      versionId: versionId,
+      sections: [_section('lifecycle', versionId)],
+      chunks: [
+        _chunk(
+          documentId: 'lifecycle',
+          versionId: versionId,
+          content: 'replacement library marker',
+        ),
+      ],
+      completedAt: now.add(const Duration(minutes: 2)),
+    );
+    expect(await repository.search('library'), hasLength(1));
+
+    await database.customStatement('DROP TABLE data_bank_text_chunks_fts');
+    await repository.rebuildSearchIndex();
+    expect(await repository.search('library'), hasLength(1));
+
+    await repository.purgeDocument('lifecycle');
+    expect(await repository.search('library'), isEmpty);
+    expect(await repository.getVersion(versionId), isNull);
+    expect(await repository.listBindingsForDocument('lifecycle'), isEmpty);
+  });
+}
+
+Future<String> _createReadyDocument(
+  DriftDataBankRepository repository, {
+  required String id,
+  required String content,
+  required DataBankBindingScope binding,
+  String? targetId,
+  required DateTime now,
+}) async {
+  final versionId = '$id-version';
+  final version = DataBankDocumentVersion(
+    id: versionId,
+    documentId: id,
+    versionNumber: 1,
+    originalFileName: '$id.md',
+    mediaType: 'text/markdown',
+    byteSize: content.length,
+    contentHash: DataBankContentHash(
+      algorithm: DataBankHashAlgorithm.sha256,
+      digest: 'a' * 64,
+    ),
+    importedAt: now,
+  );
+  final document = DataBankDocument(
+    id: id,
+    currentVersionId: versionId,
+    createdAt: now,
+    updatedAt: now,
+  );
+  await repository.createPendingDocument(
+    document: document,
+    version: version,
+    initialBinding: DataBankBinding(
+      id: '$id-binding',
+      documentId: id,
+      scope: binding,
+      characterId: binding == DataBankBindingScope.character ? targetId : null,
+      chatId: binding == DataBankBindingScope.chat ? targetId : null,
+      createdAt: now,
+      updatedAt: now,
+    ),
+  );
+  await repository.beginProcessing(
+    documentId: id,
+    versionId: versionId,
+    startedAt: now,
+  );
+  await repository.completeProcessing(
+    documentId: id,
+    versionId: versionId,
+    sections: [_section(id, versionId)],
+    chunks: [
+      _chunk(documentId: id, versionId: versionId, content: content),
+    ],
+    completedAt: now,
+  );
+  return versionId;
+}
+
+DataBankSection _section(String documentId, String versionId) {
+  final sectionId = '$documentId-section';
+  return DataBankSection(
+    id: sectionId,
+    documentVersionId: versionId,
+    kind: DataBankSectionKind.chapter,
+    title: 'Reference',
+    ordinal: 0,
+    locator: DataBankSourceLocator(
+      documentVersionId: versionId,
+      sectionId: sectionId,
+      chapter: 'Reference',
+      startOffset: 0,
+      endOffset: 1,
+    ),
+  );
+}
+
+DataBankTextChunk _chunk({
+  required String documentId,
+  required String versionId,
+  required String content,
+}) {
+  final sectionId = '$documentId-section';
+  return DataBankTextChunk(
+    id: '$documentId-chunk',
+    documentVersionId: versionId,
+    sectionId: sectionId,
+    ordinal: 0,
+    text: content,
+    locator: DataBankSourceLocator(
+      documentVersionId: versionId,
+      sectionId: sectionId,
+      chapter: 'Reference',
+      startOffset: 0,
+      endOffset: content.length,
+    ),
+  );
+}
+
+Future<void> _seedOwners(AppDatabase database) async {
+  const statements = [
+    'INSERT INTO characters (id, name, created_at, modified_at) '
+        "VALUES ('character-1', 'One', 1, 1)",
+    'INSERT INTO characters (id, name, created_at, modified_at) '
+        "VALUES ('character-2', 'Two', 1, 1)",
+    'INSERT INTO chats (id, character_id, created_at, updated_at) '
+        "VALUES ('chat-1', 'character-1', 1, 1)",
+  ];
+  for (final statement in statements) {
+    await database.customStatement(statement);
+  }
+}

--- a/test/data_bank_library_end_to_end_test.dart
+++ b/test/data_bank_library_end_to_end_test.dart
@@ -1,0 +1,253 @@
+// Test fixtures intentionally exercise real asynchronous file I/O.
+// ignore_for_file: avoid_slow_async_io
+
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:native_tavern/data/database/database.dart';
+import 'package:native_tavern/data/models/data_bank.dart';
+import 'package:native_tavern/data/repositories/drift_data_bank_repository.dart';
+import 'package:native_tavern/domain/repositories/data_bank_repository.dart';
+import 'package:native_tavern/domain/services/data_bank_ingestion_service.dart';
+import 'package:native_tavern/domain/services/data_bank_library_service.dart';
+import 'package:path/path.dart' as path;
+
+void main() {
+  late Directory temporary;
+  late Directory input;
+  late Directory managed;
+  late AppDatabase database;
+  late DriftDataBankRepository repository;
+  late FileDataBankManagedFileStore fileStore;
+  late DataBankLibraryService service;
+  late int idSequence;
+  final now = DateTime.utc(2026, 8, 8, 12);
+
+  setUp(() async {
+    temporary =
+        await Directory.systemTemp.createTemp('data_bank_library_test_');
+    input = Directory(path.join(temporary.path, 'input'))..createSync();
+    managed = Directory(path.join(temporary.path, 'managed'))..createSync();
+    database = AppDatabase.forTesting(NativeDatabase.memory());
+    await database.customSelect('SELECT 1').get();
+    await database.customStatement(
+      'INSERT INTO characters (id, name, created_at, modified_at) '
+      "VALUES ('character-1', 'Character', 1, 1)",
+    );
+    repository = DriftDataBankRepository(database);
+    idSequence = 0;
+    String nextId() => 'generated-${idSequence++}';
+    fileStore = FileDataBankManagedFileStore(
+      root: managed,
+      idFactory: nextId,
+    );
+    service = DataBankLibraryService(
+      repository: repository,
+      files: fileStore,
+      clock: () => now.add(Duration(seconds: idSequence)),
+      idFactory: nextId,
+    );
+  });
+
+  tearDown(() async {
+    await database.close();
+    if (temporary.existsSync()) temporary.deleteSync(recursive: true);
+  });
+
+  test('import, search, bind, disable, rebuild, preview, and delete end to end',
+      () async {
+    final source = File(path.join(input.path, 'harbor.md'))
+      ..writeAsStringSync('''
+# Safe Harbor
+
+Ships enter through the eastern channel before dawn.
+''');
+    final phases = <DataBankIngestionPhase>[];
+
+    var entry = await service.importDocument(
+      source,
+      onProgress: (progress) => phases.add(progress.phase),
+    );
+
+    expect(entry.document.processingState, DataBankProcessingState.ready);
+    expect(entry.document.indexState, DataBankIndexState.indexed);
+    expect(entry.version.originalFileName, 'harbor.md');
+    expect(entry.chunkCount, greaterThan(0));
+    expect(entry.managedPaths, hasLength(1));
+    expect(File(entry.managedPaths.single).existsSync(), isTrue);
+    expect(phases, containsAll(DataBankIngestionPhase.values));
+
+    var matches = await service.search('eastern channel');
+    expect(matches, hasLength(1));
+    expect(matches.single.citation.locator.sectionId, isNotNull);
+    expect(
+      matches.single.citation.locator.documentVersionId,
+      entry.version.id,
+    );
+
+    await service.saveBinding(
+      documentId: entry.document.id,
+      scope: DataBankBindingScope.character,
+      targetId: 'character-1',
+    );
+    entry = (await service.listDocuments()).single;
+    expect(entry.bindings, hasLength(2));
+    matches = await service.search(
+      'eastern',
+      filter: const DataBankSearchFilter.forContext(
+        includeGlobal: false,
+        characterId: 'character-1',
+      ),
+    );
+    expect(matches, hasLength(1));
+
+    await service.setDocumentEnabled(entry.document.id, false);
+    expect(await service.search('eastern'), isEmpty);
+    await service.setDocumentEnabled(entry.document.id, true);
+    expect(await service.search('eastern'), hasLength(1));
+
+    await database.customStatement('DROP TABLE data_bank_text_chunks_fts');
+    await service.rebuildSearchIndex();
+    expect(await service.search('eastern'), hasLength(1));
+
+    final preview = await service.previewDocument(entry.document.id);
+    expect(preview.sections, isNotEmpty);
+    expect(
+      preview.chunks.map((chunk) => chunk.text).join('\n'),
+      contains('eastern channel'),
+    );
+    final deletion = await service.previewDeletion(entry.document.id);
+    expect(deletion.chunkCount, preview.chunks.length);
+    expect(deletion.bindingCount, 2);
+    expect(deletion.managedPaths, hasLength(1));
+
+    await service.deleteDocument(entry.document.id);
+
+    expect(await service.listDocuments(), isEmpty);
+    expect(await service.search('eastern'), isEmpty);
+    expect(await repository.getVersion(entry.version.id), isNull);
+    expect(Directory(path.join(managed.path, entry.document.id)).existsSync(),
+        isFalse);
+  });
+
+  test('duplicate and parse failure paths leave recoverable, visible state',
+      () async {
+    final source = File(path.join(input.path, 'duplicate.txt'))
+      ..writeAsStringSync('A unique searchable document.');
+    await service.importDocument(source);
+
+    await expectLater(
+      service.importDocument(source),
+      throwsA(isA<DataBankDuplicateDocumentException>()),
+    );
+    expect(await service.listDocuments(), hasLength(1));
+
+    final empty = File(path.join(input.path, 'empty.txt'))
+      ..writeAsStringSync('');
+    await expectLater(
+      service.importDocument(empty),
+      throwsA(
+        isA<DataBankIngestionException>().having(
+          (error) => error.code,
+          'code',
+          DataBankIngestionFailureCode.emptyDocument,
+        ),
+      ),
+    );
+
+    final entries = await service.listDocuments();
+    final failed = entries.singleWhere(
+      (entry) =>
+          entry.document.processingState == DataBankProcessingState.failed,
+    );
+    expect(failed.document.failure?.code, 'emptyDocument');
+    expect(failed.managedPaths, hasLength(1));
+
+    File(failed.managedPaths.single)
+        .writeAsStringSync('The repaired document is searchable.');
+    final repaired = await service.retryDocument(failed.document.id);
+    expect(repaired.document.processingState, DataBankProcessingState.ready);
+    expect(await service.search('repaired'), hasLength(1));
+  });
+
+  test('restart recovery resumes managed imports and isolates missing sources',
+      () async {
+    final resumableSource = File(path.join(input.path, 'resumable.txt'))
+      ..writeAsStringSync('A resumable lighthouse reference.');
+    final managedSource = await fileStore.storeSource(
+      source: resumableSource,
+      documentId: 'resumable',
+      versionId: 'resumable-version',
+    );
+    await _createPending(
+      repository,
+      documentId: 'resumable',
+      versionId: 'resumable-version',
+      fileName: 'resumable.txt',
+      byteSize: managedSource.byteSize,
+      contentHash: managedSource.contentHash,
+      now: now,
+    );
+    await _createPending(
+      repository,
+      documentId: 'missing',
+      versionId: 'missing-version',
+      fileName: 'missing.txt',
+      byteSize: 10,
+      contentHash: DataBankContentHash(
+        algorithm: DataBankHashAlgorithm.sha256,
+        digest: 'b' * 64,
+      ),
+      now: now,
+    );
+
+    await service.recoverInterruptedImports();
+
+    expect(
+      (await repository.getDocument('resumable'))?.processingState,
+      DataBankProcessingState.ready,
+    );
+    expect(await service.search('lighthouse'), hasLength(1));
+    final missing = await repository.getDocument('missing');
+    expect(missing?.processingState, DataBankProcessingState.failed);
+    expect(missing?.failure?.code, 'sourceNotFound');
+  });
+}
+
+Future<void> _createPending(
+  DriftDataBankRepository repository, {
+  required String documentId,
+  required String versionId,
+  required String fileName,
+  required int byteSize,
+  required DataBankContentHash contentHash,
+  required DateTime now,
+}) async {
+  final version = DataBankDocumentVersion(
+    id: versionId,
+    documentId: documentId,
+    versionNumber: 1,
+    originalFileName: fileName,
+    mediaType: 'text/plain',
+    byteSize: byteSize,
+    contentHash: contentHash,
+    importedAt: now,
+  );
+  await repository.createPendingDocument(
+    document: DataBankDocument(
+      id: documentId,
+      currentVersionId: versionId,
+      createdAt: now,
+      updatedAt: now,
+    ),
+    version: version,
+    initialBinding: DataBankBinding(
+      id: '$documentId-binding',
+      documentId: documentId,
+      scope: DataBankBindingScope.global,
+      createdAt: now,
+      updatedAt: now,
+    ),
+  );
+}

--- a/test/data_bank_screen_test.dart
+++ b/test/data_bank_screen_test.dart
@@ -1,0 +1,255 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:native_tavern/data/models/data_bank.dart';
+import 'package:native_tavern/domain/repositories/data_bank_repository.dart';
+import 'package:native_tavern/domain/services/data_bank_ingestion_service.dart';
+import 'package:native_tavern/domain/services/data_bank_library_service.dart';
+import 'package:native_tavern/presentation/controllers/data_bank_library_controller.dart';
+import 'package:native_tavern/presentation/screens/data_bank/data_bank_screen.dart';
+
+void main() {
+  testWidgets('management screen exposes document states and real actions',
+      (tester) async {
+    final operations = _FakeDataBankOperations();
+    final controller = DataBankLibraryController(operations);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          home: DataBankScreen(
+            controller: controller,
+            fileGateway: const _NullFileGateway(),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('ready.md'), findsOneWidget);
+    expect(find.text('failed.txt'), findsOneWidget);
+    expect(find.text('disabled.pdf'), findsOneWidget);
+    expect(find.text('Ready'), findsOneWidget);
+    expect(find.text('Failed'), findsOneWidget);
+    expect(find.text('Disabled'), findsOneWidget);
+
+    await tester.tap(find.byTooltip('Preview').first);
+    await tester.pumpAndSettle();
+    expect(find.byKey(const Key('data-bank-preview-chunks')), findsOneWidget);
+    expect(find.textContaining('eastern channel'), findsOneWidget);
+    await tester.tap(find.byTooltip('Close'));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+      find.byKey(const Key('data-bank-search')),
+      'eastern',
+    );
+    await tester.testTextInput.receiveAction(TextInputAction.done);
+    await tester.pumpAndSettle();
+    expect(find.byKey(const Key('data-bank-search-results')), findsOneWidget);
+    expect(find.text('Eastern channel match'), findsOneWidget);
+
+    await tester.tap(find.byTooltip('Clear search'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('data-bank-delete-ready')));
+    await tester.pumpAndSettle();
+    expect(find.text('Delete ready.md?'), findsOneWidget);
+    await tester.tap(find.byKey(const Key('data-bank-confirm-delete')));
+    await tester.pumpAndSettle();
+
+    expect(operations.deletedIds, ['ready']);
+    expect(find.text('ready.md'), findsNothing);
+  });
+}
+
+final class _NullFileGateway implements DataBankFileGateway {
+  const _NullFileGateway();
+
+  @override
+  Future<File?> pickDocument() async => null;
+}
+
+final class _FakeDataBankOperations implements DataBankLibraryOperations {
+  final List<String> deletedIds = [];
+  late final List<DataBankLibraryEntry> entries = [
+    _entry('ready', DataBankProcessingState.ready),
+    _entry('failed', DataBankProcessingState.failed),
+    _entry('disabled', DataBankProcessingState.disabled),
+  ];
+
+  @override
+  Future<void> recoverInterruptedImports() async {}
+
+  @override
+  Future<List<DataBankLibraryEntry>> listDocuments() async => List.of(entries);
+
+  @override
+  Future<List<DataBankSearchResult>> search(
+    String query, {
+    int topK = 20,
+    DataBankSearchFilter filter = const DataBankSearchFilter(),
+  }) async {
+    final chunk = _chunk('ready');
+    return [
+      DataBankSearchResult(
+        chunk: chunk,
+        citation: chunk.toCitation('ready'),
+        documentName: 'ready.md',
+        snippet: 'Eastern channel match',
+        rank: -1,
+      ),
+    ];
+  }
+
+  @override
+  Future<DataBankDocumentPreview> previewDocument(String documentId) async {
+    final entry = entries.singleWhere(
+      (entry) => entry.document.id == documentId,
+    );
+    return DataBankDocumentPreview(
+      document: entry.document,
+      version: entry.version,
+      sections: const [],
+      chunks: [_chunk(documentId)],
+    );
+  }
+
+  @override
+  Future<DataBankDeletionPreview> previewDeletion(String documentId) async {
+    final entry = entries.singleWhere(
+      (entry) => entry.document.id == documentId,
+    );
+    return DataBankDeletionPreview(
+      documentId: documentId,
+      documentName: entry.version.originalFileName,
+      versionCount: 1,
+      chunkCount: 1,
+      bindingCount: 1,
+      managedPaths: const ['/managed/source.md'],
+    );
+  }
+
+  @override
+  Future<void> deleteDocument(String documentId) async {
+    deletedIds.add(documentId);
+    entries.removeWhere((entry) => entry.document.id == documentId);
+  }
+
+  @override
+  Future<DataBankLibraryEntry> importDocument(
+    File source, {
+    DataBankProgressCallback? onProgress,
+  }) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<DataBankLibraryEntry> retryDocument(
+    String documentId, {
+    DataBankProgressCallback? onProgress,
+  }) async {
+    return entries.singleWhere((entry) => entry.document.id == documentId);
+  }
+
+  @override
+  Future<void> setDocumentEnabled(String documentId, bool enabled) async {}
+
+  @override
+  Future<void> rebuildSearchIndex() async {}
+
+  @override
+  Future<DataBankBinding> saveBinding({
+    required String documentId,
+    required DataBankBindingScope scope,
+    String? targetId,
+    bool enabled = true,
+  }) async {
+    return _binding(documentId);
+  }
+
+  @override
+  Future<void> removeBinding(String bindingId) async {}
+}
+
+DataBankLibraryEntry _entry(String id, DataBankProcessingState state) {
+  final now = DateTime.utc(2026, 8, 8, 12);
+  final failure = state == DataBankProcessingState.failed
+      ? DataBankFailure(
+          code: 'parseFailed',
+          message: 'Document parsing failed.',
+          occurredAt: now,
+        )
+      : null;
+  final indexState = switch (state) {
+    DataBankProcessingState.ready => DataBankIndexState.indexed,
+    DataBankProcessingState.failed => DataBankIndexState.failed,
+    DataBankProcessingState.disabled => DataBankIndexState.disabled,
+    _ => DataBankIndexState.notIndexed,
+  };
+  final extension = id == 'disabled'
+      ? 'pdf'
+      : id == 'failed'
+          ? 'txt'
+          : 'md';
+  final version = DataBankDocumentVersion(
+    id: '$id-version',
+    documentId: id,
+    versionNumber: 1,
+    originalFileName: '$id.$extension',
+    mediaType: extension == 'pdf' ? 'application/pdf' : 'text/plain',
+    byteSize: 128,
+    contentHash: DataBankContentHash(
+      algorithm: DataBankHashAlgorithm.sha256,
+      digest: 'a' * 64,
+    ),
+    importedAt: now,
+    processingState: state,
+    indexState: indexState,
+    failure: failure,
+  );
+  return DataBankLibraryEntry(
+    document: DataBankDocument(
+      id: id,
+      currentVersionId: version.id,
+      processingState: state,
+      indexState: indexState,
+      failure: failure,
+      createdAt: now,
+      updatedAt: now,
+    ),
+    version: version,
+    bindings: [_binding(id)],
+    chunkCount: state == DataBankProcessingState.failed ? 0 : 1,
+    managedPaths: ['/managed/$id/source.$extension'],
+  );
+}
+
+DataBankBinding _binding(String documentId) {
+  final now = DateTime.utc(2026, 8, 8, 12);
+  return DataBankBinding(
+    id: '$documentId-binding',
+    documentId: documentId,
+    scope: DataBankBindingScope.global,
+    createdAt: now,
+    updatedAt: now,
+  );
+}
+
+DataBankTextChunk _chunk(String documentId) {
+  return DataBankTextChunk(
+    id: '$documentId-chunk',
+    documentVersionId: '$documentId-version',
+    sectionId: '$documentId-section',
+    ordinal: 0,
+    text: 'Ships use the eastern channel before dawn.',
+    locator: DataBankSourceLocator(
+      documentVersionId: '$documentId-version',
+      sectionId: '$documentId-section',
+      chapter: 'Harbor',
+      startOffset: 0,
+      endOffset: 42,
+    ),
+  );
+}


### PR DESCRIPTION
## Summary

- add a locally derived FTS5 index with incremental synchronization, deterministic Top-K retrieval, binding-aware filters, and citation provenance
- add managed import lifecycle, restart recovery, enable/disable, retry, preview, binding management, index rebuild, and coordinated deletion
- add an independent Data Bank management screen and focused repository, service, and widget coverage

## Roadmap

F05: completed
F06: completed

## Tests

- `flutter analyze --no-pub` on all 10 changed files: passed
- `flutter test --no-pub --concurrency=1 test/data_bank_fts_repository_test.dart test/data_bank_library_end_to_end_test.dart test/data_bank_screen_test.dart`: 7 passed
- `flutter test --no-pub --concurrency=1`: 269 passed, 2 skipped because `PDFIUM_MODULE_PATH` is not configured (existing native PDFium test gate)
- `dart format --output=none --set-exit-if-changed` on all 7 new files: passed
- `git diff --check`: passed

Closes #30