### PR TITLE
feat(rpg): bridge narrative actions into chat UI

### DIFF
--- a/lib/domain/services/chat_generation_pipeline.dart
+++ b/lib/domain/services/chat_generation_pipeline.dart
@@ -37,6 +37,7 @@ enum ContextContributionStatus {
 
 enum GenerationMiddlewarePhase {
   before,
+  transform,
   after,
   error,
   cancelled,
@@ -289,6 +290,19 @@ abstract class ChatGenerationMiddleware {
       null;
 
   FutureOr<void> onCancelled(ChatGenerationRequest request) {}
+}
+
+/// Optional middleware capability for consumers that need to validate or
+/// replace a complete model response before chat persistence.
+///
+/// Streaming is buffered whenever an enabled middleware implements this
+/// interface, preventing structured control payloads from being exposed as
+/// partial assistant text before they have been validated.
+abstract interface class ChatGenerationResponseTransformer {
+  FutureOr<LLMResponse> transformResponse(
+    ChatGenerationRequest request,
+    LLMResponse response,
+  );
 }
 
 class GenerationMiddlewareTrace {
@@ -796,6 +810,15 @@ class ChatGenerationSession {
       }
     }
 
+    if (terminalError == null && !cancellationToken.isCancelled) {
+      response = await _runTransforms(
+        active.middlewares,
+        request,
+        response,
+        middlewareTraces,
+      );
+    }
+
     final outcome = ChatGenerationOutcome(
       response: response,
       streaming: false,
@@ -840,6 +863,8 @@ class ChatGenerationSession {
     _lastGenerationRequest = request;
     final content = StringBuffer();
     final reasoning = StringBuffer();
+    final buffersResponse = active.middlewares
+        .any((middleware) => middleware is ChatGenerationResponseTransformer);
     var recovered = false;
     Object? terminalError;
     StackTrace? terminalStackTrace;
@@ -850,7 +875,7 @@ class ChatGenerationSession {
           if (cancellationToken.isCancelled) break;
           if (chunk.content != null) content.write(chunk.content);
           if (chunk.reasoning != null) reasoning.write(chunk.reasoning);
-          yield chunk;
+          if (!buffersResponse) yield chunk;
         }
       }
     } catch (error, stackTrace) {
@@ -866,14 +891,18 @@ class ChatGenerationSession {
           recovered = true;
           if (recovery.reasoning?.isNotEmpty == true) {
             reasoning.write(recovery.reasoning);
-            yield LLMStreamChunk(
-              reasoning: recovery.reasoning,
-              isReasoningChunk: true,
-            );
+            if (!buffersResponse) {
+              yield LLMStreamChunk(
+                reasoning: recovery.reasoning,
+                isReasoningChunk: true,
+              );
+            }
           }
           if (recovery.content.isNotEmpty) {
             content.write(recovery.content);
-            yield LLMStreamChunk(content: recovery.content);
+            if (!buffersResponse) {
+              yield LLMStreamChunk(content: recovery.content);
+            }
           }
         } else {
           terminalError = error;
@@ -882,10 +911,18 @@ class ChatGenerationSession {
       }
     }
 
-    final response = LLMResponse(
+    var response = LLMResponse(
       content: content.toString(),
       reasoning: reasoning.isEmpty ? null : reasoning.toString(),
     );
+    if (terminalError == null && !cancellationToken.isCancelled) {
+      response = await _runTransforms(
+        active.middlewares,
+        request,
+        response,
+        middlewareTraces,
+      );
+    }
     final outcome = ChatGenerationOutcome(
       response: response,
       streaming: true,
@@ -909,10 +946,22 @@ class ChatGenerationSession {
     if (terminalError != null) {
       Error.throwWithStackTrace(terminalError, terminalStackTrace!);
     }
-    if (cancellationToken.isCancelled && content.isEmpty && reasoning.isEmpty) {
+    if (cancellationToken.isCancelled &&
+        (buffersResponse || (content.isEmpty && reasoning.isEmpty))) {
       throw ChatGenerationCancelledException(
         cancellationToken.reason ?? 'Cancelled',
       );
+    }
+    if (buffersResponse) {
+      if (response.reasoning?.isNotEmpty == true) {
+        yield LLMStreamChunk(
+          reasoning: response.reasoning,
+          isReasoningChunk: true,
+        );
+      }
+      if (response.content.isNotEmpty) {
+        yield LLMStreamChunk(content: response.content);
+      }
     }
   }
 
@@ -1041,6 +1090,38 @@ class ChatGenerationSession {
         ));
       }
     }
+  }
+
+  Future<LLMResponse> _runTransforms(
+    List<ChatGenerationMiddleware> middlewares,
+    ChatGenerationRequest request,
+    LLMResponse initialResponse,
+    List<GenerationMiddlewareTrace> traces,
+  ) async {
+    var response = initialResponse;
+    for (final middleware in middlewares.reversed) {
+      if (middleware is! ChatGenerationResponseTransformer) continue;
+      final transformer = middleware as ChatGenerationResponseTransformer;
+      final stopwatch = Stopwatch()..start();
+      try {
+        response = await transformer.transformResponse(request, response);
+        traces.add(GenerationMiddlewareTrace(
+          middlewareId: middleware.id,
+          order: middleware.order,
+          phase: GenerationMiddlewarePhase.transform,
+          elapsed: stopwatch.elapsed,
+        ));
+      } catch (error) {
+        traces.add(GenerationMiddlewareTrace(
+          middlewareId: middleware.id,
+          order: middleware.order,
+          phase: GenerationMiddlewarePhase.transform,
+          elapsed: stopwatch.elapsed,
+          error: error.toString(),
+        ));
+      }
+    }
+    return response;
   }
 
   Future<LLMResponse?> _recover(

--- a/lib/domain/services/rpg_game_session_service.dart
+++ b/lib/domain/services/rpg_game_session_service.dart
@@ -231,6 +231,27 @@ class RpgGameSessionService {
     return List.unmodifiable(session.state.eventHistory);
   }
 
+  Future<List<RpgStateSnapshot>> listSessionSnapshots(String chatId) async {
+    final session = await _requireSession(chatId);
+    final rootId = await _rootSnapshotId(session.snapshot);
+    final scenarioSnapshots = await _repository.listSnapshots(
+      scenarioId: session.scenario.metadata.id,
+    );
+    final snapshots = <RpgStateSnapshot>[];
+    for (final snapshot in scenarioSnapshots) {
+      if (await _rootSnapshotId(snapshot) == rootId) snapshots.add(snapshot);
+    }
+    snapshots.sort((left, right) {
+      final byTime = left.metadata.createdAt.compareTo(
+        right.metadata.createdAt,
+      );
+      return byTime != 0
+          ? byTime
+          : left.metadata.id.compareTo(right.metadata.id);
+    });
+    return List.unmodifiable(snapshots);
+  }
+
   Future<RpgGameSession> _requireSession(String chatId) async {
     final session = await load(chatId);
     if (session == null) {

--- a/lib/domain/services/rpg_narrative_bridge.dart
+++ b/lib/domain/services/rpg_narrative_bridge.dart
@@ -1,0 +1,484 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:collection/collection.dart';
+import 'package:native_tavern/data/models/rpg/rpg.dart';
+import 'package:native_tavern/domain/services/chat_generation_pipeline.dart';
+import 'package:native_tavern/domain/services/llm_service.dart';
+import 'package:native_tavern/domain/services/rpg_game_session_service.dart';
+import 'package:native_tavern/domain/services/rpg_rule_engine.dart';
+
+typedef RpgSessionLoader = Future<RpgGameSession?> Function(String chatId);
+typedef RpgModeResolver = FutureOr<bool> Function(String chatId);
+typedef RpgNarrativeResultCallback = FutureOr<void> Function(
+    RpgNarrativeResult result);
+
+enum RpgNarrativeStatus { noAction, committed, rejected, malformed, cancelled }
+
+class RpgNarrativeResult {
+  const RpgNarrativeResult({
+    required this.chatId,
+    required this.status,
+    required this.narrative,
+    this.actionId,
+    this.actionLabel,
+    this.feedback = '',
+    this.errorCode,
+    this.execution,
+    this.snapshot,
+  });
+
+  final String chatId;
+  final RpgNarrativeStatus status;
+  final String narrative;
+  final String? actionId;
+  final String? actionLabel;
+  final String feedback;
+  final String? errorCode;
+  final RpgActionExecution? execution;
+  final RpgStateSnapshot? snapshot;
+}
+
+class RpgNarrativeEnvelope {
+  const RpgNarrativeEnvelope({required this.narrative, this.actionId});
+
+  final String narrative;
+  final String? actionId;
+}
+
+class RpgNarrativeFormatException implements Exception {
+  const RpgNarrativeFormatException(this.code, this.message);
+
+  final String code;
+  final String message;
+
+  @override
+  String toString() => 'RpgNarrativeFormatException($code): $message';
+}
+
+class RpgNarrativeResponseParser {
+  const RpgNarrativeResponseParser();
+
+  RpgNarrativeEnvelope parse(String source) {
+    final normalized = _unwrapJsonFence(source.trim());
+    Object? decoded;
+    try {
+      decoded = jsonDecode(normalized);
+    } on FormatException {
+      throw const RpgNarrativeFormatException(
+        'invalid_json',
+        'The model response is not valid JSON.',
+      );
+    }
+    if (decoded is! Map<String, dynamic>) {
+      throw const RpgNarrativeFormatException(
+        'invalid_root',
+        'The RPG response must be a JSON object.',
+      );
+    }
+
+    const allowedRootKeys = {'narrative', 'proposedAction'};
+    final unexpectedRootKeys = decoded.keys.toSet().difference(allowedRootKeys);
+    if (unexpectedRootKeys.isNotEmpty) {
+      throw RpgNarrativeFormatException(
+        'unexpected_field',
+        'Unexpected RPG response field `${unexpectedRootKeys.first}`.',
+      );
+    }
+
+    final narrative = decoded['narrative'];
+    if (narrative is! String || narrative.trim().isEmpty) {
+      throw const RpgNarrativeFormatException(
+        'invalid_narrative',
+        'The RPG response requires a non-empty narrative.',
+      );
+    }
+
+    final proposedAction = decoded['proposedAction'];
+    if (proposedAction == null) {
+      return RpgNarrativeEnvelope(narrative: narrative.trim());
+    }
+    if (proposedAction is! Map<String, dynamic> ||
+        proposedAction.keys.any((key) => key != 'actionId')) {
+      throw const RpgNarrativeFormatException(
+        'invalid_action',
+        'The proposed action may only contain an actionId.',
+      );
+    }
+    final actionId = proposedAction['actionId'];
+    if (actionId is! String || actionId.trim().isEmpty) {
+      throw const RpgNarrativeFormatException(
+        'invalid_action_id',
+        'The proposed action requires a non-empty actionId.',
+      );
+    }
+    return RpgNarrativeEnvelope(
+      narrative: narrative.trim(),
+      actionId: actionId.trim(),
+    );
+  }
+}
+
+class RpgNarrativeContextContributor extends ContextContributor {
+  RpgNarrativeContextContributor({
+    required RpgSessionLoader loadSession,
+    required RpgModeResolver isModeEnabled,
+    RpgRuleEngine engine = const RpgRuleEngine(),
+  })  : _loadSession = loadSession,
+        _isModeEnabled = isModeEnabled,
+        _engine = engine;
+
+  final RpgSessionLoader _loadSession;
+  final RpgModeResolver _isModeEnabled;
+  final RpgRuleEngine _engine;
+
+  @override
+  String get id => 'native_tavern.rpg.context';
+
+  @override
+  int get order => 700;
+
+  @override
+  int get maxTokens => 1800;
+
+  @override
+  Future<bool> isEnabled(ChatContextRequest request) async =>
+      await _isModeEnabled(request.chatId) &&
+      await _loadSession(request.chatId) != null;
+
+  @override
+  Future<ContextContribution> contribute(ChatContextRequest request) async {
+    request.cancellationToken.throwIfCancelled();
+    final session = await _loadSession(request.chatId);
+    if (session == null) {
+      throw StateError('The RPG session is no longer available.');
+    }
+    final state = session.state;
+    final scenario = session.scenario;
+    final actions = _engine.availableActions(scenario, state);
+    final payload = {
+      'scenario': {
+        'id': scenario.metadata.id,
+        'name': scenario.metadata.name,
+        'version': scenario.metadata.version,
+      },
+      'state': {
+        'turn': state.turn,
+        'locationId': state.locationId,
+        'attributes': state.attributes,
+        'variables': state.variables,
+        'inventory': state.inventory.map((entry) => entry.toJson()).toList(),
+        'relationships': state.relationships
+            .map((relationship) => relationship.toJson())
+            .toList(),
+        'quests': state.quests.map((quest) => quest.toJson()).toList(),
+        'clock': state.clock.toJson(),
+        'cooldowns': state.cooldowns,
+      },
+      'allowedActions': actions
+          .map(
+            (action) => {
+              'actionId': action.id,
+              'label': action.label,
+              if (action.description.isNotEmpty)
+                'description': action.description,
+              if (action.costs.isNotEmpty)
+                'costs': action.costs.map((cost) => cost.toJson()).toList(),
+              if (action.check != null) 'check': action.check!.toJson(),
+            },
+          )
+          .toList(),
+    };
+    const encoder = JsonEncoder.withIndent('  ');
+    return ContextContribution(
+      placement: ContextContributionPlacement.beforeConversation,
+      messages: [
+        {
+          'role': 'system',
+          'content': '''You are narrating a deterministic RPG session.
+The JSON below is authoritative. Describe events, but never claim or encode direct state mutations. You may only propose one listed action by its exact actionId. The application will validate and execute it.
+
+Return exactly one JSON object with no prose or markdown outside it:
+{"narrative":"player-facing narration","proposedAction":null}
+or
+{"narrative":"player-facing narration before resolution","proposedAction":{"actionId":"allowed_action_id"}}
+
+Do not add fields such as state, statePatch, effects, inventory, attributes, quests, random, or turn. If no listed action fits, use null.
+
+RPG_CONTEXT:
+${encoder.convert(payload)}''',
+        },
+      ],
+    );
+  }
+}
+
+class RpgNarrativeMiddleware extends ChatGenerationMiddleware
+    implements ChatGenerationResponseTransformer {
+  RpgNarrativeMiddleware({
+    required RpgGameSessionService sessionService,
+    required RpgSessionLoader loadSession,
+    required RpgModeResolver isModeEnabled,
+    required RpgNarrativeResultCallback onResult,
+    RpgNarrativeResponseParser parser = const RpgNarrativeResponseParser(),
+  })  : _sessionService = sessionService,
+        _loadSession = loadSession,
+        _isModeEnabled = isModeEnabled,
+        _onResult = onResult,
+        _parser = parser;
+
+  final RpgGameSessionService _sessionService;
+  final RpgSessionLoader _loadSession;
+  final RpgModeResolver _isModeEnabled;
+  final RpgNarrativeResultCallback _onResult;
+  final RpgNarrativeResponseParser _parser;
+
+  @override
+  String get id => 'native_tavern.rpg.response';
+
+  @override
+  int get order => 700;
+
+  @override
+  Future<bool> isEnabled(ChatGenerationRequest request) async =>
+      await _isModeEnabled(request.chatId) &&
+      await _loadSession(request.chatId) != null;
+
+  @override
+  Future<LLMResponse> transformResponse(
+    ChatGenerationRequest request,
+    LLMResponse response,
+  ) async {
+    request.cancellationToken.throwIfCancelled();
+    RpgNarrativeEnvelope envelope;
+    try {
+      envelope = _parser.parse(response.content);
+    } on RpgNarrativeFormatException catch (error) {
+      final result = RpgNarrativeResult(
+        chatId: request.chatId,
+        status: RpgNarrativeStatus.malformed,
+        narrative: '',
+        feedback: '${error.message} No action was applied.',
+        errorCode: error.code,
+      );
+      await _onResult(result);
+      return LLMResponse(
+        content: result.feedback,
+        reasoning: response.reasoning,
+      );
+    }
+
+    final actionId = envelope.actionId;
+    if (actionId == null) {
+      await _onResult(
+        RpgNarrativeResult(
+          chatId: request.chatId,
+          status: RpgNarrativeStatus.noAction,
+          narrative: envelope.narrative,
+        ),
+      );
+      return LLMResponse(
+        content: envelope.narrative,
+        reasoning: response.reasoning,
+      );
+    }
+
+    final session = await _loadSession(request.chatId);
+    final action = session?.scenario.actions
+        .where((candidate) => candidate.id == actionId)
+        .firstOrNull;
+    try {
+      request.cancellationToken.throwIfCancelled();
+      final committed = await _sessionService.executeAction(
+        chatId: request.chatId,
+        actionId: actionId,
+      );
+      final feedback = _formatCommittedFeedback(
+        action?.label ?? actionId,
+        committed.execution,
+      );
+      await _onResult(
+        RpgNarrativeResult(
+          chatId: request.chatId,
+          status: RpgNarrativeStatus.committed,
+          narrative: envelope.narrative,
+          actionId: actionId,
+          actionLabel: action?.label,
+          feedback: feedback,
+          execution: committed.execution,
+          snapshot: committed.snapshot,
+        ),
+      );
+      return LLMResponse(
+        content: '${envelope.narrative}\n\n$feedback',
+        reasoning: response.reasoning,
+      );
+    } on RpgRuleViolation catch (error) {
+      return _rejectedResponse(
+        request: request,
+        response: response,
+        envelope: envelope,
+        actionLabel: action?.label,
+        errorCode: error.code,
+        message: error.message,
+      );
+    } on RpgSessionException catch (error) {
+      return _rejectedResponse(
+        request: request,
+        response: response,
+        envelope: envelope,
+        actionLabel: action?.label,
+        errorCode: error.code,
+        message: error.message,
+      );
+    }
+  }
+
+  Future<LLMResponse> _rejectedResponse({
+    required ChatGenerationRequest request,
+    required LLMResponse response,
+    required RpgNarrativeEnvelope envelope,
+    required String? actionLabel,
+    required String errorCode,
+    required String message,
+  }) async {
+    final feedback = 'Action rejected ($errorCode): $message No state changed.';
+    await _onResult(
+      RpgNarrativeResult(
+        chatId: request.chatId,
+        status: RpgNarrativeStatus.rejected,
+        narrative: envelope.narrative,
+        actionId: envelope.actionId,
+        actionLabel: actionLabel,
+        feedback: feedback,
+        errorCode: errorCode,
+      ),
+    );
+    return LLMResponse(
+      content: '${envelope.narrative}\n\n$feedback',
+      reasoning: response.reasoning,
+    );
+  }
+
+  @override
+  Future<void> onCancelled(ChatGenerationRequest request) async {
+    if (!await _isModeEnabled(request.chatId)) return;
+    await _onResult(
+      RpgNarrativeResult(
+        chatId: request.chatId,
+        status: RpgNarrativeStatus.cancelled,
+        narrative: '',
+        feedback: 'Generation cancelled. No RPG action was applied.',
+      ),
+    );
+  }
+}
+
+String _formatCommittedFeedback(
+  String actionLabel,
+  RpgActionExecution execution,
+) {
+  final details = <String>[];
+  final roll = execution.roll;
+  if (roll != null) {
+    details.add(
+      'check ${execution.checkTotal}/${execution.difficulty} '
+      '(${roll.expression}: ${roll.values.join(', ')}'
+      '${roll.modifier == 0 ? '' : roll.modifier > 0 ? ' + ${roll.modifier}' : ' - ${-roll.modifier}'})',
+    );
+  }
+  details.addAll(_stateChanges(execution.previousState, execution.state));
+  final outcome = execution.succeeded ? 'succeeded' : 'failed its check';
+  return [
+    'Rule engine: $actionLabel $outcome.',
+    if (details.isNotEmpty) details.join('; '),
+  ].join(' ');
+}
+
+List<String> _stateChanges(RpgRuntimeState before, RpgRuntimeState after) {
+  final changes = <String>[];
+  if (before.locationId != after.locationId) {
+    changes.add('location ${before.locationId} -> ${after.locationId}');
+  }
+  for (final key in {...before.attributes.keys, ...after.attributes.keys}) {
+    if (before.attributes[key] != after.attributes[key]) {
+      changes.add(
+        '$key ${before.attributes[key] ?? 0} -> ${after.attributes[key] ?? 0}',
+      );
+    }
+  }
+  for (final key in {...before.variables.keys, ...after.variables.keys}) {
+    if (!const DeepCollectionEquality().equals(
+      before.variables[key],
+      after.variables[key],
+    )) {
+      changes.add(
+        '$key ${before.variables[key] ?? '-'} -> ${after.variables[key] ?? '-'}',
+      );
+    }
+  }
+  final beforeItems = {
+    for (final item in before.inventory) item.itemId: item.quantity,
+  };
+  final afterItems = {
+    for (final item in after.inventory) item.itemId: item.quantity,
+  };
+  for (final key in {...beforeItems.keys, ...afterItems.keys}) {
+    if (beforeItems[key] != afterItems[key]) {
+      changes.add('$key x${beforeItems[key] ?? 0} -> x${afterItems[key] ?? 0}');
+    }
+  }
+  final beforeRelationships = {
+    for (final relationship in before.relationships)
+      relationship.actorId: relationship.score,
+  };
+  final afterRelationships = {
+    for (final relationship in after.relationships)
+      relationship.actorId: relationship.score,
+  };
+  for (final key in {
+    ...beforeRelationships.keys,
+    ...afterRelationships.keys,
+  }) {
+    if (beforeRelationships[key] != afterRelationships[key]) {
+      changes.add(
+        '$key relation ${beforeRelationships[key] ?? 0} -> ${afterRelationships[key] ?? 0}',
+      );
+    }
+  }
+  final beforeQuests = {
+    for (final quest in before.quests) quest.questId: quest.status,
+  };
+  final afterQuests = {
+    for (final quest in after.quests) quest.questId: quest.status,
+  };
+  for (final key in {...beforeQuests.keys, ...afterQuests.keys}) {
+    if (beforeQuests[key] != afterQuests[key]) {
+      changes.add(
+        '$key ${beforeQuests[key]?.name ?? '-'} -> ${afterQuests[key]?.name ?? '-'}',
+      );
+    }
+  }
+  for (final key in {...before.cooldowns.keys, ...after.cooldowns.keys}) {
+    if (before.cooldowns[key] != after.cooldowns[key]) {
+      changes.add(
+        '$key cooldown ${before.cooldowns[key] ?? 0} -> ${after.cooldowns[key] ?? 0}',
+      );
+    }
+  }
+  if (before.clock.elapsedMinutes != after.clock.elapsedMinutes) {
+    changes.add(
+      'time ${before.clock.elapsedMinutes} -> ${after.clock.elapsedMinutes} minutes',
+    );
+  }
+  if (changes.isEmpty) changes.add('turn ${before.turn} -> ${after.turn}');
+  return changes;
+}
+
+String _unwrapJsonFence(String source) {
+  final match = RegExp(
+    r'^```(?:json)?\s*([\s\S]*?)\s*```$',
+    caseSensitive: false,
+  ).firstMatch(source);
+  return match?.group(1)?.trim() ?? source;
+}

--- a/lib/presentation/providers/chat_extension_providers.dart
+++ b/lib/presentation/providers/chat_extension_providers.dart
@@ -1,5 +1,8 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:native_tavern/domain/services/chat_generation_pipeline.dart';
+import 'package:native_tavern/domain/services/rpg_game_session_service.dart';
+import 'package:native_tavern/domain/services/rpg_narrative_bridge.dart';
+import 'package:native_tavern/presentation/providers/rpg_chat_providers.dart';
 
 final chatExtensionRegistryProvider = Provider<ChatExtensionRegistry>((ref) {
   final registry = ChatExtensionRegistry();
@@ -7,11 +10,13 @@ final chatExtensionRegistryProvider = Provider<ChatExtensionRegistry>((ref) {
   return registry;
 });
 
-final lastContextAssemblyProvider =
-    StateProvider<ContextAssemblyResult?>((ref) => null);
+final lastContextAssemblyProvider = StateProvider<ContextAssemblyResult?>(
+  (ref) => null,
+);
 
-final lastChatGenerationTraceProvider =
-    StateProvider<ChatGenerationTrace?>((ref) => null);
+final lastChatGenerationTraceProvider = StateProvider<ChatGenerationTrace?>(
+  (ref) => null,
+);
 
 final chatGenerationPipelineProvider = Provider<ChatGenerationPipeline>((ref) {
   final pipeline = ChatGenerationPipeline(
@@ -25,4 +30,38 @@ final chatGenerationPipelineProvider = Provider<ChatGenerationPipeline>((ref) {
   );
   ref.onDispose(pipeline.dispose);
   return pipeline;
+});
+
+/// Registers the RPG bridge only while a chat UI is mounted. Disabled RPG
+/// sessions contribute no context and perform no response transformation.
+final rpgChatExtensionsProvider = Provider<void>((ref) {
+  final registry = ref.watch(chatExtensionRegistryProvider);
+  final sessionService = ref.watch(rpgGameSessionServiceProvider);
+
+  Future<bool> isEnabled(String chatId) =>
+      ref.read(rpgChatProvider(chatId).notifier).isModeEnabled();
+  Future<RpgGameSession?> loadSession(String chatId) =>
+      ref.read(rpgChatProvider(chatId).notifier).enabledSession();
+
+  final contributorRegistration = registry.registerContributor(
+    RpgNarrativeContextContributor(
+      loadSession: loadSession,
+      isModeEnabled: isEnabled,
+    ),
+  );
+  final middlewareRegistration = registry.registerMiddleware(
+    RpgNarrativeMiddleware(
+      sessionService: sessionService,
+      loadSession: loadSession,
+      isModeEnabled: isEnabled,
+      onResult: (result) => ref
+          .read(rpgChatProvider(result.chatId).notifier)
+          .applyNarrativeResult(result),
+    ),
+  );
+
+  ref.onDispose(() {
+    middlewareRegistration.dispose();
+    contributorRegistration.dispose();
+  });
 });

--- a/lib/presentation/providers/rpg_chat_providers.dart
+++ b/lib/presentation/providers/rpg_chat_providers.dart
@@ -1,0 +1,271 @@
+import 'dart:async';
+
+import 'package:collection/collection.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:native_tavern/core/services/initialization_service.dart';
+import 'package:native_tavern/data/models/rpg/rpg.dart';
+import 'package:native_tavern/data/repositories/drift_rpg_persistence_repository.dart';
+import 'package:native_tavern/domain/repositories/rpg_persistence_repository.dart';
+import 'package:native_tavern/domain/services/rpg_game_session_service.dart';
+import 'package:native_tavern/domain/services/rpg_narrative_bridge.dart';
+import 'package:native_tavern/domain/services/rpg_rule_engine.dart';
+import 'package:native_tavern/presentation/providers/settings_providers.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+final rpgPersistenceRepositoryProvider = Provider<RpgPersistenceRepository>(
+  (ref) => DriftRpgPersistenceRepository(ref.watch(databaseProvider)),
+);
+
+final rpgGameSessionServiceProvider = Provider<RpgGameSessionService>(
+  (ref) => RpgGameSessionService(
+    repository: ref.watch(rpgPersistenceRepositoryProvider),
+  ),
+);
+
+class RpgChatUiState {
+  const RpgChatUiState({
+    this.isLoading = false,
+    this.enabled = false,
+    this.session,
+    this.snapshots = const [],
+    this.lastResult,
+    this.error,
+  });
+
+  final bool isLoading;
+  final bool enabled;
+  final RpgGameSession? session;
+  final List<RpgStateSnapshot> snapshots;
+  final RpgNarrativeResult? lastResult;
+  final String? error;
+
+  bool get hasSession => session != null;
+
+  RpgChatUiState copyWith({
+    bool? isLoading,
+    bool? enabled,
+    RpgGameSession? session,
+    bool clearSession = false,
+    List<RpgStateSnapshot>? snapshots,
+    RpgNarrativeResult? lastResult,
+    bool clearLastResult = false,
+    String? error,
+  }) {
+    return RpgChatUiState(
+      isLoading: isLoading ?? this.isLoading,
+      enabled: enabled ?? this.enabled,
+      session: clearSession ? null : (session ?? this.session),
+      snapshots: snapshots ?? this.snapshots,
+      lastResult: clearLastResult ? null : (lastResult ?? this.lastResult),
+      error: error,
+    );
+  }
+}
+
+class RpgChatController extends StateNotifier<RpgChatUiState> {
+  RpgChatController({
+    required this.chatId,
+    required RpgGameSessionService sessionService,
+    required RpgPersistenceRepository repository,
+    required SharedPreferences preferences,
+    RpgRuleEngine engine = const RpgRuleEngine(),
+  })  : _sessionService = sessionService,
+        _repository = repository,
+        _preferences = preferences,
+        _engine = engine,
+        super(const RpgChatUiState()) {
+    unawaited(load());
+  }
+
+  final String chatId;
+  final RpgGameSessionService _sessionService;
+  final RpgPersistenceRepository _repository;
+  final SharedPreferences _preferences;
+  final RpgRuleEngine _engine;
+  Future<void>? _loading;
+  bool _hasLoaded = false;
+
+  String get _modePreferenceKey => 'rpg.mode.enabled.$chatId';
+
+  List<RpgActionDefinition> get availableActions {
+    final session = state.session;
+    if (session == null) return const [];
+    return _engine.availableActions(session.scenario, session.state);
+  }
+
+  bool isActionAvailable(String actionId) =>
+      availableActions.any((action) => action.id == actionId);
+
+  Future<void> load({bool force = false}) {
+    if (!force && _hasLoaded) return Future.value();
+    final current = _loading;
+    if (current != null) return current;
+    final loading = _load();
+    _loading = loading;
+    return loading.whenComplete(() => _loading = null);
+  }
+
+  Future<void> _load() async {
+    state = state.copyWith(isLoading: true, error: null);
+    try {
+      final session = await _sessionService.load(chatId);
+      final enabledPreference = _preferences.getBool(_modePreferenceKey);
+      final snapshots = session == null
+          ? const <RpgStateSnapshot>[]
+          : await _sessionService.listSessionSnapshots(chatId);
+      _hasLoaded = true;
+      state = state.copyWith(
+        isLoading: false,
+        enabled: session != null && (enabledPreference ?? true),
+        session: session,
+        clearSession: session == null,
+        snapshots: snapshots,
+        error: null,
+      );
+    } catch (error) {
+      _hasLoaded = true;
+      state = state.copyWith(isLoading: false, error: error.toString());
+    }
+  }
+
+  Future<bool> isModeEnabled() async {
+    await load();
+    return state.enabled && state.session != null;
+  }
+
+  Future<RpgGameSession?> enabledSession() async {
+    await load();
+    return state.enabled ? state.session : null;
+  }
+
+  Future<List<RpgScenario>> listScenarios() => _repository.listScenarios();
+
+  Future<void> enable(RpgScenario scenario) async {
+    await load();
+    state = state.copyWith(isLoading: true, error: null);
+    try {
+      final current = state.session;
+      final session = current ??
+          await _sessionService.initialize(chatId: chatId, scenario: scenario);
+      if (session.scenario.metadata.id != scenario.metadata.id) {
+        throw RpgSessionException(
+          'scenario_already_selected',
+          'This chat already uses `${session.scenario.metadata.name}`.',
+        );
+      }
+      await _preferences.setBool(_modePreferenceKey, true);
+      _hasLoaded = false;
+      await load(force: true);
+    } catch (error) {
+      state = state.copyWith(isLoading: false, error: error.toString());
+      rethrow;
+    }
+  }
+
+  Future<void> setEnabled(bool enabled) async {
+    await load();
+    if (enabled && state.session == null) {
+      throw const RpgSessionException(
+        'session_not_found',
+        'Choose an RPG scenario before enabling RPG mode.',
+      );
+    }
+    await _preferences.setBool(_modePreferenceKey, enabled);
+    state = state.copyWith(enabled: enabled, error: null);
+  }
+
+  Future<void> executeAction(String actionId) async {
+    state = state.copyWith(isLoading: true, error: null);
+    try {
+      final session = state.session;
+      final action = session?.scenario.actions
+          .where((candidate) => candidate.id == actionId)
+          .firstOrNull;
+      final committed = await _sessionService.executeAction(
+        chatId: chatId,
+        actionId: actionId,
+      );
+      final result = RpgNarrativeResult(
+        chatId: chatId,
+        status: RpgNarrativeStatus.committed,
+        narrative: '',
+        actionId: actionId,
+        actionLabel: action?.label,
+        feedback: committed.execution.succeeded
+            ? 'Rule engine committed the action.'
+            : 'Rule engine committed the failed check outcome.',
+        execution: committed.execution,
+        snapshot: committed.snapshot,
+      );
+      _hasLoaded = false;
+      await load(force: true);
+      state = state.copyWith(lastResult: result, error: null);
+    } on RpgRuleViolation catch (error) {
+      final result = RpgNarrativeResult(
+        chatId: chatId,
+        status: RpgNarrativeStatus.rejected,
+        narrative: '',
+        actionId: actionId,
+        feedback:
+            'Action rejected (${error.code}): ${error.message} No state changed.',
+        errorCode: error.code,
+      );
+      state = state.copyWith(isLoading: false, lastResult: result, error: null);
+    } catch (error) {
+      state = state.copyWith(isLoading: false, error: error.toString());
+      rethrow;
+    }
+  }
+
+  Future<void> rollback(String snapshotId) async {
+    state = state.copyWith(isLoading: true, error: null);
+    try {
+      await _sessionService.rollback(chatId: chatId, snapshotId: snapshotId);
+      _hasLoaded = false;
+      await load(force: true);
+    } catch (error) {
+      state = state.copyWith(isLoading: false, error: error.toString());
+      rethrow;
+    }
+  }
+
+  Future<void> forkBranch({
+    required String snapshotId,
+    required String branchId,
+  }) async {
+    state = state.copyWith(isLoading: true, error: null);
+    try {
+      await _sessionService.forkBranch(
+        chatId: chatId,
+        fromSnapshotId: snapshotId,
+        branchId: branchId,
+      );
+      _hasLoaded = false;
+      await load(force: true);
+    } catch (error) {
+      state = state.copyWith(isLoading: false, error: error.toString());
+      rethrow;
+    }
+  }
+
+  Future<void> applyNarrativeResult(RpgNarrativeResult result) async {
+    if (result.status == RpgNarrativeStatus.committed) {
+      _hasLoaded = false;
+      await load(force: true);
+    }
+    state = state.copyWith(lastResult: result, error: null);
+  }
+}
+
+final rpgChatProvider =
+    StateNotifierProvider.family<RpgChatController, RpgChatUiState, String>((
+  ref,
+  chatId,
+) {
+  return RpgChatController(
+    chatId: chatId,
+    sessionService: ref.watch(rpgGameSessionServiceProvider),
+    repository: ref.watch(rpgPersistenceRepositoryProvider),
+    preferences: ref.watch(sharedPreferencesProvider),
+  );
+});

--- a/lib/presentation/screens/chat/chat_screen.dart
+++ b/lib/presentation/screens/chat/chat_screen.dart
@@ -12,10 +12,12 @@ import 'package:native_tavern/data/models/character.dart';
 import 'package:native_tavern/data/models/chat.dart';
 import 'package:native_tavern/data/models/chat_background.dart';
 import 'package:native_tavern/data/models/live2d.dart';
+import 'package:native_tavern/data/models/rpg/rpg.dart';
 import 'package:native_tavern/core/utils/share_utils.dart';
 import 'package:native_tavern/domain/services/chat_export_service.dart';
 import 'package:native_tavern/domain/services/llm_service.dart';
 import 'package:native_tavern/domain/services/markdown_hotkey_service.dart';
+import 'package:native_tavern/domain/services/rpg_scenario_package_service.dart';
 import 'package:native_tavern/domain/services/slash_command_service.dart';
 import 'package:native_tavern/domain/services/tts_service.dart';
 import 'package:native_tavern/l10n/generated/app_localizations.dart';
@@ -23,9 +25,11 @@ import 'package:native_tavern/presentation/controllers/chat_tts_autoplay_control
 import 'package:native_tavern/presentation/providers/bookmark_providers.dart';
 import 'package:native_tavern/presentation/providers/background_providers.dart';
 import 'package:native_tavern/presentation/providers/chat_providers.dart';
+import 'package:native_tavern/presentation/providers/chat_extension_providers.dart';
 import 'package:native_tavern/presentation/providers/character_providers.dart';
 import 'package:native_tavern/presentation/providers/persona_providers.dart';
 import 'package:native_tavern/presentation/providers/quick_reply_providers.dart';
+import 'package:native_tavern/presentation/providers/rpg_chat_providers.dart';
 import 'package:native_tavern/presentation/providers/settings_providers.dart';
 import 'package:native_tavern/presentation/providers/tts_providers.dart';
 import 'package:native_tavern/presentation/providers/world_info_providers.dart';
@@ -51,6 +55,7 @@ import 'package:native_tavern/presentation/widgets/chat/tts_playback_controls.da
 import 'package:native_tavern/presentation/widgets/chat/sprite_display.dart';
 import 'package:native_tavern/presentation/widgets/live2d/live2d_character_view.dart';
 import 'package:native_tavern/presentation/widgets/live2d/live2d_stage_gestures.dart';
+import 'package:native_tavern/presentation/widgets/rpg/rpg_game_panel.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:path/path.dart' as p;
 import 'package:uuid/uuid.dart';
@@ -77,6 +82,7 @@ class ChatScreen extends ConsumerStatefulWidget {
 }
 
 class _ChatScreenState extends ConsumerState<ChatScreen> {
+  static final Object _importRpg = Object();
   final TextEditingController _messageController = TextEditingController();
   final ScrollController _scrollController = ScrollController();
   final FocusNode _focusNode = FocusNode();
@@ -98,6 +104,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       ref.read(activeChatProvider.notifier).loadChat(widget.chatId);
       ref.read(bookmarkNotifierProvider.notifier).loadBookmarks(widget.chatId);
+      ref.read(rpgChatProvider(widget.chatId).notifier).load();
       // Refresh context usage to ensure fresh calculation
       // This handles cases where world info was updated while not in chat
       refreshContextUsageProviders(ref);
@@ -391,6 +398,124 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
           attachments: attachments,
         );
     _scrollToBottom();
+  }
+
+  Future<void> _toggleRpgMode() async {
+    final controller = ref.read(rpgChatProvider(widget.chatId).notifier);
+    final rpgState = ref.read(rpgChatProvider(widget.chatId));
+    try {
+      if (rpgState.enabled) {
+        await controller.setEnabled(false);
+      } else if (rpgState.hasSession) {
+        await controller.setEnabled(true);
+      } else {
+        await _showRpgScenarioPicker();
+      }
+    } catch (error) {
+      if (mounted) _showSnackBar(error.toString());
+    }
+  }
+
+  Future<void> _showRpgScenarioPicker() async {
+    final controller = ref.read(rpgChatProvider(widget.chatId).notifier);
+    final scenarios = await controller.listScenarios();
+    if (!mounted) return;
+    final selected = await showModalBottomSheet<Object>(
+      context: context,
+      showDragHandle: true,
+      builder: (sheetContext) => SafeArea(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxHeight: 440),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 0, 8, 8),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        'Choose RPG scenario',
+                        style: Theme.of(context).textTheme.titleMedium,
+                      ),
+                    ),
+                    IconButton(
+                      onPressed: () => Navigator.pop(sheetContext, _importRpg),
+                      icon: const Icon(Icons.file_open_outlined),
+                      tooltip: 'Import scenario',
+                    ),
+                  ],
+                ),
+              ),
+              if (scenarios.isEmpty)
+                const Padding(
+                  padding: EdgeInsets.all(24),
+                  child: Text(
+                      'No saved scenarios. Import a JSON or YAML package.'),
+                )
+              else
+                Flexible(
+                  child: ListView.separated(
+                    shrinkWrap: true,
+                    itemCount: scenarios.length,
+                    separatorBuilder: (_, __) => const Divider(height: 1),
+                    itemBuilder: (_, index) {
+                      final scenario = scenarios[index];
+                      return ListTile(
+                        leading: const Icon(Icons.sports_esports_outlined),
+                        title: Text(scenario.metadata.name),
+                        subtitle: Text(
+                          '${scenario.metadata.id} · ${scenario.metadata.version}',
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                        onTap: () => Navigator.pop(sheetContext, scenario),
+                      );
+                    },
+                  ),
+                ),
+              ListTile(
+                key: const Key('rpg-import-scenario'),
+                leading: const Icon(Icons.file_open_outlined),
+                title: const Text('Import scenario package'),
+                onTap: () => Navigator.pop(sheetContext, _importRpg),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    if (selected is RpgScenario) {
+      await controller.enable(selected);
+    } else if (selected == _importRpg) {
+      await _importRpgScenario();
+    }
+  }
+
+  Future<void> _importRpgScenario() async {
+    final selection = await FilePicker.platform.pickFiles(
+      type: FileType.custom,
+      allowedExtensions: RpgScenarioPackageService.supportedExtensions,
+      withData: true,
+    );
+    if (selection == null || selection.files.isEmpty) return;
+    final file = selection.files.single;
+    final bytes = file.bytes ??
+        (file.path == null ? null : await File(file.path!).readAsBytes());
+    if (bytes == null) {
+      throw StateError('The selected scenario could not be read.');
+    }
+    final result = await const RpgScenarioPackageService().importBytesAsync(
+      bytes,
+      fileName: file.name,
+    );
+    if (!result.isValid) {
+      throw StateError(
+          result.issues.map((issue) => issue.toString()).join('\n'));
+    }
+    await ref
+        .read(rpgChatProvider(widget.chatId).notifier)
+        .enable(result.scenario!);
   }
 
   Future<void> _handleSlashCommand(String input) async {
@@ -872,6 +997,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
 
   @override
   Widget build(BuildContext context) {
+    ref.watch(rpgChatExtensionsProvider);
     final chatState = ref.watch(activeChatProvider);
     final llmConfig = ref.watch(llmConfigProvider);
     final isConfigured = _isApiConfigured(llmConfig);
@@ -935,6 +1061,11 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
                   child: chatState.isLoading
                       ? const Center(child: CircularProgressIndicator())
                       : _buildMessagesArea(chatState),
+                ),
+
+                RpgGamePanel(
+                  chatId: widget.chatId,
+                  onDisable: _toggleRpgMode,
                 ),
 
                 // Slash command suggestions
@@ -1006,6 +1137,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     final hasAuthorNote = chatState.chat?.authorNoteEnabled == true &&
         (chatState.chat?.authorNote.isNotEmpty ?? false);
     final llmConfig = ref.watch(llmConfigProvider);
+    final rpgState = ref.watch(rpgChatProvider(widget.chatId));
 
     return AppBar(
       title: Column(
@@ -1045,6 +1177,17 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
       ),
       actions: [
         ChatTTSPlaybackControls(ownerId: widget.chatId),
+        IconButton(
+          key: const Key('rpg-mode-toggle'),
+          icon: Icon(
+            rpgState.enabled
+                ? Icons.sports_esports
+                : Icons.sports_esports_outlined,
+            color: rpgState.enabled ? AppTheme.accentColor : null,
+          ),
+          tooltip: rpgState.enabled ? 'Disable RPG mode' : 'Enable RPG mode',
+          onPressed: rpgState.isLoading ? null : _toggleRpgMode,
+        ),
         // Author's Note button
         IconButton(
           icon: Icon(

--- a/lib/presentation/widgets/rpg/rpg_game_panel.dart
+++ b/lib/presentation/widgets/rpg/rpg_game_panel.dart
@@ -1,0 +1,633 @@
+import 'package:collection/collection.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:native_tavern/data/models/rpg/rpg.dart';
+import 'package:native_tavern/domain/services/rpg_narrative_bridge.dart';
+import 'package:native_tavern/domain/services/rpg_game_session_service.dart';
+import 'package:native_tavern/presentation/providers/rpg_chat_providers.dart';
+import 'package:native_tavern/presentation/theme/app_theme.dart';
+
+class RpgGamePanel extends ConsumerWidget {
+  const RpgGamePanel({
+    super.key,
+    required this.chatId,
+    required this.onDisable,
+  });
+
+  final String chatId;
+  final VoidCallback onDisable;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final uiState = ref.watch(rpgChatProvider(chatId));
+    final session = uiState.session;
+    if (!uiState.enabled || session == null) return const SizedBox.shrink();
+
+    final panelHeight = (MediaQuery.sizeOf(context).height * 0.34)
+        .clamp(240.0, 340.0)
+        .toDouble();
+    return DefaultTabController(
+      length: 6,
+      child: Container(
+        key: const Key('rpg-game-panel'),
+        height: panelHeight,
+        decoration: const BoxDecoration(
+          color: AppTheme.darkCard,
+          border: Border(top: BorderSide(color: AppTheme.darkDivider)),
+        ),
+        child: Column(
+          children: [
+            SizedBox(
+              height: 42,
+              child: Row(
+                children: [
+                  const SizedBox(width: 12),
+                  const Icon(Icons.sports_esports, size: 18),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    flex: 3,
+                    child: Text(
+                      session.scenario.metadata.name,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: Theme.of(context).textTheme.titleSmall,
+                    ),
+                  ),
+                  Expanded(
+                    flex: 2,
+                    child: Text(
+                      'Turn ${session.state.turn} · ${session.branchId}',
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      textAlign: TextAlign.end,
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            color: AppTheme.textMuted,
+                          ),
+                    ),
+                  ),
+                  IconButton(
+                    key: const Key('rpg-disable'),
+                    onPressed: onDisable,
+                    icon: const Icon(Icons.close, size: 19),
+                    tooltip: 'Disable RPG mode',
+                  ),
+                ],
+              ),
+            ),
+            if (uiState.lastResult case final result?)
+              _ResultBanner(result: result),
+            const TabBar(
+              isScrollable: true,
+              tabAlignment: TabAlignment.start,
+              dividerHeight: 1,
+              tabs: [
+                Tab(
+                    key: Key('rpg-tab-status'),
+                    icon: Icon(Icons.tune),
+                    text: 'Status'),
+                Tab(
+                    key: Key('rpg-tab-inventory'),
+                    icon: Icon(Icons.backpack_outlined),
+                    text: 'Inventory'),
+                Tab(
+                    key: Key('rpg-tab-quests'),
+                    icon: Icon(Icons.task_alt),
+                    text: 'Quests'),
+                Tab(
+                    key: Key('rpg-tab-relations'),
+                    icon: Icon(Icons.people_outline),
+                    text: 'Relations'),
+                Tab(
+                    key: Key('rpg-tab-actions'),
+                    icon: Icon(Icons.bolt),
+                    text: 'Actions'),
+                Tab(
+                    key: Key('rpg-tab-log'),
+                    icon: Icon(Icons.history),
+                    text: 'Log'),
+              ],
+            ),
+            Expanded(
+              child: Stack(
+                children: [
+                  TabBarView(
+                    children: [
+                      _StatusView(session: session),
+                      _InventoryView(session: session),
+                      _QuestView(session: session),
+                      _RelationshipView(session: session),
+                      _ActionView(chatId: chatId, session: session),
+                      _LogView(
+                        chatId: chatId,
+                        session: session,
+                        snapshots: uiState.snapshots,
+                      ),
+                    ],
+                  ),
+                  if (uiState.isLoading)
+                    const Positioned(
+                      left: 0,
+                      right: 0,
+                      top: 0,
+                      child: LinearProgressIndicator(minHeight: 2),
+                    ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ResultBanner extends StatelessWidget {
+  const _ResultBanner({required this.result});
+
+  final RpgNarrativeResult result;
+
+  @override
+  Widget build(BuildContext context) {
+    final isError = result.status == RpgNarrativeStatus.rejected ||
+        result.status == RpgNarrativeStatus.malformed;
+    final isCancelled = result.status == RpgNarrativeStatus.cancelled;
+    if (result.feedback.isEmpty) return const SizedBox.shrink();
+    final color = isError
+        ? Colors.red
+        : isCancelled
+            ? Colors.orange
+            : Colors.green;
+    return Container(
+      key: const Key('rpg-result-banner'),
+      width: double.infinity,
+      color: color.withValues(alpha: 0.13),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 7),
+      child: Row(
+        children: [
+          Icon(
+            isError
+                ? Icons.error_outline
+                : isCancelled
+                    ? Icons.cancel_outlined
+                    : Icons.verified_outlined,
+            size: 17,
+            color: color,
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              result.feedback,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _StatusView extends StatelessWidget {
+  const _StatusView({required this.session});
+
+  final RpgGameSession session;
+
+  @override
+  Widget build(BuildContext context) {
+    final scenario = session.scenario;
+    final state = session.state;
+    final location = scenario.locations
+        .where((candidate) => candidate.id == state.locationId)
+        .firstOrNull;
+    return ListView(
+      key: const Key('rpg-status-view'),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      children: [
+        _SectionLine(
+          icon: Icons.place_outlined,
+          label: 'Location',
+          value: location?.label ??
+              (state.locationId.isEmpty ? 'Unknown' : state.locationId),
+        ),
+        _SectionLine(
+          icon: Icons.schedule,
+          label: 'Time',
+          value:
+              'Day ${state.clock.day}, ${_clockLabel(state.clock.minuteOfDay)}',
+        ),
+        const Divider(),
+        ...scenario.attributes.map((definition) {
+          final value =
+              state.attributes[definition.id] ?? definition.initialValue;
+          final bounds = definition.maximum == null
+              ? '$value'
+              : '$value / ${definition.maximum}';
+          return _SectionLine(
+            icon: Icons.monitor_heart_outlined,
+            label: definition.label,
+            value: bounds,
+          );
+        }),
+        if (state.variables.isNotEmpty) ...[
+          const Divider(),
+          ...state.variables.entries.map(
+            (entry) => _SectionLine(
+              icon: Icons.data_object,
+              label: entry.key,
+              value: '${entry.value}',
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+class _InventoryView extends StatelessWidget {
+  const _InventoryView({required this.session});
+
+  final RpgGameSession session;
+
+  @override
+  Widget build(BuildContext context) {
+    if (session.state.inventory.isEmpty) {
+      return const _EmptyView(
+          icon: Icons.backpack_outlined, label: 'Inventory is empty');
+    }
+    return ListView.separated(
+      key: const Key('rpg-inventory-view'),
+      padding: const EdgeInsets.symmetric(vertical: 6),
+      itemCount: session.state.inventory.length,
+      separatorBuilder: (_, __) => const Divider(height: 1),
+      itemBuilder: (context, index) {
+        final entry = session.state.inventory[index];
+        final definition = session.scenario.items
+            .where((item) => item.id == entry.itemId)
+            .firstOrNull;
+        return ListTile(
+          dense: true,
+          leading: const Icon(Icons.inventory_2_outlined),
+          title: Text(definition?.label ?? entry.itemId),
+          subtitle: definition?.description.isEmpty ?? true
+              ? null
+              : Text(definition!.description,
+                  maxLines: 1, overflow: TextOverflow.ellipsis),
+          trailing: Text('x${entry.quantity}'),
+        );
+      },
+    );
+  }
+}
+
+class _QuestView extends StatelessWidget {
+  const _QuestView({required this.session});
+
+  final RpgGameSession session;
+
+  @override
+  Widget build(BuildContext context) {
+    if (session.state.quests.isEmpty) {
+      return const _EmptyView(icon: Icons.task_alt, label: 'No quests');
+    }
+    return ListView.separated(
+      key: const Key('rpg-quest-view'),
+      padding: const EdgeInsets.symmetric(vertical: 6),
+      itemCount: session.state.quests.length,
+      separatorBuilder: (_, __) => const Divider(height: 1),
+      itemBuilder: (context, index) {
+        final quest = session.state.quests[index];
+        final definition = session.scenario.quests
+            .where((item) => item.id == quest.questId)
+            .firstOrNull;
+        final stage = definition?.stages
+            .where((item) => item.id == quest.stageId)
+            .firstOrNull;
+        return ListTile(
+          dense: true,
+          leading: Icon(_questIcon(quest.status)),
+          title: Text(definition?.label ?? quest.questId),
+          subtitle: Text(
+            [
+              quest.status.name,
+              if (stage != null) stage.label,
+              if (quest.objectiveProgress.isNotEmpty)
+                quest.objectiveProgress.entries
+                    .map((entry) => '${entry.key}: ${entry.value}')
+                    .join(', '),
+            ].join(' · '),
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _RelationshipView extends StatelessWidget {
+  const _RelationshipView({required this.session});
+
+  final RpgGameSession session;
+
+  @override
+  Widget build(BuildContext context) {
+    if (session.state.relationships.isEmpty) {
+      return const _EmptyView(
+          icon: Icons.people_outline, label: 'No relationships');
+    }
+    return ListView.separated(
+      key: const Key('rpg-relationship-view'),
+      padding: const EdgeInsets.symmetric(vertical: 6),
+      itemCount: session.state.relationships.length,
+      separatorBuilder: (_, __) => const Divider(height: 1),
+      itemBuilder: (context, index) {
+        final relationship = session.state.relationships[index];
+        final actor = session.scenario.actors
+            .where((candidate) => candidate.id == relationship.actorId)
+            .firstOrNull;
+        return ListTile(
+          dense: true,
+          leading: const Icon(Icons.person_outline),
+          title: Text(actor?.label ?? relationship.actorId),
+          subtitle: relationship.tags.isEmpty
+              ? null
+              : Text(relationship.tags.join(', ')),
+          trailing: Text('${relationship.score}'),
+        );
+      },
+    );
+  }
+}
+
+class _ActionView extends ConsumerWidget {
+  const _ActionView({required this.chatId, required this.session});
+
+  final String chatId;
+  final RpgGameSession session;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    if (session.scenario.actions.isEmpty) {
+      return const _EmptyView(icon: Icons.bolt, label: 'No actions defined');
+    }
+    final controller = ref.read(rpgChatProvider(chatId).notifier);
+    final availableIds =
+        controller.availableActions.map((action) => action.id).toSet();
+    return ListView.separated(
+      key: const Key('rpg-action-view'),
+      padding: const EdgeInsets.symmetric(vertical: 6),
+      itemCount: session.scenario.actions.length,
+      separatorBuilder: (_, __) => const Divider(height: 1),
+      itemBuilder: (context, index) {
+        final action = session.scenario.actions[index];
+        final available = availableIds.contains(action.id);
+        final cooldown = session.state.cooldowns[action.id] ?? 0;
+        final details = <String>[
+          if (action.description.isNotEmpty) action.description,
+          if (action.costs.isNotEmpty)
+            'Cost: ${action.costs.map((cost) => '${cost.path} ${cost.amount}').join(', ')}',
+          if (action.check != null)
+            'Check: ${action.check!.dice.expression} + ${action.check!.attributeId} vs ${action.check!.difficulty}',
+          if (!available)
+            cooldown > 0
+                ? 'Cooldown: $cooldown turn(s)'
+                : 'Requirements or resources not met',
+        ];
+        return ListTile(
+          key: Key('rpg-action-${action.id}'),
+          dense: true,
+          enabled: available,
+          leading: Icon(available ? Icons.play_arrow : Icons.lock_outline),
+          title: Text(action.label),
+          subtitle: details.isEmpty
+              ? null
+              : Text(details.join('\n'),
+                  maxLines: 3, overflow: TextOverflow.ellipsis),
+          onTap: available
+              ? () async {
+                  await controller.executeAction(action.id);
+                  if (!context.mounted) return;
+                  final result = ref.read(rpgChatProvider(chatId)).lastResult;
+                  if (result != null) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(content: Text(result.feedback)),
+                    );
+                  }
+                }
+              : null,
+        );
+      },
+    );
+  }
+}
+
+class _LogView extends ConsumerWidget {
+  const _LogView({
+    required this.chatId,
+    required this.session,
+    required this.snapshots,
+  });
+
+  final String chatId;
+  final RpgGameSession session;
+  final List<RpgStateSnapshot> snapshots;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final events = session.state.eventHistory.reversed.toList();
+    return ListView(
+      key: const Key('rpg-log-view'),
+      padding: const EdgeInsets.symmetric(vertical: 6),
+      children: [
+        if (events.isEmpty)
+          const SizedBox(
+            height: 72,
+            child: _EmptyView(icon: Icons.history, label: 'No turns recorded'),
+          ),
+        ...events.map((event) => _eventTile(session, event)),
+        const Divider(height: 16),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+          child:
+              Text('Snapshots', style: Theme.of(context).textTheme.titleSmall),
+        ),
+        ...snapshots.reversed.map(
+          (snapshot) => ListTile(
+            dense: true,
+            leading: Icon(
+              snapshot.metadata.id == session.snapshot.metadata.id
+                  ? Icons.radio_button_checked
+                  : Icons.radio_button_unchecked,
+              size: 20,
+            ),
+            title: Text(
+                'Turn ${snapshot.metadata.turn} · ${snapshot.metadata.branchId}'),
+            subtitle: Text(
+              snapshot.metadata.createdAt.toLocal().toString(),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+            trailing: PopupMenuButton<String>(
+              key: Key('rpg-snapshot-${snapshot.metadata.id}'),
+              tooltip: 'Snapshot actions',
+              enabled: snapshot.metadata.id != session.snapshot.metadata.id,
+              itemBuilder: (_) => const [
+                PopupMenuItem(
+                    value: 'restore', child: Text('Restore snapshot')),
+                PopupMenuItem(value: 'fork', child: Text('Fork new branch')),
+              ],
+              onSelected: (value) async {
+                final controller = ref.read(rpgChatProvider(chatId).notifier);
+                try {
+                  if (value == 'restore') {
+                    await controller.rollback(snapshot.metadata.id);
+                  } else {
+                    final branchId = await _askForBranchId(context);
+                    if (branchId == null || branchId.isEmpty) return;
+                    await controller.forkBranch(
+                      snapshotId: snapshot.metadata.id,
+                      branchId: branchId,
+                    );
+                  }
+                } catch (error) {
+                  if (context.mounted) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(content: Text(error.toString())),
+                    );
+                  }
+                }
+              },
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+Widget _eventTile(RpgGameSession session, RpgEventRecord event) {
+  final action = session.scenario.actions
+      .where((candidate) => candidate.id == event.actionId)
+      .firstOrNull;
+  final roll = event.data['roll'];
+  final details = <String>['Turn ${event.turn}', 'Source: Rule engine'];
+  if (roll is Map<String, Object?>) {
+    details.add('Roll: ${roll['total']} (${roll['expression']})');
+  } else if (roll is Map) {
+    details.add('Roll: ${roll['total']} (${roll['expression']})');
+  }
+  final effects = event.data['effects'];
+  if (effects is List && effects.isNotEmpty) {
+    final labels = effects.whereType<Map<Object?, Object?>>().map((effect) {
+      final type = effect['type'] ?? 'effect';
+      final target = effect['target'];
+      return target == null ? '$type' : '$type:$target';
+    });
+    details.add('Changes: ${labels.join(', ')}');
+  }
+  return ListTile(
+    dense: true,
+    leading: const Icon(Icons.verified_user_outlined),
+    title: Text(
+        action?.label ?? (event.summary.isEmpty ? event.type : event.summary)),
+    subtitle:
+        Text(details.join(' · '), maxLines: 2, overflow: TextOverflow.ellipsis),
+  );
+}
+
+class _SectionLine extends StatelessWidget {
+  const _SectionLine({
+    required this.icon,
+    required this.label,
+    required this.value,
+  });
+
+  final IconData icon;
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 6),
+      child: Row(
+        children: [
+          Icon(icon, size: 18, color: AppTheme.textMuted),
+          const SizedBox(width: 8),
+          Expanded(
+              child: Text(label, maxLines: 1, overflow: TextOverflow.ellipsis)),
+          const SizedBox(width: 12),
+          Flexible(
+            child: Text(
+              value,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              textAlign: TextAlign.end,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _EmptyView extends StatelessWidget {
+  const _EmptyView({required this.icon, required this.label});
+
+  final IconData icon;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, color: AppTheme.textMuted),
+          const SizedBox(width: 8),
+          Text(label, style: const TextStyle(color: AppTheme.textMuted)),
+        ],
+      ),
+    );
+  }
+}
+
+Future<String?> _askForBranchId(BuildContext context) async {
+  var branchId = '';
+  return showDialog<String>(
+    context: context,
+    builder: (dialogContext) => AlertDialog(
+      title: const Text('Fork branch'),
+      content: TextField(
+        key: const Key('rpg-branch-id'),
+        autofocus: true,
+        onChanged: (value) => branchId = value,
+        decoration: const InputDecoration(labelText: 'Branch ID'),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(dialogContext),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.pop(dialogContext, branchId.trim()),
+          child: const Text('Fork'),
+        ),
+      ],
+    ),
+  );
+}
+
+IconData _questIcon(RpgQuestStatus status) => switch (status) {
+      RpgQuestStatus.inactive => Icons.pause_circle_outline,
+      RpgQuestStatus.active => Icons.play_circle_outline,
+      RpgQuestStatus.completed => Icons.check_circle_outline,
+      RpgQuestStatus.failed => Icons.cancel_outlined,
+    };
+
+String _clockLabel(int minuteOfDay) {
+  final hours = (minuteOfDay ~/ 60).toString().padLeft(2, '0');
+  final minutes = (minuteOfDay % 60).toString().padLeft(2, '0');
+  return '$hours:$minutes';
+}

--- a/test/rpg_narrative_ui_end_to_end_test.dart
+++ b/test/rpg_narrative_ui_end_to_end_test.dart
@@ -1,0 +1,448 @@
+import 'dart:async';
+import 'dart:collection';
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:native_tavern/core/services/initialization_service.dart';
+import 'package:native_tavern/data/database/database.dart';
+import 'package:native_tavern/data/models/character.dart' as models;
+import 'package:native_tavern/data/models/rpg/rpg.dart';
+import 'package:native_tavern/data/repositories/character_repository.dart';
+import 'package:native_tavern/data/repositories/chat_repository.dart';
+import 'package:native_tavern/domain/services/chat_generation_pipeline.dart';
+import 'package:native_tavern/domain/services/llm_service.dart';
+import 'package:native_tavern/domain/services/rpg_narrative_bridge.dart';
+import 'package:native_tavern/presentation/providers/chat_extension_providers.dart';
+import 'package:native_tavern/presentation/providers/chat_providers.dart';
+import 'package:native_tavern/presentation/providers/rpg_chat_providers.dart';
+import 'package:native_tavern/presentation/providers/settings_providers.dart';
+import 'package:native_tavern/presentation/providers/vector_storage_providers.dart';
+import 'package:native_tavern/presentation/widgets/rpg/rpg_game_panel.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory temporaryDirectory;
+  late AppDatabase database;
+  late ChatRepository chatRepository;
+  late CharacterRepository characterRepository;
+  late _ControlledLlmService llmService;
+  late ProviderContainer container;
+  late String chatId;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    final preferences = await SharedPreferences.getInstance();
+    temporaryDirectory = await Directory.systemTemp.createTemp('rpg-bridge-');
+    final databaseFile = File('${temporaryDirectory.path}/rpg.sqlite');
+    database = AppDatabase.forTesting(NativeDatabase(databaseFile));
+    await database.customSelect('SELECT 1').get();
+    chatRepository = ChatRepository(database);
+    characterRepository = CharacterRepository(
+      database,
+      temporaryDirectory.path,
+    );
+    llmService = _ControlledLlmService();
+    container = ProviderContainer(overrides: [
+      databaseProvider.overrideWithValue(database),
+      dataPathProvider.overrideWithValue(temporaryDirectory.path),
+      characterRepositoryProvider.overrideWithValue(characterRepository),
+      chatRepositoryProvider.overrideWithValue(chatRepository),
+      llmServiceProvider.overrideWithValue(llmService),
+      sharedPreferencesProvider.overrideWithValue(preferences),
+      ragContextProvider.overrideWithValue((_) async => null),
+    ]);
+
+    final now = DateTime.utc(2026, 8, 8);
+    await characterRepository.createCharacter(models.Character(
+      id: 'rpg-character',
+      name: 'Game Master',
+      description: 'Runs deterministic RPG tests.',
+      createdAt: now,
+      modifiedAt: now,
+    ));
+    chatId = (await container
+        .read(activeChatProvider.notifier)
+        .createChat('rpg-character'))!;
+    await container.read(rpgChatProvider(chatId).notifier).enable(_scenario);
+    container.read(rpgChatExtensionsProvider);
+  });
+
+  tearDown(() async {
+    container.dispose();
+    await database.close();
+    await temporaryDirectory.delete(recursive: true);
+  });
+
+  test('injects RPG context, validates an action, and persists its result',
+      () async {
+    llmService.responses.add(const LLMResponse(
+      content:
+          '{"narrative":"You push into the ruins.","proposedAction":{"actionId":"explore"}}',
+    ));
+
+    await container
+        .read(activeChatProvider.notifier)
+        .sendMessage('Explore the ruins', _config);
+
+    final request = llmService.requests.single;
+    final rpgPrompt = request.singleWhere(
+      (message) =>
+          message['role'] == 'system' &&
+          '${message['content']}'.contains('RPG_CONTEXT:'),
+    );
+    expect(rpgPrompt['content'], contains('"actionId": "explore"'));
+    expect(rpgPrompt['content'], isNot(contains('"actionId": "expensive"')));
+
+    final uiState = container.read(rpgChatProvider(chatId));
+    expect(uiState.session!.state.turn, 1);
+    expect(uiState.session!.state.attributes['energy'], 2);
+    expect(uiState.session!.state.inventory.single.itemId, 'relic');
+    expect(
+        uiState.session!.state.quests.single.status, RpgQuestStatus.completed);
+    expect(uiState.lastResult?.status, RpgNarrativeStatus.committed);
+
+    final messages = await chatRepository.getMessages(chatId);
+    expect(messages.last.content, contains('You push into the ruins.'));
+    expect(messages.last.content, contains('Rule engine: Explore succeeded.'));
+    expect(messages.last.content, isNot(contains('proposedAction')));
+    expect(uiState.snapshots, hasLength(2));
+  });
+
+  test('buffers a streamed control envelope until it has been validated',
+      () async {
+    llmService.responses.add(const LLMResponse(
+      content:
+          '{"narrative":"A careful step forward.","proposedAction":{"actionId":"explore"}}',
+    ));
+
+    await container
+        .read(activeChatProvider.notifier)
+        .sendMessage('Move carefully', _streamingConfig);
+
+    final messages = await chatRepository.getMessages(chatId);
+    expect(messages.last.content, startsWith('A careful step forward.'));
+    expect(messages.last.content, isNot(contains('{"narrative"')));
+    expect(container.read(rpgChatProvider(chatId)).session!.state.turn, 1);
+  });
+
+  test('disabled RPG mode preserves the baseline chat request and response',
+      () async {
+    await container.read(rpgChatProvider(chatId).notifier).setEnabled(false);
+    llmService.responses.add(
+      const LLMResponse(content: 'A normal unstructured chat reply.'),
+    );
+
+    await container
+        .read(activeChatProvider.notifier)
+        .sendMessage('Talk normally', _config);
+
+    expect(
+      llmService.requests.single.any(
+        (message) => '${message['content']}'.contains('RPG_CONTEXT:'),
+      ),
+      isFalse,
+    );
+    final messages = await chatRepository.getMessages(chatId);
+    expect(messages.last.content, 'A normal unstructured chat reply.');
+    expect(container.read(rpgChatProvider(chatId)).session!.state.turn, 0);
+  });
+
+  test('malformed and rejected suggestions never create partial snapshots',
+      () async {
+    final controller = container.read(rpgChatProvider(chatId).notifier);
+    final initialSnapshot =
+        container.read(rpgChatProvider(chatId)).session!.snapshot.metadata.id;
+
+    llmService.responses.add(
+      const LLMResponse(content: '{"narrative":"Broken"'),
+    );
+    await container
+        .read(activeChatProvider.notifier)
+        .sendMessage('Malformed turn', _config);
+    var state = container.read(rpgChatProvider(chatId));
+    expect(state.lastResult?.status, RpgNarrativeStatus.malformed);
+    expect(state.session!.snapshot.metadata.id, initialSnapshot);
+    expect(state.snapshots, hasLength(1));
+
+    llmService.responses.add(const LLMResponse(
+      content:
+          '{"narrative":"I alter the state.","proposedAction":null,"turn":99}',
+    ));
+    await container
+        .read(activeChatProvider.notifier)
+        .sendMessage('Bypass the rules', _config);
+    state = container.read(rpgChatProvider(chatId));
+    expect(state.lastResult?.status, RpgNarrativeStatus.malformed);
+    expect(state.lastResult?.errorCode, 'unexpected_field');
+    expect(state.session!.state.turn, 0);
+    expect(state.session!.snapshot.metadata.id, initialSnapshot);
+
+    llmService.responses.add(const LLMResponse(
+      content:
+          '{"narrative":"You spend everything.","proposedAction":{"actionId":"expensive"}}',
+    ));
+    await container
+        .read(activeChatProvider.notifier)
+        .sendMessage('Spend energy', _config);
+    state = container.read(rpgChatProvider(chatId));
+    expect(state.lastResult?.status, RpgNarrativeStatus.rejected);
+    expect(state.lastResult?.errorCode, 'insufficient_resource');
+    expect(state.session!.snapshot.metadata.id, initialSnapshot);
+    expect(state.snapshots, hasLength(1));
+    expect(controller.availableActions.map((action) => action.id), ['explore']);
+  });
+
+  test('cancelling generation records cancellation and commits no action',
+      () async {
+    llmService.blockNextResponse();
+    final sending = container
+        .read(activeChatProvider.notifier)
+        .sendMessage('Stop before resolving', _config);
+    await llmService.started.future;
+
+    await container.read(activeChatProvider.notifier).cancelGeneration();
+    llmService.releaseBlockedResponse(const LLMResponse(
+      content:
+          '{"narrative":"Too late.","proposedAction":{"actionId":"explore"}}',
+    ));
+    await sending;
+
+    final state = container.read(rpgChatProvider(chatId));
+    expect(state.lastResult?.status, RpgNarrativeStatus.cancelled);
+    expect(state.session!.state.turn, 0);
+    expect(state.snapshots, hasLength(1));
+    expect(
+      (await chatRepository.getMessages(chatId))
+          .map((message) => message.content),
+      ['Stop before resolving'],
+    );
+  });
+
+  testWidgets(
+      'game panel covers all views and refreshes action and branch state',
+      (tester) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(UncontrolledProviderScope(
+      container: container,
+      child: MaterialApp(
+        home: Scaffold(
+          body: Align(
+            alignment: Alignment.bottomCenter,
+            child: RpgGamePanel(chatId: chatId, onDisable: _noop),
+          ),
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(find.byKey(const Key('rpg-game-panel')), findsOneWidget);
+    for (final key in const [
+      'rpg-tab-status',
+      'rpg-tab-inventory',
+      'rpg-tab-quests',
+      'rpg-tab-relations',
+      'rpg-tab-actions',
+      'rpg-tab-log',
+    ]) {
+      expect(find.byKey(Key(key)), findsOneWidget);
+    }
+
+    final initialSnapshot =
+        container.read(rpgChatProvider(chatId)).session!.snapshot.metadata.id;
+    final tabController = DefaultTabController.of(
+      tester.element(find.byKey(const Key('rpg-tab-status'))),
+    );
+    tabController.animateTo(4);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('rpg-action-explore')));
+    await tester.pumpAndSettle();
+    var state = container.read(rpgChatProvider(chatId));
+    expect(state.session!.state.turn, 1);
+    final mainTurnSnapshot = state.session!.snapshot.metadata.id;
+    await tester.pump(const Duration(seconds: 5));
+    await tester.pumpAndSettle();
+
+    tabController.animateTo(5);
+    await tester.pumpAndSettle();
+    await tester.drag(
+      find.byKey(const Key('rpg-log-view')),
+      const Offset(0, -220),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(Key('rpg-snapshot-$initialSnapshot')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Fork new branch'));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byKey(const Key('rpg-branch-id')), 'alternate');
+    await tester.tap(find.text('Fork'));
+    await tester.pumpAndSettle();
+
+    state = container.read(rpgChatProvider(chatId));
+    expect(state.session!.branchId, 'alternate');
+    expect(state.session!.state.turn, 0);
+
+    await container
+        .read(rpgChatProvider(chatId).notifier)
+        .rollback(mainTurnSnapshot);
+    await tester.pumpAndSettle();
+    state = container.read(rpgChatProvider(chatId));
+    expect(state.session!.branchId, startsWith('chat_'));
+    expect(state.session!.state.turn, 1);
+    expect(find.textContaining('Turn 1'), findsWidgets);
+    expect(tester.takeException(), isNull);
+  });
+}
+
+void _noop() {}
+
+const _config = LLMConfig(
+  provider: LLMProvider.openAICompatible,
+  model: 'test-model',
+  apiKey: '',
+  apiUrl: 'http://localhost',
+  contextLength: 4096,
+  maxTokens: 512,
+  streamEnabled: false,
+  autoSummarizeEnabled: false,
+);
+
+const _streamingConfig = LLMConfig(
+  provider: LLMProvider.openAICompatible,
+  model: 'test-model',
+  apiKey: '',
+  apiUrl: 'http://localhost',
+  contextLength: 4096,
+  maxTokens: 512,
+  streamEnabled: true,
+  autoSummarizeEnabled: false,
+);
+
+class _ControlledLlmService extends LLMService {
+  final Queue<LLMResponse> responses = Queue<LLMResponse>();
+  final List<List<ChatMessageMap>> requests = [];
+  Completer<void> started = Completer<void>();
+  Completer<LLMResponse>? _blockedResponse;
+
+  void blockNextResponse() {
+    started = Completer<void>();
+    _blockedResponse = Completer<LLMResponse>();
+  }
+
+  void releaseBlockedResponse(LLMResponse response) {
+    final blocked = _blockedResponse!;
+    _blockedResponse = null;
+    blocked.complete(response);
+  }
+
+  Future<LLMResponse> _next(List<Map<String, dynamic>> messages) async {
+    requests.add(
+      messages.map((message) => Map<String, dynamic>.from(message)).toList(),
+    );
+    final blocked = _blockedResponse;
+    if (blocked != null) {
+      if (!started.isCompleted) started.complete();
+      return blocked.future;
+    }
+    return responses.removeFirst();
+  }
+
+  @override
+  Future<LLMResponse> generateWithReasoning(
+    List<Map<String, dynamic>> messages,
+    LLMConfig config,
+  ) =>
+      _next(messages);
+
+  @override
+  Stream<LLMStreamChunk> generateStreamWithReasoning(
+    List<Map<String, dynamic>> messages,
+    LLMConfig config,
+  ) async* {
+    final response = await _next(messages);
+    final midpoint = response.content.length ~/ 2;
+    yield LLMStreamChunk(content: response.content.substring(0, midpoint));
+    yield LLMStreamChunk(content: response.content.substring(midpoint));
+  }
+}
+
+const _scenario = RpgScenario(
+  metadata: RpgScenarioMetadata(
+    id: 'bridge_test',
+    name: 'Bridge Test',
+    version: '1.0.0',
+  ),
+  initialSeed: 77,
+  protectedFields: [
+    'random.initialSeed',
+    'random.state',
+    'random.rollsConsumed',
+    'turn',
+    'attributes',
+    'inventory',
+    'quests',
+    'cooldowns',
+    'eventHistory',
+  ],
+  attributes: [
+    RpgAttributeDefinition(
+      id: 'energy',
+      label: 'Energy',
+      initialValue: 3,
+      minimum: 0,
+      maximum: 5,
+    ),
+  ],
+  items: [RpgItemDefinition(id: 'relic', label: 'Relic')],
+  actors: [RpgActorDefinition(id: 'guide', label: 'Guide')],
+  locations: [RpgLocationDefinition(id: 'camp', label: 'Camp')],
+  quests: [RpgQuestDefinition(id: 'ruins', label: 'Explore the ruins')],
+  actions: [
+    RpgActionDefinition(
+      id: 'explore',
+      label: 'Explore',
+      costs: [RpgActionCost(path: 'attributes.energy', amount: 1)],
+      check: RpgSkillCheck(
+        attributeId: 'energy',
+        dice: RpgDiceSpec('1d1'),
+        difficulty: 1,
+        successEffects: [
+          RpgEffect(type: RpgEffectType.addItem, target: 'relic', amount: 1),
+          RpgEffect(
+            type: RpgEffectType.setQuestStatus,
+            target: 'ruins',
+            value: 'completed',
+          ),
+          RpgEffect(
+            type: RpgEffectType.adjustRelationship,
+            target: 'guide',
+            amount: 2,
+          ),
+        ],
+      ),
+    ),
+    RpgActionDefinition(
+      id: 'expensive',
+      label: 'Spend everything',
+      costs: [RpgActionCost(path: 'attributes.energy', amount: 99)],
+    ),
+  ],
+  initialState: RpgRuntimeState(
+    scenarioId: 'bridge_test',
+    scenarioVersion: '1.0.0',
+    random: RpgRandomState(initialSeed: 77, state: 77),
+    attributes: {'energy': 3},
+    relationships: [RpgRelationshipState(actorId: 'guide')],
+    locationId: 'camp',
+    quests: [RpgQuestState(questId: 'ruins', status: RpgQuestStatus.active)],
+  ),
+);


### PR DESCRIPTION
## Summary

- `C05` completed: inject authoritative RPG state, allowed actions, and narration constraints; parse a strict JSON action envelope; route proposals through the deterministic rule engine; buffer structured streaming responses; and surface malformed, rejected, cancelled, and committed outcomes without allowing LLM state patches.
- `C06` completed: add per-chat RPG mode, scenario selection/import, state/inventory/quest/relationship/action/log views, rule and roll feedback, snapshot restore, and branch creation with immediate persisted-state refresh.
- Preserve baseline chat requests and responses while RPG mode is disabled.

## Tests

- `flutter test` (full suite): 237 passed, 2 expected environment-gated skips
- Rebase integration suite: 23 passed across RPG narrative UI, chat extensions, generation pipeline, TTS chat E2E, and TTS autoplay
- Final RPG E2E on latest `main`: 6 passed
- Targeted `flutter analyze --no-fatal-infos --no-fatal-warnings`: no analyzer errors (existing warnings/info remain)
- `git diff --check`

Closes #28