### PR TITLE
feat(data-bank): add chat context and semantic reranking

### DIFF
--- a/lib/data/models/chat.dart
+++ b/lib/data/models/chat.dart
@@ -3,7 +3,7 @@ class ChatSummary {
   final String id;
   final String content; // Summarized content
   final int
-      endMessageIndex; // Index of the last message included in this summary
+  endMessageIndex; // Index of the last message included in this summary
   final DateTime createdAt;
 
   const ChatSummary({
@@ -14,18 +14,18 @@ class ChatSummary {
   });
 
   Map<String, dynamic> toJson() => {
-        'id': id,
-        'content': content,
-        'endMessageIndex': endMessageIndex,
-        'createdAt': createdAt.toIso8601String(),
-      };
+    'id': id,
+    'content': content,
+    'endMessageIndex': endMessageIndex,
+    'createdAt': createdAt.toIso8601String(),
+  };
 
   factory ChatSummary.fromJson(Map<String, dynamic> json) => ChatSummary(
-        id: json['id'] as String,
-        content: json['content'] as String,
-        endMessageIndex: json['endMessageIndex'] as int,
-        createdAt: DateTime.parse(json['createdAt'] as String),
-      );
+    id: json['id'] as String,
+    content: json['content'] as String,
+    endMessageIndex: json['endMessageIndex'] as int,
+    createdAt: DateTime.parse(json['createdAt'] as String),
+  );
 }
 
 /// Chat session model
@@ -38,7 +38,7 @@ class Chat {
   final int authorNoteDepth; // Depth for injection (messages from end)
   final bool authorNoteEnabled; // Whether Author's Note is active
   final List<ChatSummary>
-      summaries; // History summaries for context compression
+  summaries; // History summaries for context compression
 
   /// Per-chat settings (persisted as JSON):
   /// startReplyWith, linkedWorldInfoIds, ...
@@ -115,43 +115,40 @@ class Chat {
   }
 
   Map<String, dynamic> toJson() => {
-        'id': id,
-        'characterId': characterId,
-        'groupId': groupId,
-        'title': title,
-        'authorNote': authorNote,
-        'authorNoteDepth': authorNoteDepth,
-        'authorNoteEnabled': authorNoteEnabled,
-        'summaries': summaries.map((s) => s.toJson()).toList(),
-        'settings': settings,
-        'createdAt': createdAt.toIso8601String(),
-        'updatedAt': updatedAt.toIso8601String(),
-      };
+    'id': id,
+    'characterId': characterId,
+    'groupId': groupId,
+    'title': title,
+    'authorNote': authorNote,
+    'authorNoteDepth': authorNoteDepth,
+    'authorNoteEnabled': authorNoteEnabled,
+    'summaries': summaries.map((s) => s.toJson()).toList(),
+    'settings': settings,
+    'createdAt': createdAt.toIso8601String(),
+    'updatedAt': updatedAt.toIso8601String(),
+  };
 
   factory Chat.fromJson(Map<String, dynamic> json) => Chat(
-        id: json['id'] as String,
-        characterId: json['characterId'] as String,
-        groupId: json['groupId'] as String?,
-        title: json['title'] as String? ?? 'New Chat',
-        authorNote: json['authorNote'] as String? ?? '',
-        authorNoteDepth: json['authorNoteDepth'] as int? ?? 4,
-        authorNoteEnabled: json['authorNoteEnabled'] as bool? ?? false,
-        summaries: (json['summaries'] as List<dynamic>?)
-                ?.map((s) => ChatSummary.fromJson(s as Map<String, dynamic>))
-                .toList() ??
-            [],
-        settings: json['settings'] as Map<String, dynamic>? ?? const {},
-        createdAt: DateTime.parse(json['createdAt'] as String),
-        updatedAt: DateTime.parse(json['updatedAt'] as String),
-      );
+    id: json['id'] as String,
+    characterId: json['characterId'] as String,
+    groupId: json['groupId'] as String?,
+    title: json['title'] as String? ?? 'New Chat',
+    authorNote: json['authorNote'] as String? ?? '',
+    authorNoteDepth: json['authorNoteDepth'] as int? ?? 4,
+    authorNoteEnabled: json['authorNoteEnabled'] as bool? ?? false,
+    summaries:
+        (json['summaries'] as List<dynamic>?)
+            ?.map((s) => ChatSummary.fromJson(s as Map<String, dynamic>))
+            .toList() ??
+        [],
+    settings: json['settings'] as Map<String, dynamic>? ?? const {},
+    createdAt: DateTime.parse(json['createdAt'] as String),
+    updatedAt: DateTime.parse(json['updatedAt'] as String),
+  );
 }
 
 /// Message role enum
-enum MessageRole {
-  user,
-  assistant,
-  system,
-}
+enum MessageRole { user, assistant, system }
 
 /// Image attachment for chat messages
 class ChatAttachment {
@@ -172,22 +169,22 @@ class ChatAttachment {
   });
 
   Map<String, dynamic> toJson() => {
-        'id': id,
-        'path': path,
-        if (mimeType != null) 'mimeType': mimeType,
-        if (width != null) 'width': width,
-        if (height != null) 'height': height,
-        if (sizeBytes != null) 'sizeBytes': sizeBytes,
-      };
+    'id': id,
+    'path': path,
+    if (mimeType != null) 'mimeType': mimeType,
+    if (width != null) 'width': width,
+    if (height != null) 'height': height,
+    if (sizeBytes != null) 'sizeBytes': sizeBytes,
+  };
 
   factory ChatAttachment.fromJson(Map<String, dynamic> json) => ChatAttachment(
-        id: json['id'] as String,
-        path: json['path'] as String,
-        mimeType: json['mimeType'] as String?,
-        width: json['width'] as int?,
-        height: json['height'] as int?,
-        sizeBytes: json['sizeBytes'] as int?,
-      );
+    id: json['id'] as String,
+    path: json['path'] as String,
+    mimeType: json['mimeType'] as String?,
+    width: json['width'] as int?,
+    height: json['height'] as int?,
+    sizeBytes: json['sizeBytes'] as int?,
+  );
 }
 
 /// Chat message model
@@ -200,11 +197,12 @@ class ChatMessage {
   final List<String> swipes;
   final int currentSwipeIndex;
   final String?
-      characterId; // For group chats - which character sent this message
+  characterId; // For group chats - which character sent this message
   final String? characterName; // Cached character name for display
   final String? reasoning; // Chain of Thought / Thinking content from LLM
   final List<String>? reasoningSwipes; // Reasoning content for each swipe
   final List<ChatAttachment> attachments; // Image attachments
+  final Map<String, dynamic> metadata;
 
   const ChatMessage({
     required this.id,
@@ -219,6 +217,7 @@ class ChatMessage {
     this.reasoning,
     this.reasoningSwipes,
     this.attachments = const [],
+    this.metadata = const {},
   });
 
   /// Get the current reasoning content (for current swipe)
@@ -252,6 +251,7 @@ class ChatMessage {
     String? reasoning,
     List<String>? reasoningSwipes,
     List<ChatAttachment>? attachments,
+    Map<String, dynamic>? metadata,
     bool clearCharacterId = false,
     bool clearCharacterName = false,
     bool clearReasoning = false,
@@ -265,50 +265,58 @@ class ChatMessage {
       swipes: swipes ?? this.swipes,
       currentSwipeIndex: currentSwipeIndex ?? this.currentSwipeIndex,
       characterId: clearCharacterId ? null : (characterId ?? this.characterId),
-      characterName:
-          clearCharacterName ? null : (characterName ?? this.characterName),
+      characterName: clearCharacterName
+          ? null
+          : (characterName ?? this.characterName),
       reasoning: clearReasoning ? null : (reasoning ?? this.reasoning),
-      reasoningSwipes:
-          clearReasoning ? null : (reasoningSwipes ?? this.reasoningSwipes),
+      reasoningSwipes: clearReasoning
+          ? null
+          : (reasoningSwipes ?? this.reasoningSwipes),
       attachments: attachments ?? this.attachments,
+      metadata: metadata ?? this.metadata,
     );
   }
 
   Map<String, dynamic> toJson() => {
-        'id': id,
-        'chatId': chatId,
-        'role': role.name,
-        'content': content,
-        'timestamp': timestamp.toIso8601String(),
-        'swipes': swipes,
-        'currentSwipeIndex': currentSwipeIndex,
-        'characterId': characterId,
-        'characterName': characterName,
-        if (reasoning != null) 'reasoning': reasoning,
-        if (reasoningSwipes != null) 'reasoningSwipes': reasoningSwipes,
-        if (attachments.isNotEmpty)
-          'attachments': attachments.map((a) => a.toJson()).toList(),
-      };
+    'id': id,
+    'chatId': chatId,
+    'role': role.name,
+    'content': content,
+    'timestamp': timestamp.toIso8601String(),
+    'swipes': swipes,
+    'currentSwipeIndex': currentSwipeIndex,
+    'characterId': characterId,
+    'characterName': characterName,
+    if (reasoning != null) 'reasoning': reasoning,
+    if (reasoningSwipes != null) 'reasoningSwipes': reasoningSwipes,
+    if (attachments.isNotEmpty)
+      'attachments': attachments.map((a) => a.toJson()).toList(),
+    if (metadata.isNotEmpty) 'metadata': metadata,
+  };
 
   factory ChatMessage.fromJson(Map<String, dynamic> json) => ChatMessage(
-        id: json['id'] as String,
-        chatId: json['chatId'] as String,
-        role: MessageRole.values.firstWhere(
-          (r) => r.name == json['role'],
-          orElse: () => MessageRole.user,
-        ),
-        content: json['content'] as String,
-        timestamp: DateTime.parse(json['timestamp'] as String),
-        swipes: (json['swipes'] as List<dynamic>?)?.cast<String>() ?? [],
-        currentSwipeIndex: json['currentSwipeIndex'] as int? ?? 0,
-        characterId: json['characterId'] as String?,
-        characterName: json['characterName'] as String?,
-        reasoning: json['reasoning'] as String?,
-        reasoningSwipes:
-            (json['reasoningSwipes'] as List<dynamic>?)?.cast<String>(),
-        attachments: (json['attachments'] as List<dynamic>?)
-                ?.map((a) => ChatAttachment.fromJson(a as Map<String, dynamic>))
-                .toList() ??
-            [],
-      );
+    id: json['id'] as String,
+    chatId: json['chatId'] as String,
+    role: MessageRole.values.firstWhere(
+      (r) => r.name == json['role'],
+      orElse: () => MessageRole.user,
+    ),
+    content: json['content'] as String,
+    timestamp: DateTime.parse(json['timestamp'] as String),
+    swipes: (json['swipes'] as List<dynamic>?)?.cast<String>() ?? [],
+    currentSwipeIndex: json['currentSwipeIndex'] as int? ?? 0,
+    characterId: json['characterId'] as String?,
+    characterName: json['characterName'] as String?,
+    reasoning: json['reasoning'] as String?,
+    reasoningSwipes: (json['reasoningSwipes'] as List<dynamic>?)
+        ?.cast<String>(),
+    attachments:
+        (json['attachments'] as List<dynamic>?)
+            ?.map((a) => ChatAttachment.fromJson(a as Map<String, dynamic>))
+            .toList() ??
+        [],
+    metadata: json['metadata'] is Map
+        ? Map<String, dynamic>.from(json['metadata'] as Map)
+        : const {},
+  );
 }

--- a/lib/data/models/data_bank_context.dart
+++ b/lib/data/models/data_bank_context.dart
@@ -1,0 +1,246 @@
+import 'package:native_tavern/data/models/data_bank.dart';
+
+const dataBankContextsMetadataKey = 'dataBankContexts';
+
+enum DataBankRetrievalMode { localFts, semanticReranked, semanticFallback }
+
+final class DataBankContextSettings {
+  final bool enabled;
+  final bool queryRewriteEnabled;
+  final bool semanticRerankingEnabled;
+  final int topK;
+  final int maxTokens;
+  final int maxChunksPerDocument;
+  final double semanticWeight;
+
+  const DataBankContextSettings({
+    this.enabled = true,
+    this.queryRewriteEnabled = false,
+    this.semanticRerankingEnabled = false,
+    this.topK = 6,
+    this.maxTokens = 1200,
+    this.maxChunksPerDocument = 2,
+    this.semanticWeight = 0.65,
+  });
+
+  factory DataBankContextSettings.fromJson(Map<String, dynamic> json) {
+    return DataBankContextSettings(
+      enabled: json['enabled'] as bool? ?? true,
+      queryRewriteEnabled: json['queryRewriteEnabled'] as bool? ?? false,
+      semanticRerankingEnabled:
+          json['semanticRerankingEnabled'] as bool? ?? false,
+      topK: _boundedInt(json['topK'], fallback: 6, minimum: 1, maximum: 20),
+      maxTokens: _boundedInt(
+        json['maxTokens'],
+        fallback: 1200,
+        minimum: 128,
+        maximum: 4096,
+      ),
+      maxChunksPerDocument: _boundedInt(
+        json['maxChunksPerDocument'],
+        fallback: 2,
+        minimum: 1,
+        maximum: 10,
+      ),
+      semanticWeight: ((json['semanticWeight'] as num?)?.toDouble() ?? 0.65)
+          .clamp(0.0, 1.0),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'enabled': enabled,
+        'queryRewriteEnabled': queryRewriteEnabled,
+        'semanticRerankingEnabled': semanticRerankingEnabled,
+        'topK': topK,
+        'maxTokens': maxTokens,
+        'maxChunksPerDocument': maxChunksPerDocument,
+        'semanticWeight': semanticWeight,
+      };
+
+  DataBankContextSettings copyWith({
+    bool? enabled,
+    bool? queryRewriteEnabled,
+    bool? semanticRerankingEnabled,
+    int? topK,
+    int? maxTokens,
+    int? maxChunksPerDocument,
+    double? semanticWeight,
+  }) {
+    return DataBankContextSettings.fromJson({
+      'enabled': enabled ?? this.enabled,
+      'queryRewriteEnabled': queryRewriteEnabled ?? this.queryRewriteEnabled,
+      'semanticRerankingEnabled':
+          semanticRerankingEnabled ?? this.semanticRerankingEnabled,
+      'topK': topK ?? this.topK,
+      'maxTokens': maxTokens ?? this.maxTokens,
+      'maxChunksPerDocument': maxChunksPerDocument ?? this.maxChunksPerDocument,
+      'semanticWeight': semanticWeight ?? this.semanticWeight,
+    });
+  }
+}
+
+final class DataBankContextSource {
+  final String label;
+  final String documentName;
+  final String snippet;
+  final String injectedText;
+  final DataBankCitation citation;
+
+  const DataBankContextSource({
+    required this.label,
+    required this.documentName,
+    required this.snippet,
+    required this.injectedText,
+    required this.citation,
+  });
+
+  factory DataBankContextSource.fromJson(Map<String, dynamic> json) {
+    return DataBankContextSource(
+      label: json['label'] as String,
+      documentName: json['documentName'] as String,
+      snippet: json['snippet'] as String,
+      injectedText: json['injectedText'] as String,
+      citation: DataBankCitation.fromJson(
+        Map<String, dynamic>.from(json['citation'] as Map),
+      ),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'label': label,
+        'documentName': documentName,
+        'snippet': snippet,
+        'injectedText': injectedText,
+        'citation': citation.toJson(),
+      };
+
+  String get locationLabel {
+    final locator = citation.locator;
+    final details = [
+      if (locator.chapter != null) locator.chapter!,
+      if (locator.pageStart != null)
+        locator.effectivePageEnd == locator.pageStart
+            ? 'p. ${locator.pageStart}'
+            : 'pp. ${locator.pageStart}-${locator.effectivePageEnd}',
+      if (locator.startOffset != null)
+        'chars ${locator.startOffset}-${locator.endOffset}',
+    ];
+    if (details.isNotEmpty) return details.join(' | ');
+    return locator.sectionId == null ? '' : 'Section ${locator.sectionId}';
+  }
+}
+
+final class DataBankContextSnapshot {
+  final String sessionId;
+  final String originalQuery;
+  final List<String> queries;
+  final DataBankRetrievalMode mode;
+  final List<DataBankContextSource> sources;
+  final String? fallbackReason;
+
+  const DataBankContextSnapshot({
+    required this.sessionId,
+    required this.originalQuery,
+    required this.queries,
+    required this.mode,
+    required this.sources,
+    this.fallbackReason,
+  });
+
+  factory DataBankContextSnapshot.fromJson(Map<String, dynamic> json) {
+    return DataBankContextSnapshot(
+      sessionId: json['sessionId'] as String? ?? '',
+      originalQuery: json['originalQuery'] as String? ?? '',
+      queries: (json['queries'] as List<dynamic>? ?? const [])
+          .whereType<String>()
+          .toList(growable: false),
+      mode: DataBankRetrievalMode.values.firstWhere(
+        (value) => value.name == json['mode'],
+        orElse: () => DataBankRetrievalMode.localFts,
+      ),
+      sources: (json['sources'] as List<dynamic>? ?? const [])
+          .whereType<Map<Object?, Object?>>()
+          .map(
+            (value) => DataBankContextSource.fromJson(
+              Map<String, dynamic>.from(value),
+            ),
+          )
+          .toList(growable: false),
+      fallbackReason: json['fallbackReason'] as String?,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'sessionId': sessionId,
+        'originalQuery': originalQuery,
+        'queries': queries,
+        'mode': mode.name,
+        'sources': sources.map((source) => source.toJson()).toList(),
+        if (fallbackReason != null) 'fallbackReason': fallbackReason,
+      };
+}
+
+DataBankContextSnapshot? dataBankContextForSwipe(
+  Map<String, dynamic> metadata,
+  int swipeIndex,
+) {
+  final contexts = metadata[dataBankContextsMetadataKey];
+  if (contexts is! List || swipeIndex < 0 || swipeIndex >= contexts.length) {
+    return null;
+  }
+  final value = contexts[swipeIndex];
+  if (value is! Map) return null;
+  try {
+    return DataBankContextSnapshot.fromJson(Map<String, dynamic>.from(value));
+  } catch (_) {
+    return null;
+  }
+}
+
+Map<String, dynamic> appendDataBankContextMetadata({
+  required Map<String, dynamic> metadata,
+  required int existingSwipeCount,
+  required DataBankContextSnapshot? snapshot,
+}) {
+  final updated = Map<String, dynamic>.from(metadata);
+  final existing = updated[dataBankContextsMetadataKey];
+  final contexts =
+      existing is List ? List<dynamic>.from(existing) : <dynamic>[];
+  while (contexts.length < existingSwipeCount) {
+    contexts.add(null);
+  }
+  contexts.add(snapshot?.toJson());
+  if (contexts.any((value) => value != null)) {
+    updated[dataBankContextsMetadataKey] = contexts;
+  } else {
+    updated.remove(dataBankContextsMetadataKey);
+  }
+  return updated;
+}
+
+Map<String, dynamic> removeDataBankContextMetadataAt({
+  required Map<String, dynamic> metadata,
+  required int swipeIndex,
+}) {
+  final updated = Map<String, dynamic>.from(metadata);
+  final existing = updated[dataBankContextsMetadataKey];
+  if (existing is! List || swipeIndex < 0 || swipeIndex >= existing.length) {
+    return updated;
+  }
+  final contexts = List<dynamic>.from(existing)..removeAt(swipeIndex);
+  if (contexts.any((value) => value != null)) {
+    updated[dataBankContextsMetadataKey] = contexts;
+  } else {
+    updated.remove(dataBankContextsMetadataKey);
+  }
+  return updated;
+}
+
+int _boundedInt(
+  Object? value, {
+  required int fallback,
+  required int minimum,
+  required int maximum,
+}) {
+  return (value is num ? value.toInt() : fallback).clamp(minimum, maximum);
+}

--- a/lib/data/repositories/chat_repository.dart
+++ b/lib/data/repositories/chat_repository.dart
@@ -20,34 +20,37 @@ class ChatRepository {
 
   /// Get all chats
   Future<List<models.Chat>> getAllChats() async {
-    final rows = await (_db.select(_db.chats)
-          ..orderBy([(t) => OrderingTerm.desc(t.updatedAt)]))
-        .get();
+    final rows = await (_db.select(
+      _db.chats,
+    )..orderBy([(t) => OrderingTerm.desc(t.updatedAt)])).get();
     return rows.map(_chatFromRow).toList();
   }
 
   /// Get chats for a specific character
   Future<List<models.Chat>> getChatsForCharacter(String characterId) async {
-    final rows = await (_db.select(_db.chats)
-          ..where((t) => t.characterId.equals(characterId))
-          ..orderBy([(t) => OrderingTerm.desc(t.updatedAt)]))
-        .get();
+    final rows =
+        await (_db.select(_db.chats)
+              ..where((t) => t.characterId.equals(characterId))
+              ..orderBy([(t) => OrderingTerm.desc(t.updatedAt)]))
+            .get();
     return rows.map(_chatFromRow).toList();
   }
 
   /// Get recent chats
   Future<List<models.Chat>> getRecentChats({int limit = 10}) async {
-    final rows = await (_db.select(_db.chats)
-          ..orderBy([(t) => OrderingTerm.desc(t.updatedAt)])
-          ..limit(limit))
-        .get();
+    final rows =
+        await (_db.select(_db.chats)
+              ..orderBy([(t) => OrderingTerm.desc(t.updatedAt)])
+              ..limit(limit))
+            .get();
     return rows.map(_chatFromRow).toList();
   }
 
   /// Get chat by ID
   Future<models.Chat?> getChat(String id) async {
-    final row = await (_db.select(_db.chats)..where((t) => t.id.equals(id)))
-        .getSingleOrNull();
+    final row = await (_db.select(
+      _db.chats,
+    )..where((t) => t.id.equals(id))).getSingleOrNull();
     return row != null ? _chatFromRow(row) : null;
   }
 
@@ -70,18 +73,22 @@ class ChatRepository {
       updatedAt: now,
     );
 
-    await _db.into(_db.chats).insert(ChatsCompanion(
-          id: Value(newChat.id),
-          characterId: Value(newChat.characterId),
-          groupId: Value(newChat.groupId),
-          title: Value(newChat.title),
-          authorNote: Value(newChat.authorNote),
-          authorNoteDepth: Value(newChat.authorNoteDepth),
-          authorNoteEnabled: Value(newChat.authorNoteEnabled),
-          settingsJson: Value(_encodeSettings(newChat)),
-          createdAt: Value(newChat.createdAt),
-          updatedAt: Value(newChat.updatedAt),
-        ));
+    await _db
+        .into(_db.chats)
+        .insert(
+          ChatsCompanion(
+            id: Value(newChat.id),
+            characterId: Value(newChat.characterId),
+            groupId: Value(newChat.groupId),
+            title: Value(newChat.title),
+            authorNote: Value(newChat.authorNote),
+            authorNoteDepth: Value(newChat.authorNoteDepth),
+            authorNoteEnabled: Value(newChat.authorNoteEnabled),
+            settingsJson: Value(_encodeSettings(newChat)),
+            createdAt: Value(newChat.createdAt),
+            updatedAt: Value(newChat.updatedAt),
+          ),
+        );
 
     return newChat;
   }
@@ -90,15 +97,16 @@ class ChatRepository {
   Future<models.Chat> updateChat(models.Chat chat) async {
     final now = DateTime.now();
 
-    await (_db.update(_db.chats)..where((t) => t.id.equals(chat.id)))
-        .write(ChatsCompanion(
-      title: Value(chat.title),
-      authorNote: Value(chat.authorNote),
-      authorNoteDepth: Value(chat.authorNoteDepth),
-      authorNoteEnabled: Value(chat.authorNoteEnabled),
-      settingsJson: Value(_encodeSettings(chat)),
-      updatedAt: Value(now),
-    ));
+    await (_db.update(_db.chats)..where((t) => t.id.equals(chat.id))).write(
+      ChatsCompanion(
+        title: Value(chat.title),
+        authorNote: Value(chat.authorNote),
+        authorNoteDepth: Value(chat.authorNoteDepth),
+        authorNoteEnabled: Value(chat.authorNoteEnabled),
+        settingsJson: Value(_encodeSettings(chat)),
+        updatedAt: Value(now),
+      ),
+    );
 
     return chat.copyWith(updatedAt: now);
   }
@@ -114,10 +122,11 @@ class ChatRepository {
 
   /// Get messages for a chat
   Future<List<models.ChatMessage>> getMessages(String chatId) async {
-    final rows = await (_db.select(_db.messages)
-          ..where((t) => t.chatId.equals(chatId))
-          ..orderBy([(t) => OrderingTerm.asc(t.timestamp)]))
-        .get();
+    final rows =
+        await (_db.select(_db.messages)
+              ..where((t) => t.chatId.equals(chatId))
+              ..orderBy([(t) => OrderingTerm.asc(t.timestamp)]))
+            .get();
     return rows.map(_messageFromRow).toList();
   }
 
@@ -127,19 +136,27 @@ class ChatRepository {
 
     final newMessage = message.copyWith(id: id);
 
-    await _db.into(_db.messages).insert(MessagesCompanion(
-          id: Value(newMessage.id),
-          chatId: Value(newMessage.chatId),
-          role: Value(newMessage.role.name),
-          content: Value(newMessage.content),
-          timestamp: Value(newMessage.timestamp),
-          swipes: Value(jsonEncode(newMessage.swipes)),
-          currentSwipeIndex: Value(newMessage.currentSwipeIndex),
-          characterId: Value(newMessage.characterId),
-          characterName: Value(newMessage.characterName),
-          attachmentsJson: Value(jsonEncode(
-              newMessage.attachments.map((a) => a.toJson()).toList())),
-        ));
+    await _db
+        .into(_db.messages)
+        .insert(
+          MessagesCompanion(
+            id: Value(newMessage.id),
+            chatId: Value(newMessage.chatId),
+            role: Value(newMessage.role.name),
+            content: Value(newMessage.content),
+            timestamp: Value(newMessage.timestamp),
+            swipes: Value(jsonEncode(newMessage.swipes)),
+            currentSwipeIndex: Value(newMessage.currentSwipeIndex),
+            characterId: Value(newMessage.characterId),
+            characterName: Value(newMessage.characterName),
+            metadataJson: Value(jsonEncode(newMessage.metadata)),
+            attachmentsJson: Value(
+              jsonEncode(
+                newMessage.attachments.map((a) => a.toJson()).toList(),
+              ),
+            ),
+          ),
+        );
 
     // Update chat's updatedAt
     await (_db.update(_db.chats)..where((t) => t.id.equals(message.chatId)))
@@ -150,16 +167,21 @@ class ChatRepository {
 
   /// Update a message
   Future<models.ChatMessage> updateMessage(models.ChatMessage message) async {
-    await (_db.update(_db.messages)..where((t) => t.id.equals(message.id)))
-        .write(MessagesCompanion(
-      content: Value(message.content),
-      swipes: Value(jsonEncode(message.swipes)),
-      currentSwipeIndex: Value(message.currentSwipeIndex),
-      characterId: Value(message.characterId),
-      characterName: Value(message.characterName),
-      attachmentsJson: Value(
-          jsonEncode(message.attachments.map((a) => a.toJson()).toList())),
-    ));
+    await (_db.update(
+      _db.messages,
+    )..where((t) => t.id.equals(message.id))).write(
+      MessagesCompanion(
+        content: Value(message.content),
+        swipes: Value(jsonEncode(message.swipes)),
+        currentSwipeIndex: Value(message.currentSwipeIndex),
+        characterId: Value(message.characterId),
+        characterName: Value(message.characterName),
+        metadataJson: Value(jsonEncode(message.metadata)),
+        attachmentsJson: Value(
+          jsonEncode(message.attachments.map((a) => a.toJson()).toList()),
+        ),
+      ),
+    );
 
     // Update chat's updatedAt
     await (_db.update(_db.chats)..where((t) => t.id.equals(message.chatId)))
@@ -176,10 +198,12 @@ class ChatRepository {
   /// Delete all messages and message-dependent data while keeping the chat.
   Future<void> clearMessages(String chatId) async {
     await _db.transaction(() async {
-      await (_db.delete(_db.bookmarks)..where((t) => t.chatId.equals(chatId)))
-          .go();
-      await (_db.delete(_db.messages)..where((t) => t.chatId.equals(chatId)))
-          .go();
+      await (_db.delete(
+        _db.bookmarks,
+      )..where((t) => t.chatId.equals(chatId))).go();
+      await (_db.delete(
+        _db.messages,
+      )..where((t) => t.chatId.equals(chatId))).go();
       await (_db.update(_db.chats)..where((t) => t.id.equals(chatId))).write(
         ChatsCompanion(updatedAt: Value(DateTime.now())),
       );
@@ -188,28 +212,30 @@ class ChatRepository {
 
   /// Get message count for a chat
   Future<int> getMessageCount(String chatId) async {
-    final messages = await (_db.select(_db.messages)
-          ..where((t) => t.chatId.equals(chatId)))
-        .get();
+    final messages = await (_db.select(
+      _db.messages,
+    )..where((t) => t.chatId.equals(chatId))).get();
     return messages.length;
   }
 
   /// Get last message of a chat
   Future<models.ChatMessage?> getLastMessage(String chatId) async {
-    final row = await (_db.select(_db.messages)
-          ..where((t) => t.chatId.equals(chatId))
-          ..orderBy([(t) => OrderingTerm.desc(t.timestamp)])
-          ..limit(1))
-        .getSingleOrNull();
+    final row =
+        await (_db.select(_db.messages)
+              ..where((t) => t.chatId.equals(chatId))
+              ..orderBy([(t) => OrderingTerm.desc(t.timestamp)])
+              ..limit(1))
+            .getSingleOrNull();
     return row != null ? _messageFromRow(row) : null;
   }
 
   /// Get chats for a group
   Future<List<models.Chat>> getChatsForGroup(String groupId) async {
-    final rows = await (_db.select(_db.chats)
-          ..where((t) => t.groupId.equals(groupId))
-          ..orderBy([(t) => OrderingTerm.desc(t.updatedAt)]))
-        .get();
+    final rows =
+        await (_db.select(_db.chats)
+              ..where((t) => t.groupId.equals(groupId))
+              ..orderBy([(t) => OrderingTerm.desc(t.updatedAt)]))
+            .get();
     return rows.map(_chatFromRow).toList();
   }
 
@@ -231,7 +257,8 @@ class ChatRepository {
       authorNoteDepth: row.authorNoteDepth,
       authorNoteEnabled: row.authorNoteEnabled,
       settings: settings,
-      summaries: (settings['summaries'] as List<dynamic>?)
+      summaries:
+          (settings['summaries'] as List<dynamic>?)
               ?.whereType<Map<String, dynamic>>()
               .map(models.ChatSummary.fromJson)
               .toList() ??
@@ -262,6 +289,7 @@ class ChatRepository {
       currentSwipeIndex: row.currentSwipeIndex,
       characterId: row.characterId,
       characterName: row.characterName,
+      metadata: _parseMetadata(row.metadataJson),
       attachments: _parseAttachments(row.attachmentsJson),
     );
   }
@@ -279,11 +307,21 @@ class ChatRepository {
     try {
       final list = jsonDecode(json) as List;
       return list
-          .map((item) =>
-              models.ChatAttachment.fromJson(item as Map<String, dynamic>))
+          .map(
+            (item) =>
+                models.ChatAttachment.fromJson(item as Map<String, dynamic>),
+          )
           .toList();
     } catch (_) {
       return [];
+    }
+  }
+
+  Map<String, dynamic> _parseMetadata(String json) {
+    try {
+      return Map<String, dynamic>.from(jsonDecode(json) as Map);
+    } catch (_) {
+      return const {};
     }
   }
 }

--- a/lib/domain/services/data_bank_context_service.dart
+++ b/lib/domain/services/data_bank_context_service.dart
@@ -1,0 +1,434 @@
+import 'dart:math';
+
+import 'package:native_tavern/data/models/data_bank_context.dart';
+import 'package:native_tavern/data/models/vector_storage.dart';
+import 'package:native_tavern/domain/repositories/data_bank_repository.dart';
+import 'package:native_tavern/domain/services/chat_generation_pipeline.dart';
+import 'package:native_tavern/domain/services/tokenizer_service.dart';
+
+typedef DataBankEmbeddingBatch = Future<List<List<double>>> Function(
+  List<String> texts,
+  VectorStorageSettings settings,
+);
+
+abstract interface class DataBankQueryRewriter {
+  List<String> rewrite(ChatContextRequest request, String latestQuery);
+}
+
+final class RecentConversationDataBankQueryRewriter
+    implements DataBankQueryRewriter {
+  final int maxQueries;
+
+  const RecentConversationDataBankQueryRewriter({this.maxQueries = 3});
+
+  @override
+  List<String> rewrite(ChatContextRequest request, String latestQuery) {
+    final queries = <String>[latestQuery];
+    for (final message in request.baseMessages.reversed) {
+      if (message['role'] != 'user') continue;
+      final text = dataBankTextFromMessage(message).trim();
+      if (text.isEmpty || text == latestQuery || queries.contains(text)) {
+        continue;
+      }
+      queries.add(text);
+      if (queries.length >= maxQueries) break;
+    }
+    return List<String>.unmodifiable(queries);
+  }
+}
+
+final class DataBankContextPayload {
+  final DataBankContextSnapshot snapshot;
+  final String? prompt;
+
+  const DataBankContextPayload({required this.snapshot, this.prompt});
+}
+
+final class DataBankContextService {
+  final DataBankSearchRepository _repository;
+  final DataBankEmbeddingBatch? _embedBatch;
+  final DataBankQueryRewriter _queryRewriter;
+  final TokenizerService _tokenizer;
+
+  DataBankContextService({
+    required DataBankSearchRepository repository,
+    DataBankEmbeddingBatch? embedBatch,
+    DataBankQueryRewriter queryRewriter =
+        const RecentConversationDataBankQueryRewriter(),
+    TokenizerService? tokenizer,
+  })  : _repository = repository,
+        _embedBatch = embedBatch,
+        _queryRewriter = queryRewriter,
+        _tokenizer = tokenizer ?? TokenizerService();
+
+  Future<DataBankContextPayload> retrieve({
+    required ChatContextRequest request,
+    required DataBankContextSettings settings,
+    required VectorStorageSettings embeddingSettings,
+  }) async {
+    final originalQuery = latestDataBankQuery(request.baseMessages);
+    final queries = originalQuery.isEmpty
+        ? const <String>[]
+        : settings.queryRewriteEnabled
+            ? _queryRewriter.rewrite(request, originalQuery)
+            : <String>[originalQuery];
+    final normalizedQueries = queries
+        .map((query) => query.trim())
+        .where((query) => query.isNotEmpty)
+        .toSet()
+        .toList(growable: false);
+    if (normalizedQueries.isEmpty) {
+      return DataBankContextPayload(
+        snapshot: DataBankContextSnapshot(
+          sessionId: request.sessionId,
+          originalQuery: originalQuery,
+          queries: const [],
+          mode: DataBankRetrievalMode.localFts,
+          sources: const [],
+        ),
+      );
+    }
+
+    final candidates = await _retrieveFused(
+      normalizedQueries,
+      topK: max(20, settings.topK * 4),
+      filter: DataBankSearchFilter.forContext(
+        characterId: request.characterId,
+        chatId: request.chatId,
+      ),
+    );
+    var ranked = candidates;
+    var mode = DataBankRetrievalMode.localFts;
+    String? fallbackReason;
+    if (settings.semanticRerankingEnabled && candidates.isNotEmpty) {
+      try {
+        ranked = await _semanticRerank(
+          query: originalQuery,
+          candidates: candidates,
+          settings: embeddingSettings,
+          semanticWeight: settings.semanticWeight,
+        );
+        mode = DataBankRetrievalMode.semanticReranked;
+      } catch (error) {
+        ranked = candidates;
+        mode = DataBankRetrievalMode.semanticFallback;
+        fallbackReason = error.toString();
+      }
+    }
+
+    final diverse = _selectDiverse(
+      ranked,
+      topK: settings.topK,
+      maxPerDocument: settings.maxChunksPerDocument,
+    );
+    final assembled = _assemblePrompt(
+      diverse,
+      maxTokens: min(settings.maxTokens, request.availableContributionTokens),
+    );
+    return DataBankContextPayload(
+      snapshot: DataBankContextSnapshot(
+        sessionId: request.sessionId,
+        originalQuery: originalQuery,
+        queries: normalizedQueries,
+        mode: mode,
+        sources: assembled.sources,
+        fallbackReason: fallbackReason,
+      ),
+      prompt: assembled.prompt,
+    );
+  }
+
+  Future<List<DataBankSearchResult>> _retrieveFused(
+    List<String> queries, {
+    required int topK,
+    required DataBankSearchFilter filter,
+  }) async {
+    final fused = <String, _FusedResult>{};
+    for (var queryIndex = 0; queryIndex < queries.length; queryIndex++) {
+      final results = await _repository.search(
+        queries[queryIndex],
+        topK: topK,
+        filter: filter,
+      );
+      final queryWeight = (queries.length - queryIndex) / queries.length;
+      for (var rankIndex = 0; rankIndex < results.length; rankIndex++) {
+        final result = results[rankIndex];
+        final score = queryWeight / (60 + rankIndex + 1);
+        final existing = fused[result.chunk.id];
+        if (existing == null) {
+          fused[result.chunk.id] = _FusedResult(result, score);
+        } else {
+          existing.score += score;
+        }
+      }
+    }
+    final ordered = fused.values.toList()
+      ..sort((left, right) {
+        final byScore = right.score.compareTo(left.score);
+        if (byScore != 0) return byScore;
+        final byRank = left.result.rank.compareTo(right.result.rank);
+        if (byRank != 0) return byRank;
+        return left.result.chunk.id.compareTo(right.result.chunk.id);
+      });
+    return ordered.map((item) => item.result).toList(growable: false);
+  }
+
+  Future<List<DataBankSearchResult>> _semanticRerank({
+    required String query,
+    required List<DataBankSearchResult> candidates,
+    required VectorStorageSettings settings,
+    required double semanticWeight,
+  }) async {
+    final embedBatch = _embedBatch;
+    if (embedBatch == null) {
+      throw StateError('Embedding service is unavailable.');
+    }
+    final embeddings = await embedBatch([
+      query,
+      ...candidates.map((result) => result.chunk.text),
+    ], settings);
+    if (embeddings.length != candidates.length + 1 ||
+        embeddings.first.isEmpty) {
+      throw const FormatException('Embedding response size is invalid.');
+    }
+    final queryEmbedding = embeddings.first;
+    final scored = <_SemanticResult>[];
+    for (var index = 0; index < candidates.length; index++) {
+      final embedding = embeddings[index + 1];
+      if (embedding.length != queryEmbedding.length || embedding.isEmpty) {
+        throw const FormatException('Embedding dimensions do not match.');
+      }
+      final semanticScore = (_cosine(queryEmbedding, embedding) + 1) / 2;
+      final localScore = 1 / (index + 1);
+      scored.add(
+        _SemanticResult(
+          candidates[index],
+          semanticWeight * semanticScore + (1 - semanticWeight) * localScore,
+          index,
+        ),
+      );
+    }
+    scored.sort((left, right) {
+      final byScore = right.score.compareTo(left.score);
+      if (byScore != 0) return byScore;
+      return left.localIndex.compareTo(right.localIndex);
+    });
+    return scored.map((item) => item.result).toList(growable: false);
+  }
+
+  List<DataBankSearchResult> _selectDiverse(
+    List<DataBankSearchResult> candidates, {
+    required int topK,
+    required int maxPerDocument,
+  }) {
+    final selected = <DataBankSearchResult>[];
+    final selectedChunks = <String>{};
+    final perDocument = <String, int>{};
+
+    for (final result in candidates) {
+      final documentId = result.citation.documentId;
+      if (perDocument.containsKey(documentId)) continue;
+      selected.add(result);
+      selectedChunks.add(result.chunk.id);
+      perDocument[documentId] = 1;
+      if (selected.length >= topK) return selected;
+    }
+    for (final result in candidates) {
+      if (selectedChunks.contains(result.chunk.id)) continue;
+      final documentId = result.citation.documentId;
+      final count = perDocument[documentId] ?? 0;
+      if (count >= maxPerDocument) continue;
+      selected.add(result);
+      selectedChunks.add(result.chunk.id);
+      perDocument[documentId] = count + 1;
+      if (selected.length >= topK) break;
+    }
+    return selected;
+  }
+
+  _AssembledDataBankPrompt _assemblePrompt(
+    List<DataBankSearchResult> results, {
+    required int maxTokens,
+  }) {
+    if (results.isEmpty || maxTokens < 24) {
+      return const _AssembledDataBankPrompt(null, []);
+    }
+    const intro = 'Relevant Data Bank sources for the current request follow. '
+        'Use them only when relevant and preserve the source labels when '
+        'referring to factual details.';
+    final blocks = <String>[];
+    final sources = <DataBankContextSource>[];
+    for (final result in results) {
+      final label = 'D${sources.length + 1}';
+      var quote = result.chunk.text.trim();
+      var block = _sourceBlock(result, label, quote);
+      var candidatePrompt = _joinPrompt(intro, [...blocks, block]);
+      if (_messageTokens(candidatePrompt) > maxTokens) {
+        final remainingTokens =
+            maxTokens - _messageTokens(_joinPrompt(intro, blocks));
+        if (remainingTokens < 32) continue;
+        final maximumCharacters = max(
+          24,
+          ((remainingTokens - 20) * TokenizerService.charsPerTokenRatio)
+              .floor(),
+        );
+        if (quote.length <= maximumCharacters) continue;
+        quote = '${quote.substring(0, maximumCharacters)}\n[truncated]';
+        block = _sourceBlock(result, label, quote);
+        candidatePrompt = _joinPrompt(intro, [...blocks, block]);
+        while (
+            _messageTokens(candidatePrompt) > maxTokens && quote.length > 40) {
+          final end = max(24, quote.length - 16);
+          quote = '${quote.substring(0, end)}\n[truncated]';
+          block = _sourceBlock(result, label, quote);
+          candidatePrompt = _joinPrompt(intro, [...blocks, block]);
+        }
+        if (_messageTokens(candidatePrompt) > maxTokens) continue;
+      }
+      blocks.add(block);
+      sources.add(
+        DataBankContextSource(
+          label: label,
+          documentName: result.documentName,
+          snippet: result.snippet,
+          injectedText: quote,
+          citation: result.citation,
+        ),
+      );
+    }
+    if (sources.isEmpty) return const _AssembledDataBankPrompt(null, []);
+    return _AssembledDataBankPrompt(_joinPrompt(intro, blocks), sources);
+  }
+
+  int _messageTokens(String text) => _tokenizer.estimateTokenCount(text) + 4;
+}
+
+final class DataBankContextContributor extends ContextContributor {
+  final DataBankContextService _service;
+  final DataBankContextSettings Function() _settings;
+  final VectorStorageSettings Function() _embeddingSettings;
+  final void Function(DataBankContextSnapshot snapshot)? _onRetrieved;
+
+  DataBankContextContributor({
+    required DataBankContextService service,
+    required DataBankContextSettings Function() settings,
+    required VectorStorageSettings Function() embeddingSettings,
+    void Function(DataBankContextSnapshot snapshot)? onRetrieved,
+  })  : _service = service,
+        _settings = settings,
+        _embeddingSettings = embeddingSettings,
+        _onRetrieved = onRetrieved;
+
+  @override
+  String get id => 'data-bank.retrieval';
+
+  @override
+  int get order => 300;
+
+  @override
+  int get maxTokens => _settings().maxTokens;
+
+  @override
+  bool isEnabled(ChatContextRequest request) => _settings().enabled;
+
+  @override
+  Future<ContextContribution> contribute(ChatContextRequest request) async {
+    final payload = await _service.retrieve(
+      request: request,
+      settings: _settings(),
+      embeddingSettings: _embeddingSettings(),
+    );
+    _onRetrieved?.call(payload.snapshot);
+    final prompt = payload.prompt;
+    return ContextContribution(
+      messages: prompt == null
+          ? const []
+          : [
+              {'role': 'system', 'content': prompt},
+            ],
+      placement: ContextContributionPlacement.beforeConversation,
+    );
+  }
+}
+
+String latestDataBankQuery(List<ChatMessageMap> messages) {
+  for (final message in messages.reversed) {
+    if (message['role'] != 'user') continue;
+    final text = dataBankTextFromMessage(message).trim();
+    if (text.isNotEmpty) return text;
+  }
+  return '';
+}
+
+String dataBankTextFromMessage(ChatMessageMap message) {
+  final content = message['content'];
+  if (content is String) return content;
+  if (content is List) {
+    return content
+        .whereType<Map<Object?, Object?>>()
+        .where((part) => part['text'] is String)
+        .map((part) => part['text'] as String)
+        .join('\n');
+  }
+  return '';
+}
+
+String _sourceBlock(DataBankSearchResult result, String label, String quote) {
+  final locator = result.citation.locator;
+  final locationDetails = [
+    if (locator.chapter != null) 'chapter "${locator.chapter}"',
+    if (locator.pageStart != null)
+      locator.effectivePageEnd == locator.pageStart
+          ? 'page ${locator.pageStart}'
+          : 'pages ${locator.pageStart}-${locator.effectivePageEnd}',
+    if (locator.startOffset != null)
+      'characters ${locator.startOffset}-${locator.endOffset}',
+  ];
+  final location = locationDetails.isNotEmpty
+      ? locationDetails.join(', ')
+      : locator.sectionId == null
+          ? 'document'
+          : 'section ${locator.sectionId}';
+  return '[$label]\n'
+      'Document: ${result.documentName}\n'
+      'Location: $location\n'
+      'Excerpt:\n$quote';
+}
+
+String _joinPrompt(String intro, List<String> blocks) =>
+    '$intro\n\n${blocks.join('\n\n')}';
+
+double _cosine(List<double> left, List<double> right) {
+  var dot = 0.0;
+  var leftNorm = 0.0;
+  var rightNorm = 0.0;
+  for (var index = 0; index < left.length; index++) {
+    dot += left[index] * right[index];
+    leftNorm += left[index] * left[index];
+    rightNorm += right[index] * right[index];
+  }
+  if (leftNorm == 0 || rightNorm == 0) return -1;
+  return dot / (sqrt(leftNorm) * sqrt(rightNorm));
+}
+
+final class _FusedResult {
+  final DataBankSearchResult result;
+  double score;
+
+  _FusedResult(this.result, this.score);
+}
+
+final class _SemanticResult {
+  final DataBankSearchResult result;
+  final double score;
+  final int localIndex;
+
+  const _SemanticResult(this.result, this.score, this.localIndex);
+}
+
+final class _AssembledDataBankPrompt {
+  final String? prompt;
+  final List<DataBankContextSource> sources;
+
+  const _AssembledDataBankPrompt(this.prompt, this.sources);
+}

--- a/lib/presentation/providers/chat_providers.dart
+++ b/lib/presentation/providers/chat_providers.dart
@@ -7,6 +7,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:native_tavern/data/models/bookmark.dart';
 import 'package:native_tavern/data/models/chat.dart';
 import 'package:native_tavern/data/models/character.dart';
+import 'package:native_tavern/data/models/data_bank_context.dart';
 import 'package:native_tavern/data/models/group.dart';
 import 'package:native_tavern/data/models/persona.dart';
 import 'package:native_tavern/data/models/prompt_manager.dart';
@@ -19,6 +20,7 @@ import 'package:native_tavern/domain/services/macro_service.dart';
 import 'package:native_tavern/domain/services/chat_summarization_service.dart';
 import 'package:native_tavern/domain/services/chat_generation_pipeline.dart';
 import 'package:native_tavern/presentation/providers/chat_extension_providers.dart';
+import 'package:native_tavern/presentation/providers/data_bank_providers.dart';
 import 'package:native_tavern/presentation/providers/group_providers.dart';
 import 'package:native_tavern/presentation/providers/memory_providers.dart';
 import 'package:native_tavern/presentation/providers/persona_providers.dart';
@@ -39,13 +41,13 @@ class ActiveChatState {
   final Character? character;
   final Group? group; // For group chats
   final Map<String, Character>
-      groupCharacters; // Character cache for group chats
+  groupCharacters; // Character cache for group chats
   final List<ChatMessage> messages;
   final bool isLoading;
   final bool isGenerating;
   final String? error;
   final String?
-      currentResponderId; // Which character is currently responding (group chat)
+  currentResponderId; // Which character is currently responding (group chat)
 
   const ActiveChatState({
     this.chat,
@@ -105,6 +107,7 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
   // Track cancellation flag for stream processing
   bool _isCancelling = false;
   ChatGenerationSession? _activeGenerationSession;
+  DataBankContextSnapshot? _pendingDataBankContext;
 
   ActiveChatNotifier({
     required ChatRepository chatRepository,
@@ -115,15 +118,15 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
     required ChatSummarizationService summarizationService,
     required ChatGenerationPipeline generationPipeline,
     required Ref ref,
-  })  : _chatRepository = chatRepository,
-        _characterRepository = characterRepository,
-        _personaRepository = personaRepository,
-        _llmService = llmService,
-        _worldInfoMatcher = worldInfoMatcher,
-        _summarizationService = summarizationService,
-        _generationPipeline = generationPipeline,
-        _ref = ref,
-        super(const ActiveChatState());
+  }) : _chatRepository = chatRepository,
+       _characterRepository = characterRepository,
+       _personaRepository = personaRepository,
+       _llmService = llmService,
+       _worldInfoMatcher = worldInfoMatcher,
+       _summarizationService = summarizationService,
+       _generationPipeline = generationPipeline,
+       _ref = ref,
+       super(const ActiveChatState());
 
   Future<Persona?> _resolvePersona({
     String? characterId,
@@ -144,8 +147,9 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
     }
 
     if (effectiveChatId != null) {
-      final connected =
-          connectedWhere((connection) => connection.chatId == effectiveChatId);
+      final connected = connectedWhere(
+        (connection) => connection.chatId == effectiveChatId,
+      );
       if (connected != null) return connected;
     }
     if (effectiveGroupId != null) {
@@ -185,6 +189,7 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
     ChatGenerationMode mode, {
     String? characterId,
   }) {
+    _pendingDataBankContext = null;
     final previousSession = _activeGenerationSession;
     if (previousSession != null) {
       unawaited(previousSession.cancel('Superseded by a new generation'));
@@ -211,12 +216,34 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
     final session = _activeGenerationSession;
     if (session == null) return messages;
     final result = await session.assemble(messages);
+    final dataBankContext = _ref.read(lastDataBankContextProvider);
+    if (dataBankContext?.sessionId == session.sessionId) {
+      _pendingDataBankContext = dataBankContext!.sources.isEmpty
+          ? null
+          : dataBankContext;
+    }
     if (result.cancelled) {
       throw ChatGenerationCancelledException(
         session.cancellationToken.reason ?? 'Cancelled',
       );
     }
     return result.messages;
+  }
+
+  Map<String, dynamic> _newAssistantMetadata() {
+    return appendDataBankContextMetadata(
+      metadata: const {},
+      existingSwipeCount: 0,
+      snapshot: _pendingDataBankContext,
+    );
+  }
+
+  Map<String, dynamic> _metadataForNewSwipe(ChatMessage message) {
+    return appendDataBankContextMetadata(
+      metadata: message.metadata,
+      existingSwipeCount: message.swipes.length,
+      snapshot: _pendingDataBankContext,
+    );
   }
 
   void _closeGenerationSession([ChatGenerationSession? session]) {
@@ -236,9 +263,7 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
         last.swipes.any((swipe) => swipe.isNotEmpty)) {
       return;
     }
-    state = state.copyWith(
-      messages: messages.sublist(0, messages.length - 1),
-    );
+    state = state.copyWith(messages: messages.sublist(0, messages.length - 1));
   }
 
   /// Stream generation with assistant prefill: the prefill text is sent as
@@ -322,10 +347,8 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
       }
       return await session.generate(
         context,
-        (request) => _llmService.generateWithReasoning(
-          request.messages,
-          request.config,
-        ),
+        (request) =>
+            _llmService.generateWithReasoning(request.messages, request.config),
       );
     } finally {
       if (session != null) _closeGenerationSession(session);
@@ -357,8 +380,9 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
         return;
       }
 
-      final character =
-          await _characterRepository.getCharacter(chat.characterId);
+      final character = await _characterRepository.getCharacter(
+        chat.characterId,
+      );
       var messages = await _chatRepository.getMessages(chatId);
 
       if (!chat.isGroupChat && character != null) {
@@ -377,8 +401,9 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
         // Load all group member characters
         final groupChars = <String, Character>{};
         for (final member in group.members) {
-          final char =
-              await _characterRepository.getCharacter(member.characterId);
+          final char = await _characterRepository.getCharacter(
+            member.characterId,
+          );
           if (char != null) {
             groupChars[char.id] = char;
           }
@@ -425,12 +450,14 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
       characterId: character.id,
       chatId: chat.id,
     );
-    final macroService = MacroService(MacroContext.fromData(
-      character: character,
-      persona: persona,
-      chat: chat,
-      messages: messages,
-    ));
+    final macroService = MacroService(
+      MacroContext.fromData(
+        character: character,
+        persona: persona,
+        chat: chat,
+        messages: messages,
+      ),
+    );
     final primaryGreeting = macroService.process(character.firstMessage);
     final existingSwipes = first.swipes.isEmpty
         ? <String>[first.content]
@@ -551,8 +578,9 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
       // Load all member characters
       final groupChars = <String, Character>{};
       for (final member in group.members) {
-        final char =
-            await _characterRepository.getCharacter(member.characterId);
+        final char = await _characterRepository.getCharacter(
+          member.characterId,
+        );
         if (char != null) {
           groupChars[char.id] = char;
         }
@@ -560,7 +588,9 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
 
       if (groupChars.isEmpty) {
         state = state.copyWith(
-            isLoading: false, error: 'No valid characters in group');
+          isLoading: false,
+          error: 'No valid characters in group',
+        );
         return null;
       }
 
@@ -602,8 +632,9 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
             messages: messages,
             groupCharacters: groupChars.values.toList(),
           );
-          final processedGreeting =
-              MacroService(macroContext).process(char.firstMessage);
+          final processedGreeting = MacroService(
+            macroContext,
+          ).process(char.firstMessage);
 
           final greetingSwipes = [
             processedGreeting,
@@ -687,6 +718,7 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
     try {
       // Prepare context for LLM
       final context = await _buildContext();
+      final assistantMetadata = _newAssistantMetadata();
 
       // Create placeholder for assistant message
       final assistantMessage = ChatMessage(
@@ -697,11 +729,10 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
         timestamp: DateTime.now(),
         swipes: [''],
         currentSwipeIndex: 0,
+        metadata: assistantMetadata,
       );
 
-      state = state.copyWith(
-        messages: [...state.messages, assistantMessage],
-      );
+      state = state.copyWith(messages: [...state.messages, assistantMessage]);
 
       String finalContent;
       String? finalReasoning;
@@ -720,8 +751,9 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
           final updatedMessage = assistantMessage.copyWith(
             content: contentBuffer.toString(),
             swipes: [contentBuffer.toString()],
-            reasoning:
-                reasoningBuffer.isNotEmpty ? reasoningBuffer.toString() : null,
+            reasoning: reasoningBuffer.isNotEmpty
+                ? reasoningBuffer.toString()
+                : null,
             reasoningSwipes: reasoningBuffer.isNotEmpty
                 ? [reasoningBuffer.toString()]
                 : null,
@@ -732,8 +764,9 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
           state = state.copyWith(messages: updatedMessages);
         }
         finalContent = contentBuffer.toString();
-        finalReasoning =
-            reasoningBuffer.isNotEmpty ? reasoningBuffer.toString() : null;
+        finalReasoning = reasoningBuffer.isNotEmpty
+            ? reasoningBuffer.toString()
+            : null;
       } else {
         // Non-streaming: get complete response at once with reasoning support
         final response = await _generateWithPrefill(context, config);
@@ -762,7 +795,9 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
       state = state.copyWith(isGenerating: false);
       if (_ref.read(appSettingsProvider).memoryAutoExtractionEnabled) {
         unawaited(
-          _ref.read(memoryInboxProvider.notifier).extractChat(
+          _ref
+              .read(memoryInboxProvider.notifier)
+              .extractChat(
                 state.chat!.id,
                 automatic: true,
                 turnMessages: [userMessage, finalMessage],
@@ -778,10 +813,7 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
         return;
       }
       debugPrint('❌ ChatProvider sendMessage error: $e\n$stackTrace');
-      state = state.copyWith(
-        isGenerating: false,
-        error: e.toString(),
-      );
+      state = state.copyWith(isGenerating: false, error: e.toString());
     }
   }
 
@@ -797,6 +829,7 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
 
     try {
       final context = await _buildContext(excludeLastAssistant: true);
+      final responseMetadata = _metadataForNewSwipe(lastMessage);
 
       String finalContent;
       String? finalReasoning;
@@ -823,8 +856,9 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
           newSwipes.add(contentBuffer.toString());
 
           // Handle reasoning swipes
-          final newReasoningSwipes =
-              List<String>.from(lastMessage.reasoningSwipes ?? []);
+          final newReasoningSwipes = List<String>.from(
+            lastMessage.reasoningSwipes ?? [],
+          );
           while (newReasoningSwipes.length < newSwipeIndex) {
             newReasoningSwipes.add('');
           }
@@ -840,10 +874,13 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
             content: contentBuffer.toString(),
             swipes: newSwipes,
             currentSwipeIndex: newSwipeIndex,
-            reasoning:
-                reasoningBuffer.isNotEmpty ? reasoningBuffer.toString() : null,
-            reasoningSwipes:
-                newReasoningSwipes.isNotEmpty ? newReasoningSwipes : null,
+            reasoning: reasoningBuffer.isNotEmpty
+                ? reasoningBuffer.toString()
+                : null,
+            reasoningSwipes: newReasoningSwipes.isNotEmpty
+                ? newReasoningSwipes
+                : null,
+            metadata: responseMetadata,
           );
 
           final updatedMessages = List<ChatMessage>.from(state.messages);
@@ -851,8 +888,9 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
           state = state.copyWith(messages: updatedMessages);
         }
         finalContent = contentBuffer.toString();
-        finalReasoning =
-            reasoningBuffer.isNotEmpty ? reasoningBuffer.toString() : null;
+        finalReasoning = reasoningBuffer.isNotEmpty
+            ? reasoningBuffer.toString()
+            : null;
       } else {
         // Non-streaming mode with reasoning support
         final response = await _generateWithPrefill(context, config);
@@ -865,8 +903,9 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
       newSwipes.add(finalContent);
 
       // Handle reasoning swipes for final message
-      final newReasoningSwipes =
-          List<String>.from(lastMessage.reasoningSwipes ?? []);
+      final newReasoningSwipes = List<String>.from(
+        lastMessage.reasoningSwipes ?? [],
+      );
       while (newReasoningSwipes.length < newSwipes.length - 1) {
         newReasoningSwipes.add('');
       }
@@ -879,8 +918,10 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
         swipes: newSwipes,
         currentSwipeIndex: newSwipes.length - 1,
         reasoning: finalReasoning,
-        reasoningSwipes:
-            newReasoningSwipes.isNotEmpty ? newReasoningSwipes : null,
+        reasoningSwipes: newReasoningSwipes.isNotEmpty
+            ? newReasoningSwipes
+            : null,
+        metadata: responseMetadata,
       );
       await _chatRepository.updateMessage(finalMessage);
 
@@ -940,6 +981,10 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
       content: updatedSwipes[newIndex],
       swipes: updatedSwipes,
       currentSwipeIndex: newIndex,
+      metadata: removeDataBankContextMetadataAt(
+        metadata: message.metadata,
+        swipeIndex: swipeIndex,
+      ),
     );
 
     await _chatRepository.updateMessage(updatedMessage);
@@ -980,16 +1025,16 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
 
   /// Add an attachment to an existing message
   Future<void> addAttachmentToMessage(
-      String messageId, ChatAttachment attachment) async {
+    String messageId,
+    ChatAttachment attachment,
+  ) async {
     final messageIndex = state.messages.indexWhere((m) => m.id == messageId);
     if (messageIndex < 0) return;
 
     final message = state.messages[messageIndex];
     final updatedAttachments = [...message.attachments, attachment];
 
-    final updatedMessage = message.copyWith(
-      attachments: updatedAttachments,
-    );
+    final updatedMessage = message.copyWith(attachments: updatedAttachments);
 
     await _chatRepository.updateMessage(updatedMessage);
 
@@ -1032,9 +1077,7 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
       await _chatRepository.deleteMessage(msg.id);
     }
 
-    state = state.copyWith(
-      messages: state.messages.sublist(0, messageIndex),
-    );
+    state = state.copyWith(messages: state.messages.sublist(0, messageIndex));
   }
 
   /// Regenerate a specific assistant message (adds new swipe)
@@ -1051,6 +1094,7 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
     try {
       // Build context up to (but not including) this message
       final context = await _buildContextUpTo(messageIndex);
+      final responseMetadata = _metadataForNewSwipe(message);
 
       String finalContent;
       String? finalReasoning;
@@ -1081,8 +1125,9 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
           }
 
           // Handle reasoning swipes
-          final newReasoningSwipes =
-              List<String>.from(message.reasoningSwipes ?? []);
+          final newReasoningSwipes = List<String>.from(
+            message.reasoningSwipes ?? [],
+          );
           while (newReasoningSwipes.length < newSwipes.length - 1) {
             newReasoningSwipes.add('');
           }
@@ -1090,8 +1135,8 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
             if (newReasoningSwipes.length < newSwipes.length) {
               newReasoningSwipes.add(reasoningBuffer.toString());
             } else {
-              newReasoningSwipes[newSwipes.length - 1] =
-                  reasoningBuffer.toString();
+              newReasoningSwipes[newSwipes.length - 1] = reasoningBuffer
+                  .toString();
             }
           }
 
@@ -1099,10 +1144,13 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
             content: contentBuffer.toString(),
             swipes: newSwipes,
             currentSwipeIndex: newSwipes.length - 1,
-            reasoning:
-                reasoningBuffer.isNotEmpty ? reasoningBuffer.toString() : null,
-            reasoningSwipes:
-                newReasoningSwipes.isNotEmpty ? newReasoningSwipes : null,
+            reasoning: reasoningBuffer.isNotEmpty
+                ? reasoningBuffer.toString()
+                : null,
+            reasoningSwipes: newReasoningSwipes.isNotEmpty
+                ? newReasoningSwipes
+                : null,
+            metadata: responseMetadata,
           );
 
           final updatedMessages = List<ChatMessage>.from(state.messages);
@@ -1110,8 +1158,9 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
           state = state.copyWith(messages: updatedMessages);
         }
         finalContent = contentBuffer.toString();
-        finalReasoning =
-            reasoningBuffer.isNotEmpty ? reasoningBuffer.toString() : null;
+        finalReasoning = reasoningBuffer.isNotEmpty
+            ? reasoningBuffer.toString()
+            : null;
       } else {
         // Non-streaming mode with reasoning support
         final response = await _generateWithPrefill(context, config);
@@ -1124,8 +1173,9 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
       newSwipes.add(finalContent);
 
       // Handle reasoning swipes for final message
-      final newReasoningSwipes =
-          List<String>.from(message.reasoningSwipes ?? []);
+      final newReasoningSwipes = List<String>.from(
+        message.reasoningSwipes ?? [],
+      );
       while (newReasoningSwipes.length < newSwipes.length - 1) {
         newReasoningSwipes.add('');
       }
@@ -1138,8 +1188,10 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
         swipes: newSwipes,
         currentSwipeIndex: newSwipes.length - 1,
         reasoning: finalReasoning,
-        reasoningSwipes:
-            newReasoningSwipes.isNotEmpty ? newReasoningSwipes : null,
+        reasoningSwipes: newReasoningSwipes.isNotEmpty
+            ? newReasoningSwipes
+            : null,
+        metadata: responseMetadata,
       );
       await _chatRepository.updateMessage(finalMessage);
 
@@ -1202,8 +1254,9 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
 
       String nextCharId;
       if (lastAssistantMsg.characterId != null) {
-        final lastIndex =
-            activeMemberIds.indexOf(lastAssistantMsg.characterId!);
+        final lastIndex = activeMemberIds.indexOf(
+          lastAssistantMsg.characterId!,
+        );
         final nextIndex = (lastIndex + 1) % activeMemberIds.length;
         nextCharId = activeMemberIds[nextIndex];
       } else {
@@ -1229,7 +1282,8 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
       final context = [...await _buildContext()];
       context.add({
         'role': 'system',
-        'content': '[Write the next reply from the point of view of the user '
+        'content':
+            '[Write the next reply from the point of view of the user '
             'persona. Write only what the user says and does, in the '
             'same style as their previous messages. Do not write for '
             'any other character. Do not add any commentary.]',
@@ -1261,6 +1315,7 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
 
     try {
       final context = await _buildContext();
+      final assistantMetadata = _newAssistantMetadata();
 
       // Create placeholder for assistant message
       final assistantMessage = ChatMessage(
@@ -1271,11 +1326,10 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
         timestamp: DateTime.now(),
         swipes: [''],
         currentSwipeIndex: 0,
+        metadata: assistantMetadata,
       );
 
-      state = state.copyWith(
-        messages: [...state.messages, assistantMessage],
-      );
+      state = state.copyWith(messages: [...state.messages, assistantMessage]);
 
       String finalContent;
       String? finalReasoning;
@@ -1299,8 +1353,9 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
           final updatedMessage = assistantMessage.copyWith(
             content: contentBuffer.toString(),
             swipes: [contentBuffer.toString()],
-            reasoning:
-                reasoningBuffer.isNotEmpty ? reasoningBuffer.toString() : null,
+            reasoning: reasoningBuffer.isNotEmpty
+                ? reasoningBuffer.toString()
+                : null,
             reasoningSwipes: reasoningBuffer.isNotEmpty
                 ? [reasoningBuffer.toString()]
                 : null,
@@ -1311,8 +1366,9 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
           state = state.copyWith(messages: updatedMessages);
         }
         finalContent = contentBuffer.toString();
-        finalReasoning =
-            reasoningBuffer.isNotEmpty ? reasoningBuffer.toString() : null;
+        finalReasoning = reasoningBuffer.isNotEmpty
+            ? reasoningBuffer.toString()
+            : null;
       } else {
         // Non-streaming: get complete response at once with reasoning support
         final response = await _generateWithPrefill(context, config);
@@ -1347,18 +1403,17 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
         return;
       }
       debugPrint(
-          '❌ ChatProvider _generateAssistantResponse error: $e\n$stackTrace');
-      state = state.copyWith(
-        isGenerating: false,
-        error: e.toString(),
+        '❌ ChatProvider _generateAssistantResponse error: $e\n$stackTrace',
       );
+      state = state.copyWith(isGenerating: false, error: e.toString());
     }
   }
 
   /// Build context for LLM
   /// This method builds the full message list according to Prompt Manager configuration
-  Future<List<Map<String, dynamic>>> _buildContext(
-      {bool excludeLastAssistant = false}) async {
+  Future<List<Map<String, dynamic>>> _buildContext({
+    bool excludeLastAssistant = false,
+  }) async {
     final messages = <Map<String, dynamic>>[];
     final character = state.character;
     final chat = state.chat;
@@ -1383,14 +1438,17 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
       // Use recent messages for building context
       chatMessages = recentMessages;
       debugPrint(
-          '📝 Using summary + ${chatMessages.length} recent messages for context');
+        '📝 Using summary + ${chatMessages.length} recent messages for context',
+      );
     }
 
     // Find matching World Info entries
     List<WorldInfoEntry> worldInfoEntries = [];
     if (character != null) {
-      worldInfoEntries =
-          await _findMatchingWorldInfoEntries(character, chatMessages);
+      worldInfoEntries = await _findMatchingWorldInfoEntries(
+        character,
+        chatMessages,
+      );
     }
 
     // Get Prompt Manager configuration
@@ -1497,12 +1555,10 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
         summary: latestSummary,
         chatId: state.chat!.id,
       );
-      messages.add({
-        'role': 'assistant',
-        'content': summaryMessage.content,
-      });
+      messages.add({'role': 'assistant', 'content': summaryMessage.content});
       debugPrint(
-          '📌 Added summary to context: ${latestSummary.content.substring(0, min(100, latestSummary.content.length))}...');
+        '📌 Added summary to context: ${latestSummary.content.substring(0, min(100, latestSummary.content.length))}...',
+      );
     }
 
     // Add chat messages with depth-based injections
@@ -1518,15 +1574,17 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
     final personaDepth = personaPosition == PersonaDescriptionPosition.atDepth
         ? persona!.descriptionSettings.depth
         : (personaPosition == PersonaDescriptionPosition.topAN ||
-                personaPosition == PersonaDescriptionPosition.bottomAN)
-            ? authorNoteDepth
-            : null;
+              personaPosition == PersonaDescriptionPosition.bottomAN)
+        ? authorNoteDepth
+        : null;
 
     // RAG: retrieve relevant knowledge for the latest user message
     if (chatMessages.isNotEmpty) {
       final lastUserMessage = chatMessages
-          .lastWhere((m) => m.role == MessageRole.user,
-              orElse: () => chatMessages.last)
+          .lastWhere(
+            (m) => m.role == MessageRole.user,
+            orElse: () => chatMessages.last,
+          )
           .content;
       final ragContext = await _ref.read(ragContextProvider)(lastUserMessage);
       if (ragContext != null && ragContext.isNotEmpty) {
@@ -1637,7 +1695,9 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
       if (personaMessage != null) {
         final chatStartIndex = messages.length - chatMessages.length;
         messages.insert(
-            chatStartIndex.clamp(0, messages.length), personaMessage);
+          chatStartIndex.clamp(0, messages.length),
+          personaMessage,
+        );
       }
     }
 
@@ -1678,8 +1738,9 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
       final content = msg['content'];
       String preview;
       if (content is String) {
-        preview =
-            content.length > 100 ? '${content.substring(0, 100)}...' : content;
+        preview = content.length > 100
+            ? '${content.substring(0, 100)}...'
+            : content;
       } else if (content is List) {
         preview = '[Multimodal: ${content.length} parts]';
       } else {
@@ -1710,12 +1771,14 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
         final baseContent = persona?.systemPromptOverride?.isNotEmpty == true
             ? persona!.systemPromptOverride!
             : section.content?.isNotEmpty == true
-                ? section.content!
-                : (character?.systemPrompt.isNotEmpty == true
-                    ? character!.systemPrompt
-                    : PromptSection.getDefaultContent(
-                        PromptSectionType.systemPrompt));
-        final embeddedPersona = persona != null &&
+            ? section.content!
+            : (character?.systemPrompt.isNotEmpty == true
+                  ? character!.systemPrompt
+                  : PromptSection.getDefaultContent(
+                      PromptSectionType.systemPrompt,
+                    ));
+        final embeddedPersona =
+            persona != null &&
                 persona.descriptionSettings.position ==
                     PersonaDescriptionPosition.inSystemPrompt
             ? _personaPromptText(persona, processMacros)
@@ -1904,11 +1967,12 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
         final content = persona?.postHistoryInstructions?.isNotEmpty == true
             ? persona!.postHistoryInstructions!
             : section.content?.isNotEmpty == true
-                ? section.content!
-                : (character?.postHistoryInstructions.isNotEmpty == true
-                    ? character!.postHistoryInstructions
-                    : PromptSection.getDefaultContent(
-                        PromptSectionType.postHistoryInstructions));
+            ? section.content!
+            : (character?.postHistoryInstructions.isNotEmpty == true
+                  ? character!.postHistoryInstructions
+                  : PromptSection.getDefaultContent(
+                      PromptSectionType.postHistoryInstructions,
+                    ));
         if (content.isNotEmpty) {
           messages.add({'role': role, 'content': processMacros(content)});
         }
@@ -1935,8 +1999,10 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
       case PromptSectionType.custom:
         // Custom prompt from imported preset
         if (section.content?.isNotEmpty == true) {
-          messages
-              .add({'role': role, 'content': processMacros(section.content!)});
+          messages.add({
+            'role': role,
+            'content': processMacros(section.content!),
+          });
         }
         break;
     }
@@ -2001,8 +2067,10 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
     // Find matching World Info entries
     List<WorldInfoEntry> worldInfoEntries = [];
     if (character != null) {
-      worldInfoEntries =
-          await _findMatchingWorldInfoEntries(character, chatMessages);
+      worldInfoEntries = await _findMatchingWorldInfoEntries(
+        character,
+        chatMessages,
+      );
     }
 
     // Get Prompt Manager configuration
@@ -2098,12 +2166,10 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
         summary: latestSummary,
         chatId: state.chat!.id,
       );
-      messages.add({
-        'role': 'assistant',
-        'content': summaryMessage.content,
-      });
+      messages.add({'role': 'assistant', 'content': summaryMessage.content});
       debugPrint(
-          '📌 Added summary to context: ${latestSummary.content.substring(0, min(100, latestSummary.content.length))}...');
+        '📌 Added summary to context: ${latestSummary.content.substring(0, min(100, latestSummary.content.length))}...',
+      );
     }
 
     // Add chat messages with depth-based injections
@@ -2119,8 +2185,10 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
     // RAG: retrieve relevant knowledge for the latest user message
     if (chatMessages.isNotEmpty) {
       final lastUserMessage = chatMessages
-          .lastWhere((m) => m.role == MessageRole.user,
-              orElse: () => chatMessages.last)
+          .lastWhere(
+            (m) => m.role == MessageRole.user,
+            orElse: () => chatMessages.last,
+          )
           .content;
       final ragContext = await _ref.read(ragContextProvider)(lastUserMessage);
       if (ragContext != null && ragContext.isNotEmpty) {
@@ -2250,31 +2318,38 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
     // NOTE: World infos with characterId == null but isGlobal == false are NOT included
     // The user must explicitly enable isGlobal to make a world info available to all characters
     final enabledWorldInfoIds = allWorldInfos
-        .where((w) =>
-            w.enabled &&
-            (w.isGlobal ||
-                w.characterId == character.id ||
-                chatLinkedIds.contains(w.id) ||
-                w.id == personaLorebookId ||
-                activeIds.contains(w.id)))
+        .where(
+          (w) =>
+              w.enabled &&
+              (w.isGlobal ||
+                  w.characterId == character.id ||
+                  chatLinkedIds.contains(w.id) ||
+                  w.id == personaLorebookId ||
+                  activeIds.contains(w.id)),
+        )
         .map((w) => w.id)
         .toList();
 
     // Combine with manually activated IDs
-    final allWorldInfoIds =
-        <String>{...enabledWorldInfoIds, ...activeIds}.toList();
+    final allWorldInfoIds = <String>{
+      ...enabledWorldInfoIds,
+      ...activeIds,
+    }.toList();
 
     // Debug logging - Enhanced for troubleshooting
     debugPrint(
-        '\n╔══════════════════════════════════════════════════════════════');
+      '\n╔══════════════════════════════════════════════════════════════',
+    );
     debugPrint('║ 🌍 WORLD INFO DEBUG - Finding matching entries');
     debugPrint(
-        '╠══════════════════════════════════════════════════════════════');
+      '╠══════════════════════════════════════════════════════════════',
+    );
     debugPrint('║ Current character: ${character.name} (ID: ${character.id})');
     debugPrint('║ Active IDs from provider: $activeIds');
     debugPrint('║ Total world infos in database: ${allWorldInfos.length}');
     debugPrint(
-        '╠──────────────────────────────────────────────────────────────');
+      '╠──────────────────────────────────────────────────────────────',
+    );
 
     for (final wi in allWorldInfos) {
       final included = allWorldInfoIds.contains(wi.id);
@@ -2296,7 +2371,8 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
       debugPrint('║   • enabled: ${wi.enabled}');
       debugPrint('║   • isGlobal: ${wi.isGlobal}');
       debugPrint(
-          '║   • characterId: ${wi.characterId ?? "null (not linked to any character)"}');
+        '║   • characterId: ${wi.characterId ?? "null (not linked to any character)"}',
+      );
       if (reasons.isNotEmpty) {
         debugPrint('║   • Reasons: ${reasons.join(", ")}');
       }
@@ -2305,15 +2381,18 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
       }
       if (!wi.isGlobal && wi.characterId == null && !isManuallyActive) {
         debugPrint(
-            '║   ℹ️ Not global and not linked - enable isGlobal to use with all characters');
+          '║   ℹ️ Not global and not linked - enable isGlobal to use with all characters',
+        );
       }
     }
 
     debugPrint(
-        '╠──────────────────────────────────────────────────────────────');
+      '╠──────────────────────────────────────────────────────────────',
+    );
     debugPrint('║ Final world info IDs to search: $allWorldInfoIds');
     debugPrint(
-        '╚══════════════════════════════════════════════════════════════\n');
+      '╚══════════════════════════════════════════════════════════════\n',
+    );
 
     if (allWorldInfoIds.isEmpty) {
       debugPrint('⚠️ No world info IDs to search - returning empty list');
@@ -2333,15 +2412,19 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
 
     final contextText = contextBuffer.toString();
     debugPrint(
-        '\n╔══════════════════════════════════════════════════════════════');
+      '\n╔══════════════════════════════════════════════════════════════',
+    );
     debugPrint('║ 🔍 WORLD INFO MATCHING');
     debugPrint(
-        '╠══════════════════════════════════════════════════════════════');
+      '╠══════════════════════════════════════════════════════════════',
+    );
     debugPrint('║ Context text length: ${contextText.length} chars');
     debugPrint(
-        '║ Context preview: ${contextText.substring(0, min(200, contextText.length))}...');
+      '║ Context preview: ${contextText.substring(0, min(200, contextText.length))}...',
+    );
     debugPrint(
-        '╠──────────────────────────────────────────────────────────────');
+      '╠──────────────────────────────────────────────────────────────',
+    );
 
     // Find matching entries
     final matchedEntries = await _worldInfoMatcher.findMatchingEntries(
@@ -2357,28 +2440,32 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
       debugPrint('║   • Entry is not enabled');
       debugPrint('║   • Entry is not constant and keys don\'t match context');
       debugPrint(
-          '║   • World Info is not linked to this character and not global');
+        '║   • World Info is not linked to this character and not global',
+      );
     } else {
       debugPrint('║ ✅ MATCHED ${matchedEntries.length} ENTRIES:');
       for (final entry in matchedEntries) {
         final name = entry.comment.isNotEmpty
             ? entry.comment
             : (entry.keys.isEmpty
-                ? "(constant, no keys)"
-                : entry.keys.join(", "));
+                  ? "(constant, no keys)"
+                  : entry.keys.join(", "));
         final isConstant = entry.constant || entry.keys.isEmpty;
         debugPrint('║   • [${entry.position.name}] $name');
         debugPrint(
-            '║     enabled=${entry.enabled}, constant=${entry.constant}, keys=${entry.keys}');
+          '║     enabled=${entry.enabled}, constant=${entry.constant}, keys=${entry.keys}',
+        );
         if (isConstant) {
           debugPrint('║     → Included as CONSTANT entry');
         }
         debugPrint(
-            '║     Content: ${entry.content.substring(0, min(50, entry.content.length))}...');
+          '║     Content: ${entry.content.substring(0, min(50, entry.content.length))}...',
+        );
       }
     }
     debugPrint(
-        '╚══════════════════════════════════════════════════════════════\n');
+      '╚══════════════════════════════════════════════════════════════\n',
+    );
 
     return matchedEntries;
   }
@@ -2390,10 +2477,7 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
 
     // Add text content if present
     if (msg.content.isNotEmpty) {
-      contentParts.add({
-        'type': 'text',
-        'text': msg.content,
-      });
+      contentParts.add({'type': 'text', 'text': msg.content});
     }
 
     // Add image attachments as base64
@@ -2408,9 +2492,7 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
           // Use OpenAI-compatible format (works with most providers)
           contentParts.add({
             'type': 'image_url',
-            'image_url': {
-              'url': 'data:$mimeType;base64,$base64Data',
-            },
+            'image_url': {'url': 'data:$mimeType;base64,$base64Data'},
           });
         }
       } catch (e) {
@@ -2419,10 +2501,7 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
       }
     }
 
-    return {
-      'role': 'user',
-      'content': contentParts,
-    };
+    return {'role': 'user', 'content': contentParts};
   }
 
   String _generateId() {
@@ -2461,7 +2540,8 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
 
       // Determine which messages to summarize
       final messagesToSummarize = chat.summaries.isEmpty
-          ? state.messages // First summary: summarize all messages
+          ? state
+                .messages // First summary: summarize all messages
           : _summarizationService.getRecentMessages(
               allMessages: state.messages,
               latestSummary: chat.summaries.last,
@@ -2492,9 +2572,11 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
       state = state.copyWith(chat: updatedChat);
 
       debugPrint(
-          '✅ Summary created successfully (${updatedSummaries.length} total summaries)');
+        '✅ Summary created successfully (${updatedSummaries.length} total summaries)',
+      );
       debugPrint(
-          '📌 Summary preview: ${summary.content.substring(0, min(100, summary.content.length))}...');
+        '📌 Summary preview: ${summary.content.substring(0, min(100, summary.content.length))}...',
+      );
     } catch (e) {
       debugPrint('❌ Failed to create summary: $e');
       // Don't fail the entire message sending if summarization fails
@@ -2554,8 +2636,10 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
   Future<void> updateStartReplyWith(String text) async {
     if (state.chat == null) return;
 
-    final updatedChat =
-        state.chat!.withSetting('startReplyWith', text.isEmpty ? null : text);
+    final updatedChat = state.chat!.withSetting(
+      'startReplyWith',
+      text.isEmpty ? null : text,
+    );
     await _chatRepository.updateChat(updatedChat);
     state = state.copyWith(chat: updatedChat);
   }
@@ -2565,7 +2649,9 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
     if (state.chat == null) return;
 
     final updatedChat = state.chat!.withSetting(
-        'linkedWorldInfoIds', worldInfoIds.isEmpty ? null : worldInfoIds);
+      'linkedWorldInfoIds',
+      worldInfoIds.isEmpty ? null : worldInfoIds,
+    );
     await _chatRepository.updateChat(updatedChat);
     state = state.copyWith(chat: updatedChat);
   }
@@ -2625,13 +2711,15 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
     if (state.chat == null) return;
 
     // Find the message index for this bookmark
-    final messageIndex =
-        state.messages.indexWhere((m) => m.id == bookmark.messageId);
+    final messageIndex = state.messages.indexWhere(
+      (m) => m.id == bookmark.messageId,
+    );
     if (messageIndex < 0) {
       // Message not found - might be in a different branch
       // Try to restore messages up to the bookmark's message index
-      state =
-          state.copyWith(error: 'Bookmark message not found in current chat');
+      state = state.copyWith(
+        error: 'Bookmark message not found in current chat',
+      );
       return;
     }
 
@@ -2702,7 +2790,9 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
     if (_ref.read(appSettingsProvider).memoryAutoExtractionEnabled &&
         turnMessages.any((message) => message.role == MessageRole.assistant)) {
       unawaited(
-        _ref.read(memoryInboxProvider.notifier).extractChat(
+        _ref
+            .read(memoryInboxProvider.notifier)
+            .extractChat(
               state.chat!.id,
               automatic: true,
               turnMessages: turnMessages,
@@ -2736,8 +2826,9 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
         );
 
         if (lastAssistantMsg.characterId != null) {
-          final lastIndex =
-              activeMemberIds.indexOf(lastAssistantMsg.characterId!);
+          final lastIndex = activeMemberIds.indexOf(
+            lastAssistantMsg.characterId!,
+          );
           final nextIndex = (lastIndex + 1) % activeMemberIds.length;
           return [activeMemberIds[nextIndex]];
         }
@@ -2768,7 +2859,9 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
 
   /// Select responders using natural/AI-based selection
   List<String> _selectNaturalResponders(
-      String userMessage, List<String> activeMemberIds) {
+    String userMessage,
+    List<String> activeMemberIds,
+  ) {
     final group = state.group;
     if (group == null) return [];
 
@@ -2818,7 +2911,9 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
 
   /// Generate a response from a specific character in a group chat
   Future<void> _generateGroupCharacterResponse(
-      String characterId, LLMConfig config) async {
+    String characterId,
+    LLMConfig config,
+  ) async {
     final character = state.groupCharacters[characterId];
     if (character == null || state.chat == null) return;
 
@@ -2835,6 +2930,7 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
 
     try {
       final context = await _buildGroupContext(character);
+      final assistantMetadata = _newAssistantMetadata();
 
       // Create placeholder for assistant message
       final assistantMessage = ChatMessage(
@@ -2847,11 +2943,10 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
         currentSwipeIndex: 0,
         characterId: character.id,
         characterName: character.name,
+        metadata: assistantMetadata,
       );
 
-      state = state.copyWith(
-        messages: [...state.messages, assistantMessage],
-      );
+      state = state.copyWith(messages: [...state.messages, assistantMessage]);
 
       String finalContent;
       String? finalReasoning;
@@ -2875,8 +2970,9 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
           final updatedMessage = assistantMessage.copyWith(
             content: contentBuffer.toString(),
             swipes: [contentBuffer.toString()],
-            reasoning:
-                reasoningBuffer.isNotEmpty ? reasoningBuffer.toString() : null,
+            reasoning: reasoningBuffer.isNotEmpty
+                ? reasoningBuffer.toString()
+                : null,
             reasoningSwipes: reasoningBuffer.isNotEmpty
                 ? [reasoningBuffer.toString()]
                 : null,
@@ -2887,8 +2983,9 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
           state = state.copyWith(messages: updatedMessages);
         }
         finalContent = contentBuffer.toString();
-        finalReasoning =
-            reasoningBuffer.isNotEmpty ? reasoningBuffer.toString() : null;
+        finalReasoning = reasoningBuffer.isNotEmpty
+            ? reasoningBuffer.toString()
+            : null;
       } else {
         // Non-streaming: get complete response at once with reasoning support
         final response = await _generateWithPrefill(context, config);
@@ -2914,10 +3011,7 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
       );
       await _chatRepository.addMessage(finalMessage);
 
-      state = state.copyWith(
-        isGenerating: false,
-        clearCurrentResponder: true,
-      );
+      state = state.copyWith(isGenerating: false, clearCurrentResponder: true);
     } catch (e, stackTrace) {
       _closeGenerationSession();
       if (e is ChatGenerationCancelledException) {
@@ -2939,7 +3033,8 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
 
   /// Build context for group chat
   Future<List<Map<String, dynamic>>> _buildGroupContext(
-      Character respondingCharacter) async {
+    Character respondingCharacter,
+  ) async {
     final messages = <Map<String, dynamic>>[];
     final group = state.group;
     if (group == null) return messages;
@@ -3000,8 +3095,9 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
     if (persona != null && persona.name.isNotEmpty) {
       buffer.writeln('The user is ${persona.name}.');
       if (persona.description.isNotEmpty) {
-        buffer
-            .writeln('User description: ${processMacros(persona.description)}');
+        buffer.writeln(
+          'User description: ${processMacros(persona.description)}',
+        );
       }
       buffer.writeln();
     }
@@ -3010,11 +3106,13 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
     buffer.writeln('=== YOUR CHARACTER: ${respondingCharacter.name} ===');
     if (respondingCharacter.description.isNotEmpty) {
       buffer.writeln(
-          'Description: ${processMacros(respondingCharacter.description)}');
+        'Description: ${processMacros(respondingCharacter.description)}',
+      );
     }
     if (respondingCharacter.personality.isNotEmpty) {
       buffer.writeln(
-          'Personality: ${processMacros(respondingCharacter.personality)}');
+        'Personality: ${processMacros(respondingCharacter.personality)}',
+      );
     }
     buffer.writeln();
 
@@ -3024,15 +3122,17 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
       if (entry.key != respondingCharacter.id) {
         final char = entry.value;
         buffer.writeln(
-            '${char.name}: ${char.description.isNotEmpty ? processMacros(char.description) : "No description"}');
+          '${char.name}: ${char.description.isNotEmpty ? processMacros(char.description) : "No description"}',
+        );
       }
     }
     buffer.writeln();
 
     // Add scenario if the responding character has one
     if (respondingCharacter.scenario.isNotEmpty) {
-      buffer
-          .writeln('Scenario: ${processMacros(respondingCharacter.scenario)}');
+      buffer.writeln(
+        'Scenario: ${processMacros(respondingCharacter.scenario)}',
+      );
       buffer.writeln();
     }
 
@@ -3043,11 +3143,14 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
 
     buffer.writeln();
     buffer.writeln(
-        'IMPORTANT: Stay in character as ${respondingCharacter.name}. ');
+      'IMPORTANT: Stay in character as ${respondingCharacter.name}. ',
+    );
     buffer.writeln(
-        'Do not speak for other characters. Only respond as ${respondingCharacter.name}.');
+      'Do not speak for other characters. Only respond as ${respondingCharacter.name}.',
+    );
     buffer.writeln(
-        'Do not include your name prefix in your response - just write your dialogue/actions directly.');
+      'Do not include your name prefix in your response - just write your dialogue/actions directly.',
+    );
 
     return buffer.toString();
   }
@@ -3078,7 +3181,9 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
 
   /// Manually trigger a specific character to respond (for manual mode)
   Future<void> triggerCharacterResponse(
-      String characterId, LLMConfig config) async {
+    String characterId,
+    LLMConfig config,
+  ) async {
     if (!state.isGroupChat) return;
     await _generateGroupCharacterResponse(characterId, config);
   }
@@ -3087,29 +3192,32 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
 /// Provider for active chat
 final activeChatProvider =
     StateNotifierProvider<ActiveChatNotifier, ActiveChatState>((ref) {
-  final chatRepo = ref.watch(chatRepositoryProvider);
-  final characterRepo = ref.watch(characterRepositoryProvider);
-  final personaRepo = ref.watch(personaRepositoryProvider);
-  final llmService = ref.watch(llmServiceProvider);
-  final worldInfoMatcher = ref.watch(worldInfoMatcherProvider);
-  final summarizationService = ref.watch(chatSummarizationServiceProvider);
-  final generationPipeline = ref.watch(chatGenerationPipelineProvider);
+      ref.watch(dataBankContextRegistrationProvider);
+      final chatRepo = ref.watch(chatRepositoryProvider);
+      final characterRepo = ref.watch(characterRepositoryProvider);
+      final personaRepo = ref.watch(personaRepositoryProvider);
+      final llmService = ref.watch(llmServiceProvider);
+      final worldInfoMatcher = ref.watch(worldInfoMatcherProvider);
+      final summarizationService = ref.watch(chatSummarizationServiceProvider);
+      final generationPipeline = ref.watch(chatGenerationPipelineProvider);
 
-  return ActiveChatNotifier(
-    chatRepository: chatRepo,
-    characterRepository: characterRepo,
-    personaRepository: personaRepo,
-    llmService: llmService,
-    worldInfoMatcher: worldInfoMatcher,
-    summarizationService: summarizationService,
-    generationPipeline: generationPipeline,
-    ref: ref,
-  );
-});
+      return ActiveChatNotifier(
+        chatRepository: chatRepo,
+        characterRepository: characterRepo,
+        personaRepository: personaRepo,
+        llmService: llmService,
+        worldInfoMatcher: worldInfoMatcher,
+        summarizationService: summarizationService,
+        generationPipeline: generationPipeline,
+        ref: ref,
+      );
+    });
 
 /// Chat list for a character
-final characterChatsProvider =
-    FutureProvider.family<List<Chat>, String>((ref, characterId) async {
+final characterChatsProvider = FutureProvider.family<List<Chat>, String>((
+  ref,
+  characterId,
+) async {
   final repo = ref.watch(chatRepositoryProvider);
   return repo.getChatsForCharacter(characterId);
 });

--- a/lib/presentation/providers/data_bank_providers.dart
+++ b/lib/presentation/providers/data_bank_providers.dart
@@ -1,27 +1,125 @@
+import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:native_tavern/core/services/initialization_service.dart';
+import 'package:native_tavern/data/models/data_bank_context.dart';
 import 'package:native_tavern/data/repositories/drift_data_bank_repository.dart';
 import 'package:native_tavern/domain/repositories/data_bank_repository.dart';
+import 'package:native_tavern/domain/services/chat_generation_pipeline.dart';
+import 'package:native_tavern/domain/services/data_bank_context_service.dart';
 import 'package:native_tavern/domain/services/data_bank_library_service.dart';
+import 'package:native_tavern/presentation/providers/chat_extension_providers.dart';
+import 'package:native_tavern/presentation/providers/settings_providers.dart';
+import 'package:native_tavern/presentation/providers/vector_storage_providers.dart';
 import 'package:path/path.dart' as path;
+import 'package:shared_preferences/shared_preferences.dart';
 
 final dataBankRepositoryProvider = Provider<DataBankRepository>((ref) {
   return DriftDataBankRepository(ref.watch(databaseProvider));
 });
 
-final dataBankManagedFileStoreProvider =
-    Provider<DataBankManagedFileStore>((ref) {
+final dataBankManagedFileStoreProvider = Provider<DataBankManagedFileStore>((
+  ref,
+) {
   return FileDataBankManagedFileStore(
     root: Directory(path.join(ref.watch(dataPathProvider), 'data_bank')),
   );
 });
 
-final dataBankLibraryServiceProvider =
-    Provider<DataBankLibraryOperations>((ref) {
+final dataBankLibraryServiceProvider = Provider<DataBankLibraryOperations>((
+  ref,
+) {
   return DataBankLibraryService(
     repository: ref.watch(dataBankRepositoryProvider),
     files: ref.watch(dataBankManagedFileStoreProvider),
   );
 });
+
+final dataBankContextSettingsProvider =
+    StateNotifierProvider<
+      DataBankContextSettingsNotifier,
+      DataBankContextSettings
+    >((ref) {
+      return DataBankContextSettingsNotifier(
+        ref.watch(sharedPreferencesProvider),
+      );
+    });
+
+final lastDataBankContextProvider = StateProvider<DataBankContextSnapshot?>(
+  (ref) => null,
+);
+
+final dataBankContextServiceProvider = Provider<DataBankContextService>((ref) {
+  final embedder = ref.watch(embeddingServiceProvider);
+  return DataBankContextService(
+    repository: ref.watch(dataBankRepositoryProvider),
+    embedBatch: embedder.embedBatch,
+  );
+});
+
+final dataBankContextContributorProvider = Provider<DataBankContextContributor>(
+  (ref) {
+    return DataBankContextContributor(
+      service: ref.watch(dataBankContextServiceProvider),
+      settings: () => ref.read(dataBankContextSettingsProvider),
+      embeddingSettings: () => ref.read(vectorStorageSettingsProvider),
+      onRetrieved: (snapshot) {
+        ref.read(lastDataBankContextProvider.notifier).state = snapshot;
+      },
+    );
+  },
+);
+
+final dataBankContextRegistrationProvider = Provider<ChatExtensionRegistration>(
+  (ref) {
+    final registration = ref
+        .watch(chatExtensionRegistryProvider)
+        .registerContributor(ref.watch(dataBankContextContributorProvider));
+    ref.onDispose(registration.dispose);
+    return registration;
+  },
+);
+
+final class DataBankContextSettingsNotifier
+    extends StateNotifier<DataBankContextSettings> {
+  static const _storageKey = 'data_bank_context_settings';
+  final SharedPreferences _preferences;
+
+  DataBankContextSettingsNotifier(this._preferences)
+    : super(_load(_preferences));
+
+  void setEnabled(bool enabled) => _update(state.copyWith(enabled: enabled));
+
+  void setQueryRewriteEnabled(bool enabled) =>
+      _update(state.copyWith(queryRewriteEnabled: enabled));
+
+  void setSemanticRerankingEnabled(bool enabled) =>
+      _update(state.copyWith(semanticRerankingEnabled: enabled));
+
+  void setTopK(int topK) => _update(state.copyWith(topK: topK));
+
+  void setMaxTokens(int maxTokens) =>
+      _update(state.copyWith(maxTokens: maxTokens));
+
+  void setMaxChunksPerDocument(int maximum) =>
+      _update(state.copyWith(maxChunksPerDocument: maximum));
+
+  void _update(DataBankContextSettings next) {
+    state = next;
+    unawaited(_preferences.setString(_storageKey, jsonEncode(next.toJson())));
+  }
+
+  static DataBankContextSettings _load(SharedPreferences preferences) {
+    final encoded = preferences.getString(_storageKey);
+    if (encoded == null) return const DataBankContextSettings();
+    try {
+      return DataBankContextSettings.fromJson(
+        Map<String, dynamic>.from(jsonDecode(encoded) as Map),
+      );
+    } catch (_) {
+      return const DataBankContextSettings();
+    }
+  }
+}

--- a/lib/presentation/screens/chat/chat_screen.dart
+++ b/lib/presentation/screens/chat/chat_screen.dart
@@ -37,6 +37,7 @@ import 'package:native_tavern/presentation/router/app_router.dart';
 import 'package:native_tavern/presentation/theme/app_theme.dart';
 import 'package:native_tavern/presentation/widgets/chat/author_note_dialog.dart';
 import 'package:native_tavern/presentation/widgets/chat/bookmark_dialog.dart';
+import 'package:native_tavern/presentation/widgets/chat/data_bank_citation_preview.dart';
 import 'package:native_tavern/presentation/widgets/chat/chat_background_widget.dart';
 import 'package:native_tavern/presentation/widgets/chat/chat_voice_input_button.dart';
 import 'package:native_tavern/presentation/widgets/chat/message_content_widget.dart';
@@ -72,11 +73,7 @@ class ChatScreen extends ConsumerStatefulWidget {
   final String chatId;
   final String? initialMessageId;
 
-  const ChatScreen({
-    super.key,
-    required this.chatId,
-    this.initialMessageId,
-  });
+  const ChatScreen({super.key, required this.chatId, this.initialMessageId});
 
   @override
   ConsumerState<ChatScreen> createState() => _ChatScreenState();
@@ -139,8 +136,9 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     if (_initialMessageJumpScheduled || targetId == null || messages.isEmpty) {
       return;
     }
-    final actualIndex =
-        messages.indexWhere((message) => message.id == targetId);
+    final actualIndex = messages.indexWhere(
+      (message) => message.id == targetId,
+    );
     if (actualIndex < 0) {
       _initialMessageJumpScheduled = true;
       return;
@@ -150,7 +148,8 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
       if (!mounted || !_scrollController.hasClients) return;
       final reversedIndex = messages.length - 1 - actualIndex;
       final denominator = math.max(1, messages.length - 1);
-      final estimatedOffset = _scrollController.position.maxScrollExtent *
+      final estimatedOffset =
+          _scrollController.position.maxScrollExtent *
           reversedIndex /
           denominator;
       _scrollController.jumpTo(
@@ -192,7 +191,9 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     Live2DStageTransform transform,
   ) async {
     try {
-      await ref.read(activeChatProvider.notifier).updateLive2DStageTransform(
+      await ref
+          .read(activeChatProvider.notifier)
+          .updateLive2DStageTransform(
             scale: transform.scale,
             offsetX: transform.offsetX,
             offsetY: transform.offsetY,
@@ -232,8 +233,9 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
   void _scrollToBottomImmediate() {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (_scrollController.hasClients) {
-        _scrollController
-            .jumpTo(0); // With reverse: true, position 0 is the bottom
+        _scrollController.jumpTo(
+          0,
+        ); // With reverse: true, position 0 is the bottom
       }
     });
   }
@@ -393,11 +395,9 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     // Hide keyboard on mobile platforms
     _focusNode.unfocus();
 
-    await ref.read(activeChatProvider.notifier).sendMessage(
-          content,
-          config,
-          attachments: attachments,
-        );
+    await ref
+        .read(activeChatProvider.notifier)
+        .sendMessage(content, config, attachments: attachments);
     _scrollToBottom();
   }
 
@@ -614,7 +614,9 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
           final lastMessage = chatState.messages.last;
           if (lastMessage.swipes.length > 1) {
             await chatNotifier.deleteSwipe(
-                lastMessage.id, lastMessage.currentSwipeIndex);
+              lastMessage.id,
+              lastMessage.currentSwipeIndex,
+            );
             if (mounted) {
               _showSnackBar(AppLocalizations.of(context)!.swipeDeleted);
             }
@@ -688,8 +690,9 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     }
 
     _showSnackBar(l10n.imageGeneration);
-    final result =
-        await ref.read(imageGenStateProvider.notifier).generate(request);
+    final result = await ref
+        .read(imageGenStateProvider.notifier)
+        .generate(request);
     if (!mounted) return;
     if (result == null || result.images.isEmpty) {
       final error = ref.read(imageGenStateProvider).error;
@@ -699,7 +702,9 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
 
     try {
       final attachments = await _saveGeneratedImages(result);
-      await ref.read(activeChatProvider.notifier).addLocalMessage(
+      await ref
+          .read(activeChatProvider.notifier)
+          .addLocalMessage(
             role: MessageRole.user,
             content: request.prompt,
             attachments: attachments,
@@ -712,7 +717,8 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
   }
 
   Future<List<ChatAttachment>> _saveGeneratedImages(
-      ImageGenResult result) async {
+    ImageGenResult result,
+  ) async {
     final appDocDir = await getApplicationDocumentsDirectory();
     final imagesDir = Directory(p.join(appDocDir.path, 'chat_images'));
     if (!await imagesDir.exists()) {
@@ -725,12 +731,14 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
       final fileName = '$imageId.${result.format}';
       final filePath = p.join(imagesDir.path, fileName);
       await File(filePath).writeAsBytes(imageBytes);
-      attachments.add(ChatAttachment(
-        id: imageId,
-        path: filePath,
-        mimeType: 'image/${result.format}',
-        sizeBytes: imageBytes.length,
-      ));
+      attachments.add(
+        ChatAttachment(
+          id: imageId,
+          path: filePath,
+          mimeType: 'image/${result.format}',
+          sizeBytes: imageBytes.length,
+        ),
+      );
     }
     return attachments;
   }
@@ -751,7 +759,8 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     if (argument == null || argument.isEmpty || argument == 'right') {
       newIndex = (newIndex + 1) % lastMessage.swipes.length;
     } else if (argument == 'left') {
-      newIndex = (newIndex - 1 + lastMessage.swipes.length) %
+      newIndex =
+          (newIndex - 1 + lastMessage.swipes.length) %
           lastMessage.swipes.length;
     } else {
       final parsed = int.tryParse(argument);
@@ -865,13 +874,15 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
       return;
     }
 
-    final text =
-        await ref.read(activeChatProvider.notifier).impersonate(config);
+    final text = await ref
+        .read(activeChatProvider.notifier)
+        .impersonate(config);
     if (!mounted) return;
     if (text != null) {
       _messageController.text = text;
-      _messageController.selection =
-          TextSelection.collapsed(offset: text.length);
+      _messageController.selection = TextSelection.collapsed(
+        offset: text.length,
+      );
     }
   }
 
@@ -904,25 +915,27 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
                   return ListView(
                     shrinkWrap: true,
                     children: worldInfos
-                        .map((wi) => CheckboxListTile(
-                              title: Text(wi.name),
-                              subtitle: Text(
-                                l10n.chatLorebooksHint,
-                                style: const TextStyle(fontSize: 11),
-                              ),
-                              value: linked.contains(wi.id),
-                              onChanged: (checked) {
-                                final updated = List<String>.from(linked);
-                                if (checked == true) {
-                                  updated.add(wi.id);
-                                } else {
-                                  updated.remove(wi.id);
-                                }
-                                ref
-                                    .read(activeChatProvider.notifier)
-                                    .updateLinkedWorldBooks(updated);
-                              },
-                            ))
+                        .map(
+                          (wi) => CheckboxListTile(
+                            title: Text(wi.name),
+                            subtitle: Text(
+                              l10n.chatLorebooksHint,
+                              style: const TextStyle(fontSize: 11),
+                            ),
+                            value: linked.contains(wi.id),
+                            onChanged: (checked) {
+                              final updated = List<String>.from(linked);
+                              if (checked == true) {
+                                updated.add(wi.id);
+                              } else {
+                                updated.remove(wi.id);
+                              }
+                              ref
+                                  .read(activeChatProvider.notifier)
+                                  .updateLinkedWorldBooks(updated);
+                            },
+                          ),
+                        )
                         .toList(),
                   );
                 },
@@ -970,10 +983,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     _scrollToBottom();
   }
 
-  void _handleChatTTSChange(
-    ActiveChatState? previous,
-    ActiveChatState next,
-  ) {
+  void _handleChatTTSChange(ActiveChatState? previous, ActiveChatState next) {
     final action = _ttsAutoPlayController.evaluate(
       previous: previous,
       next: next,
@@ -1010,7 +1020,8 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
       // 2. Chat finishes loading (transitions from loading to loaded with messages)
       final messageCountChanged =
           previous?.messages.length != next.messages.length;
-      final loadingFinished = previous?.isLoading == true &&
+      final loadingFinished =
+          previous?.isLoading == true &&
           next.isLoading == false &&
           next.messages.isNotEmpty;
 
@@ -1099,8 +1110,11 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
       color: AppTheme.primaryColor.withValues(alpha: 0.15),
       child: Row(
         children: [
-          const Icon(Icons.info_outline,
-              color: AppTheme.primaryColor, size: 20),
+          const Icon(
+            Icons.info_outline,
+            color: AppTheme.primaryColor,
+            size: 20,
+          ),
           const SizedBox(width: 12),
           Expanded(
             child: Column(
@@ -1135,7 +1149,8 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
 
   AppBar _buildAppBar(ActiveChatState chatState) {
     final l10n = AppLocalizations.of(context);
-    final hasAuthorNote = chatState.chat?.authorNoteEnabled == true &&
+    final hasAuthorNote =
+        chatState.chat?.authorNoteEnabled == true &&
         (chatState.chat?.authorNote.isNotEmpty ?? false);
     final llmConfig = ref.watch(llmConfigProvider);
     final rpgState = ref.watch(rpgChatProvider(widget.chatId));
@@ -1206,9 +1221,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
         ),
         // Live2D supplies a visual stage even when no image background is set.
         if (ref
-                    .watch(
-                      effectiveBackgroundProvider(chatState.character?.id),
-                    )
+                    .watch(effectiveBackgroundProvider(chatState.character?.id))
                     .valueOrNull
                     ?.type ==
                 BackgroundType.image ||
@@ -1217,14 +1230,16 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
             icon: Icon(
               ref.watch(appSettingsProvider.select((s) => s.chatLayoutMode)) ==
                       'bubble'
-                  ? Icons.auto_stories // Novel mode icon
+                  ? Icons
+                        .auto_stories // Novel mode icon
                   : Icons.chat_bubble, // Bubble mode icon
             ),
             tooltip: l10n.switchLayout,
             onPressed: () {
               final currentMode = ref.read(appSettingsProvider).chatLayoutMode;
-              final newMode =
-                  currentMode == 'bubble' ? 'visualNovel' : 'bubble';
+              final newMode = currentMode == 'bubble'
+                  ? 'visualNovel'
+                  : 'bubble';
               ref
                   .read(appSettingsProvider.notifier)
                   .updateChatLayoutMode(newMode);
@@ -1282,7 +1297,8 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
               child: ListTile(
                 leading: Icon(
                   Icons.format_quote,
-                  color: (ref
+                  color:
+                      (ref
                               .read(activeChatProvider)
                               .chat
                               ?.startReplyWith
@@ -1312,7 +1328,8 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
               child: ListTile(
                 leading: Icon(
                   Icons.public,
-                  color: (ref
+                  color:
+                      (ref
                               .read(activeChatProvider)
                               .chat
                               ?.linkedWorldInfoIds
@@ -1328,8 +1345,10 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
             PopupMenuItem(
               value: 'bookmarks',
               child: ListTile(
-                leading:
-                    const Icon(Icons.bookmark, color: AppTheme.accentColor),
+                leading: const Icon(
+                  Icons.bookmark,
+                  color: AppTheme.accentColor,
+                ),
                 title: Text(l10n.bookmarks),
                 contentPadding: EdgeInsets.zero,
               ),
@@ -1424,10 +1443,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
               ),
             )
           else
-            const CircleAvatar(
-              radius: 50,
-              child: Icon(Icons.person, size: 50),
-            ),
+            const CircleAvatar(radius: 50, child: Icon(Icons.person, size: 50)),
           const SizedBox(height: 16),
           Text(
             character?.name ?? l10n.chat,
@@ -1436,9 +1452,9 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
           const SizedBox(height: 8),
           Text(
             l10n.startConversation,
-            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                  color: AppTheme.textMuted,
-                ),
+            style: Theme.of(
+              context,
+            ).textTheme.bodyMedium?.copyWith(color: AppTheme.textMuted),
           ),
         ],
       ),
@@ -1446,10 +1462,12 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
   }
 
   Widget _buildMessagesArea(ActiveChatState chatState) {
-    final layoutMode =
-        ref.watch(appSettingsProvider.select((s) => s.chatLayoutMode));
-    final backgroundAsync =
-        ref.watch(effectiveBackgroundProvider(chatState.character?.id));
+    final layoutMode = ref.watch(
+      appSettingsProvider.select((s) => s.chatLayoutMode),
+    );
+    final backgroundAsync = ref.watch(
+      effectiveBackgroundProvider(chatState.character?.id),
+    );
     final background = backgroundAsync.valueOrNull ?? ChatBackground.none;
     final hasBackground = background.type == BackgroundType.image;
     final hasLive2D = chatState.character?.assets?.live2d?.enabled == true;
@@ -1567,14 +1585,15 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
           ttsSettingsProvider.select((settings) => settings.enabled),
         );
         final playback = ttsRef.watch(ttsPlaybackStateProvider);
-        final matchesStage = playback.ownerId == widget.chatId &&
+        final matchesStage =
+            playback.ownerId == widget.chatId &&
             (playback.characterId == null ||
                 playback.characterId == character.id);
         final stagePlayback = !ttsEnabled
             ? null
             : matchesStage
-                ? playback
-                : TTSPlaybackState(sequence: playback.sequence);
+            ? playback
+            : TTSPlaybackState(sequence: playback.sequence);
 
         return Live2DCharacterView(
           config: live2d!,
@@ -1603,7 +1622,10 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
   }
 
   void _showMessageOptionsForVisualNovel(
-      BuildContext context, ChatMessage message, ActiveChatState chatState) {
+    BuildContext context,
+    ChatMessage message,
+    ActiveChatState chatState,
+  ) {
     final l10n = AppLocalizations.of(context);
     final config = ref.read(llmConfigProvider);
     final isAssistant = message.role == MessageRole.assistant;
@@ -1678,8 +1700,10 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
             ),
             ListTile(
               leading: const Icon(Icons.delete, color: Colors.red),
-              title:
-                  Text(l10n.delete, style: const TextStyle(color: Colors.red)),
+              title: Text(
+                l10n.delete,
+                style: const TextStyle(color: Colors.red),
+              ),
               onTap: () {
                 Navigator.pop(context);
                 _showDeleteConfirmation(message.id);
@@ -1694,10 +1718,12 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
   Widget _buildMessageList(ActiveChatState chatState) {
     _scheduleInitialMessageJump(chatState.messages);
     final config = ref.read(llmConfigProvider);
-    final backgroundAsync =
-        ref.watch(effectiveBackgroundProvider(chatState.character?.id));
+    final backgroundAsync = ref.watch(
+      effectiveBackgroundProvider(chatState.character?.id),
+    );
     final background = backgroundAsync.valueOrNull ?? ChatBackground.none;
-    final hasBackground = background.type != BackgroundType.none ||
+    final hasBackground =
+        background.type != BackgroundType.none ||
         chatState.character?.assets?.live2d?.enabled == true;
 
     return ListView.builder(
@@ -1713,8 +1739,9 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
         final message = chatState.messages[actualIndex];
         final isLast = actualIndex == chatState.messages.length - 1;
 
-        final layoutMode =
-            ref.watch(appSettingsProvider.select((s) => s.chatLayoutMode));
+        final layoutMode = ref.watch(
+          appSettingsProvider.select((s) => s.chatLayoutMode),
+        );
 
         return _MessageBubble(
           key: _messageKeys.putIfAbsent(
@@ -1733,39 +1760,34 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
           layoutMode: layoutMode,
           highlighted: _highlightedMessageId == message.id,
           onSwipe: (swipeIndex) {
-            ref.read(activeChatProvider.notifier).swipeMessage(
-                  message.id,
-                  swipeIndex,
-                );
+            ref
+                .read(activeChatProvider.notifier)
+                .swipeMessage(message.id, swipeIndex);
           },
           onDeleteSwipe: (swipeIndex) {
-            return ref.read(activeChatProvider.notifier).deleteSwipe(
-                  message.id,
-                  swipeIndex,
-                );
+            return ref
+                .read(activeChatProvider.notifier)
+                .deleteSwipe(message.id, swipeIndex);
           },
           onEdit: (newContent) {
-            ref.read(activeChatProvider.notifier).editMessage(
-                  message.id,
-                  newContent,
-                );
+            ref
+                .read(activeChatProvider.notifier)
+                .editMessage(message.id, newContent);
           },
           onDelete: () {
             _showDeleteConfirmation(message.id);
           },
           onRegenerate: message.role == MessageRole.assistant
               ? () {
-                  ref.read(activeChatProvider.notifier).regenerateMessage(
-                        message.id,
-                        config,
-                      );
+                  ref
+                      .read(activeChatProvider.notifier)
+                      .regenerateMessage(message.id, config);
                 }
               : null,
           onContinueFromHere: () {
-            ref.read(activeChatProvider.notifier).continueFromMessage(
-                  message.id,
-                  config,
-                );
+            ref
+                .read(activeChatProvider.notifier)
+                .continueFromMessage(message.id, config);
           },
           onDeleteAndAfter: () {
             _showDeleteAndAfterConfirmation(message.id);
@@ -1809,10 +1831,9 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     );
     controller.dispose();
     if (updated != null) {
-      await ref.read(activeChatProvider.notifier).editMessage(
-            message.id,
-            updated,
-          );
+      await ref
+          .read(activeChatProvider.notifier)
+          .editMessage(message.id, updated);
     }
   }
 
@@ -1824,7 +1845,9 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
   }
 
   void _showImageGenerationDialog(
-      ChatMessage message, Character? character) async {
+    ChatMessage message,
+    Character? character,
+  ) async {
     final result = await ImageGenerationDialog.show(
       context,
       basePrompt: message.content,
@@ -1864,22 +1887,23 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
           );
 
           // Add attachment to message
-          await ref.read(activeChatProvider.notifier).addAttachmentToMessage(
-                message.id,
-                attachment,
-              );
+          await ref
+              .read(activeChatProvider.notifier)
+              .addAttachmentToMessage(message.id, attachment);
         }
 
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-              content: Text(
-                  '${l10n.generationComplete} - ${result.images.length} image(s) added')),
+            content: Text(
+              '${l10n.generationComplete} - ${result.images.length} image(s) added',
+            ),
+          ),
         );
       } catch (e) {
         debugPrint('Failed to save generated image: $e');
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Failed to save image: $e')),
-        );
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('Failed to save image: $e')));
       }
     }
   }
@@ -1896,9 +1920,9 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
 
     if (result != null && mounted) {
       final l10n = AppLocalizations.of(context);
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(l10n.bookmarkCreated)),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(l10n.bookmarkCreated)));
     }
   }
 
@@ -1998,9 +2022,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
         color: AppTheme.darkCard,
-        border: Border(
-          top: BorderSide(color: AppTheme.darkDivider),
-        ),
+        border: Border(top: BorderSide(color: AppTheme.darkDivider)),
       ),
       child: SafeArea(
         child: Column(
@@ -2025,8 +2047,10 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
                     ),
                     onPressed: () => _setInputMenuVisible(!_showInputMenu),
                     padding: EdgeInsets.zero,
-                    constraints:
-                        const BoxConstraints(minWidth: 40, minHeight: 40),
+                    constraints: const BoxConstraints(
+                      minWidth: 40,
+                      minHeight: 40,
+                    ),
                   ),
                   const SizedBox(width: 4),
                   // Input field
@@ -2071,9 +2095,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
                           .read(activeChatProvider.notifier)
                           .cancelGeneration(),
                       icon: const Icon(Icons.stop_circle),
-                      style: IconButton.styleFrom(
-                        backgroundColor: Colors.red,
-                      ),
+                      style: IconButton.styleFrom(backgroundColor: Colors.red),
                       tooltip: AppLocalizations.of(context).stopGenerating,
                     )
                   else
@@ -2094,7 +2116,8 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
   Widget _buildInputMenuOverlay(ActiveChatState chatState) {
     final quickReplyConfig = ref.watch(quickReplyConfigProvider);
     final enabledReplies = ref.watch(enabledQuickRepliesProvider);
-    final showQuickReplies = quickReplyConfig.showQuickReplies &&
+    final showQuickReplies =
+        quickReplyConfig.showQuickReplies &&
         enabledReplies.isNotEmpty &&
         !chatState.isGenerating;
     final width = math.max(0.0, MediaQuery.sizeOf(context).width - 32);
@@ -2123,7 +2146,9 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
 
   /// Build the expandable menu panel above the input field
   Widget _buildInputMenuPanel(
-      bool showQuickReplies, ActiveChatState chatState) {
+    bool showQuickReplies,
+    ActiveChatState chatState,
+  ) {
     return Container(
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
@@ -2158,16 +2183,21 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
               // Context usage indicator
               Expanded(
                 child: Container(
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 12,
+                    vertical: 8,
+                  ),
                   decoration: BoxDecoration(
                     color: AppTheme.darkCard,
                     borderRadius: BorderRadius.circular(12),
                   ),
                   child: Row(
                     children: [
-                      Icon(Icons.analytics_outlined,
-                          size: 18, color: AppTheme.textMuted),
+                      Icon(
+                        Icons.analytics_outlined,
+                        size: 18,
+                        color: AppTheme.textMuted,
+                      ),
                       const SizedBox(width: 8),
                       const Expanded(child: ContextUsageIndicator()),
                     ],
@@ -2194,29 +2224,30 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
       spacing: 8,
       runSpacing: 8,
       children: enabledReplies
-          .map((reply) => InkWell(
-                onTap: () {
-                  _handleQuickReply(reply.message, reply.autoSend);
-                  _setInputMenuVisible(false);
-                },
-                borderRadius: BorderRadius.circular(20),
-                child: Container(
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
-                  decoration: BoxDecoration(
-                    color: AppTheme.darkCard,
-                    borderRadius: BorderRadius.circular(20),
-                    border: Border.all(color: AppTheme.darkDivider),
-                  ),
-                  child: Text(
-                    reply.label,
-                    style: TextStyle(
-                      fontSize: 13,
-                      color: AppTheme.textSecondary,
-                    ),
-                  ),
+          .map(
+            (reply) => InkWell(
+              onTap: () {
+                _handleQuickReply(reply.message, reply.autoSend);
+                _setInputMenuVisible(false);
+              },
+              borderRadius: BorderRadius.circular(20),
+              child: Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 14,
+                  vertical: 8,
                 ),
-              ))
+                decoration: BoxDecoration(
+                  color: AppTheme.darkCard,
+                  borderRadius: BorderRadius.circular(20),
+                  border: Border.all(color: AppTheme.darkDivider),
+                ),
+                child: Text(
+                  reply.label,
+                  style: TextStyle(fontSize: 13, color: AppTheme.textSecondary),
+                ),
+              ),
+            ),
+          )
           .toList(),
     );
   }
@@ -2238,24 +2269,45 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
       items: [
         _buildFormattingMenuItem(MarkdownFormat.bold, Icons.format_bold, null),
         _buildFormattingMenuItem(
-            MarkdownFormat.italic, Icons.format_italic, null),
+          MarkdownFormat.italic,
+          Icons.format_italic,
+          null,
+        ),
         _buildFormattingMenuItem(
-            MarkdownFormat.underline, Icons.format_underline, null),
+          MarkdownFormat.underline,
+          Icons.format_underline,
+          null,
+        ),
         _buildFormattingMenuItem(
-            MarkdownFormat.strikethrough, Icons.strikethrough_s, null),
+          MarkdownFormat.strikethrough,
+          Icons.strikethrough_s,
+          null,
+        ),
         const PopupMenuDivider(),
         _buildFormattingMenuItem(MarkdownFormat.inlineCode, Icons.code, null),
         _buildFormattingMenuItem(
-            MarkdownFormat.codeBlock, Icons.integration_instructions, null),
+          MarkdownFormat.codeBlock,
+          Icons.integration_instructions,
+          null,
+        ),
         const PopupMenuDivider(),
         _buildFormattingMenuItem(MarkdownFormat.link, Icons.link, null),
         _buildFormattingMenuItem(
-            MarkdownFormat.quote, Icons.format_quote, null),
+          MarkdownFormat.quote,
+          Icons.format_quote,
+          null,
+        ),
         const PopupMenuDivider(),
         _buildFormattingMenuItem(
-            MarkdownFormat.bulletList, Icons.format_list_bulleted, null),
+          MarkdownFormat.bulletList,
+          Icons.format_list_bulleted,
+          null,
+        ),
         _buildFormattingMenuItem(
-            MarkdownFormat.numberedList, Icons.format_list_numbered, null),
+          MarkdownFormat.numberedList,
+          Icons.format_list_numbered,
+          null,
+        ),
       ],
     ).then((format) {
       if (format != null) {
@@ -2265,7 +2317,10 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
   }
 
   PopupMenuItem<MarkdownFormat> _buildFormattingMenuItem(
-      MarkdownFormat format, IconData icon, String? shortcut) {
+    MarkdownFormat format,
+    IconData icon,
+    String? shortcut,
+  ) {
     return PopupMenuItem<MarkdownFormat>(
       value: format,
       child: Row(
@@ -2277,10 +2332,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
             const Spacer(),
             Text(
               shortcut,
-              style: TextStyle(
-                color: AppTheme.textMuted,
-                fontSize: 12,
-              ),
+              style: TextStyle(color: AppTheme.textMuted, fontSize: 12),
             ),
           ],
         ],
@@ -2331,8 +2383,10 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
                       width: 80,
                       height: 80,
                       color: AppTheme.darkCard,
-                      child: const Icon(Icons.broken_image,
-                          color: AppTheme.textMuted),
+                      child: const Icon(
+                        Icons.broken_image,
+                        color: AppTheme.textMuted,
+                      ),
                     ),
                   ),
                 ),
@@ -2401,8 +2455,10 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
             ),
             const SizedBox(height: 16),
             ListTile(
-              leading:
-                  const Icon(Icons.photo_library, color: AppTheme.primaryColor),
+              leading: const Icon(
+                Icons.photo_library,
+                color: AppTheme.primaryColor,
+              ),
               title: Text(l10n.chooseFromGallery),
               onTap: () {
                 Navigator.pop(context);
@@ -2410,8 +2466,10 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
               },
             ),
             ListTile(
-              leading:
-                  const Icon(Icons.camera_alt, color: AppTheme.accentColor),
+              leading: const Icon(
+                Icons.camera_alt,
+                color: AppTheme.accentColor,
+              ),
               title: Text(l10n.takePhoto),
               onTap: () {
                 Navigator.pop(context);
@@ -2500,8 +2558,9 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     try {
       // Copy file to app's documents directory for persistence
       final appDir = await getApplicationDocumentsDirectory();
-      final attachmentsDir =
-          Directory(p.join(appDir.path, 'NativeTavern', 'attachments'));
+      final attachmentsDir = Directory(
+        p.join(appDir.path, 'NativeTavern', 'attachments'),
+      );
       await attachmentsDir.create(recursive: true);
 
       final uuid = const Uuid();
@@ -2537,8 +2596,9 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     try {
       // Copy file to app's documents directory for persistence
       final appDir = await getApplicationDocumentsDirectory();
-      final attachmentsDir =
-          Directory(p.join(appDir.path, 'NativeTavern', 'attachments'));
+      final attachmentsDir = Directory(
+        p.join(appDir.path, 'NativeTavern', 'attachments'),
+      );
       await attachmentsDir.create(recursive: true);
 
       final uuid = const Uuid();
@@ -2705,10 +2765,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
             const SizedBox(height: 16),
             Text(
               l10n.importNote,
-              style: const TextStyle(
-                fontSize: 12,
-                color: AppTheme.textMuted,
-              ),
+              style: const TextStyle(fontSize: 12, color: AppTheme.textMuted),
             ),
           ],
         ),
@@ -2756,7 +2813,8 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
               Text('${l10n.user}: ${result.userName}'),
               Text('${l10n.messages}: ${result.messages.length}'),
               Text(
-                  '${l10n.date}: ${result.createDate.toString().split('.')[0]}'),
+                '${l10n.date}: ${result.createDate.toString().split('.')[0]}',
+              ),
               if (result.authorNote != null && result.authorNote!.isNotEmpty)
                 Text('${l10n.hasAuthorsNote}: ${l10n.yes}'),
               const SizedBox(height: 16),
@@ -2922,18 +2980,17 @@ class _MessageBubbleState extends State<_MessageBubble> {
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 4),
       child: Row(
-        mainAxisAlignment:
-            isUser ? MainAxisAlignment.end : MainAxisAlignment.start,
+        mainAxisAlignment: isUser
+            ? MainAxisAlignment.end
+            : MainAxisAlignment.start,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          if (!isUser) ...[
-            _buildAvatar(),
-            const SizedBox(width: 8),
-          ],
+          if (!isUser) ...[_buildAvatar(), const SizedBox(width: 8)],
           Flexible(
             child: Column(
-              crossAxisAlignment:
-                  isUser ? CrossAxisAlignment.end : CrossAxisAlignment.start,
+              crossAxisAlignment: isUser
+                  ? CrossAxisAlignment.end
+                  : CrossAxisAlignment.start,
               children: [
                 GestureDetector(
                   onLongPress: () => _showMessageOptions(context),
@@ -2969,6 +3026,10 @@ class _MessageBubbleState extends State<_MessageBubble> {
                                   isStreaming: widget.isGenerating,
                                   messageId: widget.message.id,
                                 ),
+                              if (!isUser && !widget.isGenerating)
+                                DataBankCitationPreview(
+                                  message: widget.message,
+                                ),
                             ],
                           ),
                   ),
@@ -2985,8 +3046,8 @@ class _MessageBubbleState extends State<_MessageBubble> {
                           icon: const Icon(Icons.chevron_left, size: 20),
                           onPressed: widget.message.currentSwipeIndex > 0
                               ? () => widget.onSwipe(
-                                    widget.message.currentSwipeIndex - 1,
-                                  )
+                                  widget.message.currentSwipeIndex - 1,
+                                )
                               : null,
                           padding: EdgeInsets.zero,
                           constraints: const BoxConstraints(),
@@ -2999,22 +3060,19 @@ class _MessageBubbleState extends State<_MessageBubble> {
                             padding: const EdgeInsets.symmetric(horizontal: 4),
                             child: Text(
                               '${widget.message.currentSwipeIndex + 1}/${widget.message.swipes.length}',
-                              style: Theme.of(context)
-                                  .textTheme
-                                  .bodySmall
-                                  ?.copyWith(
-                                    color: AppTheme.textMuted,
-                                  ),
+                              style: Theme.of(context).textTheme.bodySmall
+                                  ?.copyWith(color: AppTheme.textMuted),
                             ),
                           ),
                         ),
                         IconButton(
                           icon: const Icon(Icons.chevron_right, size: 20),
-                          onPressed: widget.message.currentSwipeIndex <
+                          onPressed:
+                              widget.message.currentSwipeIndex <
                                   widget.message.swipes.length - 1
                               ? () => widget.onSwipe(
-                                    widget.message.currentSwipeIndex + 1,
-                                  )
+                                  widget.message.currentSwipeIndex + 1,
+                                )
                               : null,
                           padding: EdgeInsets.zero,
                           constraints: const BoxConstraints(),
@@ -3074,8 +3132,8 @@ class _MessageBubbleState extends State<_MessageBubble> {
           color: widget.highlighted
               ? Theme.of(context).colorScheme.tertiary
               : isUser
-                  ? AppTheme.accentColor.withValues(alpha: 0.5)
-                  : Colors.white.withValues(alpha: 0.3),
+              ? AppTheme.accentColor.withValues(alpha: 0.5)
+              : Colors.white.withValues(alpha: 0.3),
           width: widget.highlighted ? 3 : 1,
         ),
         // Glass morphism effect
@@ -3092,11 +3150,11 @@ class _MessageBubbleState extends State<_MessageBubble> {
       return BoxDecoration(
         color: isUser
             ? (widget.hasBackground
-                ? AppTheme.accentColor.withValues(alpha: widget.bubbleOpacity)
-                : AppTheme.accentColor)
+                  ? AppTheme.accentColor.withValues(alpha: widget.bubbleOpacity)
+                  : AppTheme.accentColor)
             : (widget.hasBackground
-                ? AppTheme.darkCard.withValues(alpha: widget.bubbleOpacity)
-                : AppTheme.darkCard),
+                  ? AppTheme.darkCard.withValues(alpha: widget.bubbleOpacity)
+                  : AppTheme.darkCard),
         borderRadius: BorderRadius.circular(16),
         border: widget.highlighted
             ? Border.all(
@@ -3113,16 +3171,11 @@ class _MessageBubbleState extends State<_MessageBubble> {
       return CharacterAvatarCircle(
         imagePath: widget.character!.assets!.avatarPath!,
         radius: 16,
-        errorBuilder: (_, __, ___) => const CircleAvatar(
-          radius: 16,
-          child: Icon(Icons.person, size: 16),
-        ),
+        errorBuilder: (_, __, ___) =>
+            const CircleAvatar(radius: 16, child: Icon(Icons.person, size: 16)),
       );
     }
-    return const CircleAvatar(
-      radius: 16,
-      child: Icon(Icons.person, size: 16),
-    );
+    return const CircleAvatar(radius: 16, child: Icon(Icons.person, size: 16));
   }
 
   /// Build the reasoning/thinking section for AI messages
@@ -3164,10 +3217,7 @@ class _MessageBubbleState extends State<_MessageBubble> {
           child: ClipRRect(
             borderRadius: BorderRadius.circular(8),
             child: ConstrainedBox(
-              constraints: const BoxConstraints(
-                maxWidth: 250,
-                maxHeight: 200,
-              ),
+              constraints: const BoxConstraints(maxWidth: 250, maxHeight: 200),
               child: Image.file(
                 File(attachments[0].path),
                 fit: BoxFit.cover,
@@ -3175,8 +3225,10 @@ class _MessageBubbleState extends State<_MessageBubble> {
                   width: 150,
                   height: 100,
                   color: AppTheme.darkBackground,
-                  child:
-                      const Icon(Icons.broken_image, color: AppTheme.textMuted),
+                  child: const Icon(
+                    Icons.broken_image,
+                    color: AppTheme.textMuted,
+                  ),
                 ),
               ),
             ),
@@ -3205,8 +3257,11 @@ class _MessageBubbleState extends State<_MessageBubble> {
                   width: 80,
                   height: 80,
                   color: AppTheme.darkBackground,
-                  child: const Icon(Icons.broken_image,
-                      size: 20, color: AppTheme.textMuted),
+                  child: const Icon(
+                    Icons.broken_image,
+                    size: 20,
+                    color: AppTheme.textMuted,
+                  ),
                 ),
               ),
             ),
@@ -3235,8 +3290,11 @@ class _MessageBubbleState extends State<_MessageBubble> {
                       width: 200,
                       height: 200,
                       color: AppTheme.darkCard,
-                      child: const Icon(Icons.broken_image,
-                          size: 48, color: AppTheme.textMuted),
+                      child: const Icon(
+                        Icons.broken_image,
+                        size: 48,
+                        color: AppTheme.textMuted,
+                      ),
                     ),
                   ),
                 ),
@@ -3345,8 +3403,10 @@ class _MessageBubbleState extends State<_MessageBubble> {
             // Regenerate (only for assistant messages)
             if (isAssistant && widget.onRegenerate != null)
               ListTile(
-                leading:
-                    const Icon(Icons.refresh, color: AppTheme.primaryColor),
+                leading: const Icon(
+                  Icons.refresh,
+                  color: AppTheme.primaryColor,
+                ),
                 title: Text(l10n.regenerate),
                 subtitle: Text(l10n.generateNewResponse),
                 onTap: () {
@@ -3357,8 +3417,10 @@ class _MessageBubbleState extends State<_MessageBubble> {
 
             // Continue from here
             ListTile(
-              leading:
-                  const Icon(Icons.play_arrow, color: AppTheme.accentColor),
+              leading: const Icon(
+                Icons.play_arrow,
+                color: AppTheme.accentColor,
+              ),
               title: Text(l10n.continueFromHere),
               subtitle: Text(
                 widget.message.role == MessageRole.user
@@ -3373,8 +3435,10 @@ class _MessageBubbleState extends State<_MessageBubble> {
 
             // Create bookmark
             ListTile(
-              leading:
-                  const Icon(Icons.bookmark_add, color: AppTheme.accentColor),
+              leading: const Icon(
+                Icons.bookmark_add,
+                color: AppTheme.accentColor,
+              ),
               title: Text(l10n.createBookmark),
               subtitle: Text(l10n.saveAsCheckpoint),
               onTap: () {
@@ -3386,8 +3450,10 @@ class _MessageBubbleState extends State<_MessageBubble> {
             // Generate image (if enabled)
             if (widget.onGenerateImage != null)
               ListTile(
-                leading: const Icon(Icons.auto_awesome,
-                    color: AppTheme.primaryColor),
+                leading: const Icon(
+                  Icons.auto_awesome,
+                  color: AppTheme.primaryColor,
+                ),
                 title: Text(l10n.generateImagesUsingAi),
                 onTap: () {
                   Navigator.pop(context);
@@ -3536,9 +3602,7 @@ class _ModelSelectorDialogState extends State<_ModelSelectorDialog> {
     final l10n = AppLocalizations.of(context);
     return Dialog(
       backgroundColor: AppTheme.darkCard,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(16),
-      ),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
       child: ConstrainedBox(
         constraints: BoxConstraints(
           maxWidth: 400,
@@ -3642,8 +3706,9 @@ class _ModelSelectorDialogState extends State<_ModelSelectorDialog> {
                             ),
                           ),
                           selected: isSelected,
-                          selectedTileColor:
-                              AppTheme.accentColor.withValues(alpha: 0.1),
+                          selectedTileColor: AppTheme.accentColor.withValues(
+                            alpha: 0.1,
+                          ),
                           shape: RoundedRectangleBorder(
                             borderRadius: BorderRadius.circular(8),
                           ),
@@ -3703,10 +3768,7 @@ class _InputMenuButton extends StatelessWidget {
             const SizedBox(width: 6),
             Text(
               label,
-              style: TextStyle(
-                fontSize: 13,
-                color: AppTheme.textSecondary,
-              ),
+              style: TextStyle(fontSize: 13, color: AppTheme.textSecondary),
             ),
           ],
         ),

--- a/lib/presentation/screens/data_bank/data_bank_screen.dart
+++ b/lib/presentation/screens/data_bank/data_bank_screen.dart
@@ -7,12 +7,14 @@ import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:native_tavern/data/models/data_bank.dart';
+import 'package:native_tavern/data/models/data_bank_context.dart';
 import 'package:native_tavern/data/repositories/character_repository.dart';
 import 'package:native_tavern/data/repositories/chat_repository.dart';
 import 'package:native_tavern/domain/repositories/data_bank_repository.dart';
 import 'package:native_tavern/domain/services/data_bank_library_service.dart';
 import 'package:native_tavern/presentation/controllers/data_bank_library_controller.dart';
 import 'package:native_tavern/presentation/providers/data_bank_providers.dart';
+import 'package:native_tavern/presentation/widgets/chat/data_bank_citation_preview.dart';
 
 abstract interface class DataBankFileGateway {
   Future<File?> pickDocument();
@@ -41,7 +43,8 @@ final class PlatformDataBankFileGateway implements DataBankFileGateway {
     final selectedPath = result.files.single.path;
     if (selectedPath == null) {
       throw const FileSystemException(
-          'The selected document could not be read.');
+        'The selected document could not be read.',
+      );
     }
     return File(selectedPath);
   }
@@ -65,19 +68,14 @@ final class RepositoryDataBankBindingTargetGateway
   final CharacterRepository _characters;
   final ChatRepository _chats;
 
-  const RepositoryDataBankBindingTargetGateway(
-    this._characters,
-    this._chats,
-  );
+  const RepositoryDataBankBindingTargetGateway(this._characters, this._chats);
 
   @override
   Future<List<DataBankBindingTarget>> listCharacters() async {
     final targets = (await _characters.getAllCharacters())
         .map(
-          (character) => DataBankBindingTarget(
-            id: character.id,
-            label: character.name,
-          ),
+          (character) =>
+              DataBankBindingTarget(id: character.id, label: character.name),
         )
         .toList();
     targets.sort((left, right) => left.label.compareTo(right.label));
@@ -87,9 +85,7 @@ final class RepositoryDataBankBindingTargetGateway
   @override
   Future<List<DataBankBindingTarget>> listChats() async {
     return (await _chats.getAllChats())
-        .map(
-          (chat) => DataBankBindingTarget(id: chat.id, label: chat.title),
-        )
+        .map((chat) => DataBankBindingTarget(id: chat.id, label: chat.title))
         .toList(growable: false);
   }
 }
@@ -119,7 +115,8 @@ class _DataBankScreenState extends ConsumerState<DataBankScreen> {
   void initState() {
     super.initState();
     _ownsController = widget.controller == null;
-    _controller = widget.controller ??
+    _controller =
+        widget.controller ??
         DataBankLibraryController(ref.read(dataBankLibraryServiceProvider));
     _controller.addListener(_refresh);
     _controller.initialize();
@@ -143,6 +140,12 @@ class _DataBankScreenState extends ConsumerState<DataBankScreen> {
       appBar: AppBar(
         title: const Text('Data Bank'),
         actions: [
+          IconButton(
+            key: const Key('data-bank-context-settings'),
+            tooltip: 'Chat retrieval settings',
+            onPressed: _showContextSettings,
+            icon: const Icon(Icons.tune),
+          ),
           IconButton(
             key: const Key('data-bank-rebuild-index'),
             tooltip: 'Rebuild search index',
@@ -246,10 +249,7 @@ class _DataBankScreenState extends ConsumerState<DataBankScreen> {
             entry: entry,
             busy: _controller.working,
             onToggle: (enabled) => _run(
-              () => _controller.setDocumentEnabled(
-                entry.document.id,
-                enabled,
-              ),
+              () => _controller.setDocumentEnabled(entry.document.id, enabled),
             ),
             onPreview: () => _showPreview(entry.document.id),
             onBindings: () => _showBindings(entry),
@@ -267,6 +267,15 @@ class _DataBankScreenState extends ConsumerState<DataBankScreen> {
       final file = await widget.fileGateway.pickDocument();
       if (file != null) await _controller.importDocument(file);
     });
+  }
+
+  Future<void> _showContextSettings() {
+    return showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      showDragHandle: true,
+      builder: (context) => const _DataBankContextSettingsSheet(),
+    );
   }
 
   Future<void> _rebuildIndex() async {
@@ -291,7 +300,8 @@ class _DataBankScreenState extends ConsumerState<DataBankScreen> {
 
   Future<void> _showBindings(DataBankLibraryEntry entry) async {
     await _run(() async {
-      final gateway = widget.bindingTargetGateway ??
+      final gateway =
+          widget.bindingTargetGateway ??
           RepositoryDataBankBindingTargetGateway(
             ref.read(characterRepositoryProvider),
             ref.read(chatRepositoryProvider),
@@ -366,6 +376,236 @@ class _DataBankScreenState extends ConsumerState<DataBankScreen> {
   }
 }
 
+class _DataBankContextSettingsSheet extends ConsumerWidget {
+  const _DataBankContextSettingsSheet();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final settings = ref.watch(dataBankContextSettingsProvider);
+    final notifier = ref.read(dataBankContextSettingsProvider.notifier);
+    final diagnostics = ref.watch(lastDataBankContextProvider);
+    return SafeArea(
+      child: SizedBox(
+        height: MediaQuery.sizeOf(context).height * 0.88,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 0, 12, 8),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      'Chat retrieval',
+                      style: Theme.of(context).textTheme.titleLarge,
+                    ),
+                  ),
+                  IconButton(
+                    tooltip: 'Close',
+                    onPressed: () => Navigator.pop(context),
+                    icon: const Icon(Icons.close),
+                  ),
+                ],
+              ),
+            ),
+            Expanded(
+              child: ListView(
+                padding: const EdgeInsets.fromLTRB(20, 0, 20, 28),
+                children: [
+                  SwitchListTile(
+                    key: const Key('data-bank-context-enabled'),
+                    contentPadding: EdgeInsets.zero,
+                    title: const Text('Use Data Bank in chat'),
+                    value: settings.enabled,
+                    onChanged: notifier.setEnabled,
+                  ),
+                  SwitchListTile(
+                    key: const Key('data-bank-query-rewrite'),
+                    contentPadding: EdgeInsets.zero,
+                    title: const Text('Conversation-aware query expansion'),
+                    value: settings.queryRewriteEnabled,
+                    onChanged: settings.enabled
+                        ? notifier.setQueryRewriteEnabled
+                        : null,
+                  ),
+                  SwitchListTile(
+                    key: const Key('data-bank-semantic-reranking'),
+                    contentPadding: EdgeInsets.zero,
+                    title: const Text('Semantic reranking'),
+                    subtitle: const Text(
+                      'Uses the configured Embedding provider',
+                    ),
+                    value: settings.semanticRerankingEnabled,
+                    onChanged: settings.enabled
+                        ? notifier.setSemanticRerankingEnabled
+                        : null,
+                  ),
+                  const Divider(height: 28),
+                  _SettingsSlider(
+                    key: const Key('data-bank-top-k'),
+                    title: 'Sources per response',
+                    valueLabel: '${settings.topK}',
+                    value: settings.topK.toDouble(),
+                    min: 1,
+                    max: 20,
+                    divisions: 19,
+                    enabled: settings.enabled,
+                    onChanged: (value) => notifier.setTopK(value.round()),
+                  ),
+                  _SettingsSlider(
+                    key: const Key('data-bank-token-budget'),
+                    title: 'Token budget',
+                    valueLabel: '${settings.maxTokens}',
+                    value: settings.maxTokens.clamp(256, 4096).toDouble(),
+                    min: 256,
+                    max: 4096,
+                    divisions: 30,
+                    enabled: settings.enabled,
+                    onChanged: (value) =>
+                        notifier.setMaxTokens((value / 128).round() * 128),
+                  ),
+                  _SettingsSlider(
+                    key: const Key('data-bank-source-diversity'),
+                    title: 'Chunks per document',
+                    valueLabel: '${settings.maxChunksPerDocument}',
+                    value: settings.maxChunksPerDocument.clamp(1, 5).toDouble(),
+                    min: 1,
+                    max: 5,
+                    divisions: 4,
+                    enabled: settings.enabled,
+                    onChanged: (value) =>
+                        notifier.setMaxChunksPerDocument(value.round()),
+                  ),
+                  const Divider(height: 32),
+                  Text(
+                    'Last retrieval',
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                  const SizedBox(height: 10),
+                  if (diagnostics == null)
+                    const Text('No chat retrieval has run yet.')
+                  else
+                    _DataBankDiagnostics(snapshot: diagnostics),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SettingsSlider extends StatelessWidget {
+  final String title;
+  final String valueLabel;
+  final double value;
+  final double min;
+  final double max;
+  final int divisions;
+  final bool enabled;
+  final ValueChanged<double> onChanged;
+
+  const _SettingsSlider({
+    super.key,
+    required this.title,
+    required this.valueLabel,
+    required this.value,
+    required this.min,
+    required this.max,
+    required this.divisions,
+    required this.enabled,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Expanded(child: Text(title)),
+            Text(valueLabel, style: Theme.of(context).textTheme.bodySmall),
+          ],
+        ),
+        Slider(
+          value: value,
+          min: min,
+          max: max,
+          divisions: divisions,
+          label: valueLabel,
+          onChanged: enabled ? onChanged : null,
+        ),
+      ],
+    );
+  }
+}
+
+class _DataBankDiagnostics extends StatelessWidget {
+  final DataBankContextSnapshot snapshot;
+
+  const _DataBankDiagnostics({required this.snapshot});
+
+  @override
+  Widget build(BuildContext context) {
+    final mode = switch (snapshot.mode) {
+      DataBankRetrievalMode.localFts => 'Local full-text search',
+      DataBankRetrievalMode.semanticReranked => 'Hybrid semantic reranking',
+      DataBankRetrievalMode.semanticFallback => 'Local fallback',
+    };
+    return Column(
+      key: const Key('data-bank-retrieval-diagnostics'),
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text(
+          snapshot.originalQuery,
+          maxLines: 3,
+          overflow: TextOverflow.ellipsis,
+        ),
+        const SizedBox(height: 4),
+        Text('$mode | ${snapshot.sources.length} source(s)'),
+        if (snapshot.fallbackReason != null)
+          Text(
+            snapshot.fallbackReason!,
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+            style: TextStyle(color: Theme.of(context).colorScheme.error),
+          ),
+        for (final source in snapshot.sources.take(3)) ...[
+          const SizedBox(height: 12),
+          Text(
+            '[${source.label}] ${source.documentName}',
+            style: Theme.of(context).textTheme.titleSmall,
+          ),
+          if (source.locationLabel.isNotEmpty)
+            Text(
+              source.locationLabel,
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+          Text(
+            source.snippet.isEmpty ? source.injectedText : source.snippet,
+            maxLines: 3,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ],
+        if (snapshot.sources.isNotEmpty) ...[
+          const SizedBox(height: 10),
+          Align(
+            alignment: Alignment.centerLeft,
+            child: TextButton.icon(
+              key: const Key('data-bank-open-diagnostics'),
+              onPressed: () => showDataBankCitationSheet(context, snapshot),
+              icon: const Icon(Icons.fact_check_outlined),
+              label: const Text('Inspect all sources'),
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+}
+
 class _DocumentCard extends StatelessWidget {
   final DataBankLibraryEntry entry;
   final bool busy;
@@ -391,7 +631,7 @@ class _DocumentCard extends StatelessWidget {
     final document = entry.document;
     final processing =
         document.processingState == DataBankProcessingState.pending ||
-            document.processingState == DataBankProcessingState.processing;
+        document.processingState == DataBankProcessingState.processing;
     final failed = document.processingState == DataBankProcessingState.failed;
     final disabled =
         document.processingState == DataBankProcessingState.disabled;
@@ -520,8 +760,11 @@ class _SearchResultTile extends StatelessWidget {
       margin: EdgeInsets.zero,
       child: ListTile(
         leading: const Icon(Icons.find_in_page_outlined),
-        title:
-            Text(result.snippet, maxLines: 4, overflow: TextOverflow.ellipsis),
+        title: Text(
+          result.snippet,
+          maxLines: 4,
+          overflow: TextOverflow.ellipsis,
+        ),
         subtitle: Text(source, maxLines: 2, overflow: TextOverflow.ellipsis),
       ),
     );
@@ -592,10 +835,11 @@ class _PreviewSheet extends StatelessWidget {
   }
 }
 
-typedef _SaveBinding = Future<void> Function({
-  required DataBankBindingScope scope,
-  String? targetId,
-});
+typedef _SaveBinding =
+    Future<void> Function({
+      required DataBankBindingScope scope,
+      String? targetId,
+    });
 
 class _BindingsDialog extends StatefulWidget {
   final DataBankLibraryEntry entry;
@@ -672,9 +916,9 @@ class _BindingsDialogState extends State<_BindingsDialog> {
                 onChanged: _working
                     ? null
                     : (scope) => setState(() {
-                          _scope = scope ?? DataBankBindingScope.global;
-                          _targetId = null;
-                        }),
+                        _scope = scope ?? DataBankBindingScope.global;
+                        _targetId = null;
+                      }),
               ),
               if (needsTarget) ...[
                 const SizedBox(height: 12),
@@ -761,8 +1005,7 @@ class _StatusBadge extends StatelessWidget {
       DataBankProcessingState.ready => Colors.green,
       DataBankProcessingState.failed => Theme.of(context).colorScheme.error,
       DataBankProcessingState.disabled => Colors.grey,
-      DataBankProcessingState.pending ||
-      DataBankProcessingState.processing =>
+      DataBankProcessingState.pending || DataBankProcessingState.processing =>
         Theme.of(context).colorScheme.primary,
       DataBankProcessingState.deleted => Colors.grey,
     };
@@ -831,10 +1074,7 @@ class _EmptyState extends StatelessWidget {
             Icon(icon, size: 48, color: Theme.of(context).colorScheme.outline),
             const SizedBox(height: 12),
             Text(title, style: Theme.of(context).textTheme.titleMedium),
-            if (action != null) ...[
-              const SizedBox(height: 16),
-              action!,
-            ],
+            if (action != null) ...[const SizedBox(height: 16), action!],
           ],
         ),
       ),
@@ -843,25 +1083,25 @@ class _EmptyState extends StatelessWidget {
 }
 
 String _stateLabel(DataBankProcessingState state) => switch (state) {
-      DataBankProcessingState.pending => 'Pending',
-      DataBankProcessingState.processing => 'Processing',
-      DataBankProcessingState.ready => 'Ready',
-      DataBankProcessingState.failed => 'Failed',
-      DataBankProcessingState.disabled => 'Disabled',
-      DataBankProcessingState.deleted => 'Deleted',
-    };
+  DataBankProcessingState.pending => 'Pending',
+  DataBankProcessingState.processing => 'Processing',
+  DataBankProcessingState.ready => 'Ready',
+  DataBankProcessingState.failed => 'Failed',
+  DataBankProcessingState.disabled => 'Disabled',
+  DataBankProcessingState.deleted => 'Deleted',
+};
 
 IconData _bindingIcon(DataBankBindingScope scope) => switch (scope) {
-      DataBankBindingScope.global => Icons.public,
-      DataBankBindingScope.character => Icons.person_outline,
-      DataBankBindingScope.chat => Icons.chat_bubble_outline,
-    };
+  DataBankBindingScope.global => Icons.public,
+  DataBankBindingScope.character => Icons.person_outline,
+  DataBankBindingScope.chat => Icons.chat_bubble_outline,
+};
 
 String _scopeLabel(DataBankBindingScope scope) => switch (scope) {
-      DataBankBindingScope.global => 'Global',
-      DataBankBindingScope.character => 'Character',
-      DataBankBindingScope.chat => 'Chat',
-    };
+  DataBankBindingScope.global => 'Global',
+  DataBankBindingScope.character => 'Character',
+  DataBankBindingScope.chat => 'Chat',
+};
 
 String _bindingLabel(DataBankBinding binding) {
   final scope = _scopeLabel(binding.scope);

--- a/lib/presentation/widgets/chat/data_bank_citation_preview.dart
+++ b/lib/presentation/widgets/chat/data_bank_citation_preview.dart
@@ -1,0 +1,192 @@
+import 'package:flutter/material.dart';
+import 'package:native_tavern/data/models/chat.dart';
+import 'package:native_tavern/data/models/data_bank_context.dart';
+
+class DataBankCitationPreview extends StatelessWidget {
+  final ChatMessage message;
+
+  const DataBankCitationPreview({super.key, required this.message});
+
+  @override
+  Widget build(BuildContext context) {
+    final snapshot = dataBankContextForSwipe(
+      message.metadata,
+      message.currentSwipeIndex,
+    );
+    if (snapshot == null || snapshot.sources.isEmpty) {
+      return const SizedBox.shrink();
+    }
+    return Padding(
+      padding: const EdgeInsets.only(top: 6),
+      child: TextButton.icon(
+        key: ValueKey('data-bank-citations-${message.id}'),
+        onPressed: () => showDataBankCitationSheet(context, snapshot),
+        icon: const Icon(Icons.menu_book_outlined, size: 17),
+        label: Text(
+          snapshot.sources.length == 1
+              ? '1 Data Bank source'
+              : '${snapshot.sources.length} Data Bank sources',
+        ),
+        style: TextButton.styleFrom(
+          visualDensity: VisualDensity.compact,
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+        ),
+      ),
+    );
+  }
+}
+
+Future<void> showDataBankCitationSheet(
+  BuildContext context,
+  DataBankContextSnapshot snapshot,
+) {
+  return showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    showDragHandle: true,
+    builder: (context) => DataBankCitationSheet(snapshot: snapshot),
+  );
+}
+
+class DataBankCitationSheet extends StatelessWidget {
+  final DataBankContextSnapshot snapshot;
+  final String title;
+
+  const DataBankCitationSheet({
+    super.key,
+    required this.snapshot,
+    this.title = 'Data Bank sources',
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: ConstrainedBox(
+        constraints: BoxConstraints(
+          maxHeight: MediaQuery.sizeOf(context).height * 0.82,
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 0, 12, 12),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      title,
+                      style: Theme.of(context).textTheme.titleLarge,
+                    ),
+                  ),
+                  IconButton(
+                    tooltip: 'Close',
+                    onPressed: () => Navigator.pop(context),
+                    icon: const Icon(Icons.close),
+                  ),
+                ],
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 0, 20, 12),
+              child: _RetrievalSummary(snapshot: snapshot),
+            ),
+            const Divider(height: 1),
+            Expanded(
+              child: ListView.separated(
+                key: const Key('data-bank-citation-list'),
+                padding: const EdgeInsets.fromLTRB(20, 16, 20, 24),
+                itemCount: snapshot.sources.length,
+                separatorBuilder: (_, __) => const Divider(height: 28),
+                itemBuilder: (context, index) =>
+                    _CitationSource(source: snapshot.sources[index]),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _RetrievalSummary extends StatelessWidget {
+  final DataBankContextSnapshot snapshot;
+
+  const _RetrievalSummary({required this.snapshot});
+
+  @override
+  Widget build(BuildContext context) {
+    final mode = switch (snapshot.mode) {
+      DataBankRetrievalMode.localFts => 'Local full-text search',
+      DataBankRetrievalMode.semanticReranked => 'Hybrid semantic reranking',
+      DataBankRetrievalMode.semanticFallback => 'Local full-text fallback',
+    };
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          snapshot.originalQuery,
+          key: const Key('data-bank-citation-query'),
+          maxLines: 3,
+          overflow: TextOverflow.ellipsis,
+          style: Theme.of(context).textTheme.bodyMedium,
+        ),
+        const SizedBox(height: 4),
+        Text(mode, style: Theme.of(context).textTheme.bodySmall),
+        if (snapshot.queries.length > 1)
+          Text(
+            '${snapshot.queries.length} local queries fused',
+            style: Theme.of(context).textTheme.bodySmall,
+          ),
+        if (snapshot.fallbackReason != null)
+          Text(
+            snapshot.fallbackReason!,
+            key: const Key('data-bank-semantic-fallback'),
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              color: Theme.of(context).colorScheme.error,
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _CitationSource extends StatelessWidget {
+  final DataBankContextSource source;
+
+  const _CitationSource({required this.source});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      key: ValueKey('data-bank-citation-${source.citation.chunkId}'),
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Icon(Icons.description_outlined, size: 19),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(
+                '[${source.label}] ${source.documentName}',
+                style: Theme.of(context).textTheme.titleSmall,
+              ),
+            ),
+          ],
+        ),
+        if (source.locationLabel.isNotEmpty) ...[
+          const SizedBox(height: 3),
+          Text(
+            source.locationLabel,
+            key: ValueKey('data-bank-location-${source.citation.chunkId}'),
+            style: Theme.of(context).textTheme.bodySmall,
+          ),
+        ],
+        const SizedBox(height: 8),
+        SelectableText(source.injectedText),
+      ],
+    );
+  }
+}

--- a/lib/presentation/widgets/chat/visual_novel_message_view.dart
+++ b/lib/presentation/widgets/chat/visual_novel_message_view.dart
@@ -6,6 +6,7 @@ import 'package:native_tavern/data/models/character.dart';
 import 'package:native_tavern/l10n/generated/app_localizations.dart';
 import 'package:native_tavern/presentation/theme/app_theme.dart';
 import 'package:native_tavern/presentation/widgets/chat/message_content_widget.dart';
+import 'package:native_tavern/presentation/widgets/chat/data_bank_citation_preview.dart';
 import 'package:native_tavern/presentation/widgets/chat/reasoning_widget.dart';
 import 'package:native_tavern/presentation/widgets/common/character_avatar_image.dart';
 
@@ -164,10 +165,7 @@ class _VisualNovelMessageViewState
         ),
         borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
         border: Border(
-          top: BorderSide(
-            color: Colors.white.withValues(alpha: 0.2),
-            width: 1,
-          ),
+          top: BorderSide(color: Colors.white.withValues(alpha: 0.2), width: 1),
         ),
       ),
       child: PageView.builder(
@@ -226,6 +224,8 @@ class _VisualNovelMessageViewState
                 isStreaming: isGenerating,
                 messageId: message.id,
               ),
+            if (!isUser && !isGenerating)
+              DataBankCitationPreview(message: message),
             // Swipe controls
             if (hasSwipes && !isGenerating) _buildSwipeControls(message),
           ],
@@ -381,10 +381,7 @@ class _VisualNovelMessageViewState
             ),
             child: Text(
               '${currentSwipeIndex + 1} / $totalSwipes',
-              style: const TextStyle(
-                color: Colors.white70,
-                fontSize: 12,
-              ),
+              style: const TextStyle(color: Colors.white70, fontSize: 12),
             ),
           ),
           IconButton(

--- a/test/chat_extension_end_to_end_test.dart
+++ b/test/chat_extension_end_to_end_test.dart
@@ -97,9 +97,11 @@ void main() {
 
     final assembly = container.read(lastContextAssemblyProvider);
     expect(assembly, isNotNull);
-    expect(assembly!.traces.single.contributorId, 'test.memory');
+    final memoryTrace = assembly!.traces.singleWhere(
+      (trace) => trace.contributorId == 'test.memory',
+    );
     expect(
-      assembly.traces.single.status,
+      memoryTrace.status,
       ContextContributionStatus.applied,
     );
     final generation = container.read(lastChatGenerationTraceProvider);
@@ -107,7 +109,7 @@ void main() {
     expect(generation?.middlewareTraces, hasLength(2));
   });
 
-  test('empty registry sends the assembled baseline without pipeline changes',
+  test('Data Bank with no matches sends the baseline without prompt changes',
       () async {
     final notifier = container.read(activeChatProvider.notifier);
     await notifier.createChat('character-1');
@@ -116,7 +118,12 @@ void main() {
 
     final assembly = container.read(lastContextAssemblyProvider);
     expect(assembly, isNotNull);
-    expect(assembly!.traces, isEmpty);
+    expect(assembly!.traces, hasLength(1));
+    expect(
+      assembly.traces.single.contributorId,
+      'data-bank.retrieval',
+    );
+    expect(assembly.traces.single.injectedMessages, isEmpty);
     expect(llmService.requests.single, assembly.messages);
     expect(
       llmService.requests.single

--- a/test/data_bank_chat_end_to_end_test.dart
+++ b/test/data_bank_chat_end_to_end_test.dart
@@ -1,0 +1,295 @@
+// Test fixtures intentionally exercise real asynchronous file I/O.
+// ignore_for_file: avoid_slow_async_io
+
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:native_tavern/core/services/initialization_service.dart';
+import 'package:native_tavern/data/database/database.dart';
+import 'package:native_tavern/data/models/chat.dart' as chat_models;
+import 'package:native_tavern/data/models/character.dart' as models;
+import 'package:native_tavern/data/models/data_bank.dart';
+import 'package:native_tavern/data/models/data_bank_context.dart';
+import 'package:native_tavern/data/repositories/character_repository.dart';
+import 'package:native_tavern/data/repositories/chat_repository.dart';
+import 'package:native_tavern/data/repositories/drift_data_bank_repository.dart';
+import 'package:native_tavern/domain/services/chat_generation_pipeline.dart';
+import 'package:native_tavern/domain/services/llm_service.dart';
+import 'package:native_tavern/presentation/providers/chat_extension_providers.dart';
+import 'package:native_tavern/presentation/providers/chat_providers.dart';
+import 'package:native_tavern/presentation/providers/data_bank_providers.dart';
+import 'package:native_tavern/presentation/providers/settings_providers.dart';
+import 'package:native_tavern/presentation/providers/vector_storage_providers.dart';
+import 'package:path/path.dart' as path;
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory temporary;
+  late Directory input;
+  late AppDatabase database;
+  late CharacterRepository characterRepository;
+  late ChatRepository chatRepository;
+  late DriftDataBankRepository dataBankRepository;
+  late _RecordingLLMService llmService;
+  late ProviderContainer container;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    final preferences = await SharedPreferences.getInstance();
+    temporary = Directory.systemTemp.createTempSync('nt_data_bank_chat_');
+    input = Directory(path.join(temporary.path, 'input'))..createSync();
+    database = AppDatabase.forTesting(NativeDatabase.memory());
+    characterRepository = CharacterRepository(database, temporary.path);
+    chatRepository = ChatRepository(database);
+    dataBankRepository = DriftDataBankRepository(database);
+    llmService = _RecordingLLMService();
+    container = ProviderContainer(overrides: [
+      databaseProvider.overrideWithValue(database),
+      dataPathProvider.overrideWithValue(temporary.path),
+      characterRepositoryProvider.overrideWithValue(characterRepository),
+      chatRepositoryProvider.overrideWithValue(chatRepository),
+      dataBankRepositoryProvider.overrideWithValue(dataBankRepository),
+      llmServiceProvider.overrideWithValue(llmService),
+      sharedPreferencesProvider.overrideWithValue(preferences),
+      ragContextProvider.overrideWithValue((_) async => null),
+    ]);
+
+    final now = DateTime.utc(2026, 8, 8, 12);
+    await characterRepository.createCharacter(models.Character(
+      id: 'character-1',
+      name: 'Archivist',
+      description: 'Answers with verifiable references.',
+      createdAt: now,
+      modifiedAt: now,
+    ));
+  });
+
+  tearDown(() async {
+    container.dispose();
+    await database.close();
+    if (temporary.existsSync()) temporary.deleteSync(recursive: true);
+  });
+
+  test(
+      'real imports, bindings, lifecycle, chat injection, and citations stay aligned',
+      () async {
+    final notifier = container.read(activeChatProvider.notifier);
+    final chatId = await notifier.createChat('character-1');
+    expect(chatId, isNotNull);
+    final library = container.read(dataBankLibraryServiceProvider);
+
+    final global = await library.importDocument(
+      _writeDocument(
+        input,
+        'global.md',
+        '# Global Route\nnavigation marker global route',
+      ),
+    );
+    final character = await library.importDocument(
+      _writeDocument(
+        input,
+        'character.md',
+        '# Character Route\nnavigation marker character route',
+      ),
+    );
+    await library.removeBinding(character.bindings.single.id);
+    await library.saveBinding(
+      documentId: character.document.id,
+      scope: DataBankBindingScope.character,
+      targetId: 'character-1',
+    );
+    final chat = await library.importDocument(
+      _writeDocument(
+        input,
+        'chat.md',
+        '# Chat Route\nnavigation marker chat route',
+      ),
+    );
+    await library.removeBinding(chat.bindings.single.id);
+    await library.saveBinding(
+      documentId: chat.document.id,
+      scope: DataBankBindingScope.chat,
+      targetId: chatId,
+    );
+
+    await notifier.sendMessage('navigation marker', _config);
+
+    expect(llmService.requests, hasLength(1));
+    final firstPrompt = _joinedPrompt(llmService.requests.single);
+    expect(firstPrompt, contains('global.md'));
+    expect(firstPrompt, contains('character.md'));
+    expect(firstPrompt, contains('chat.md'));
+    final firstSaved = await chatRepository.getMessages(chatId!);
+    final firstContext = dataBankContextForSwipe(
+      firstSaved.last.metadata,
+      firstSaved.last.currentSwipeIndex,
+    );
+    expect(firstContext, isNotNull);
+    expect(
+      firstContext!.sources.map((source) => source.citation.documentId).toSet(),
+      {global.document.id, character.document.id, chat.document.id},
+    );
+    expect(
+      firstContext.sources.every(
+        (source) => source.citation.quote.contains('navigation marker'),
+      ),
+      isTrue,
+    );
+    final chatChunkId = firstContext.sources
+        .singleWhere(
+          (source) => source.citation.documentId == chat.document.id,
+        )
+        .citation
+        .chunkId;
+
+    final replacementId = '${global.version.id}-replacement';
+    const replacementText = 'navigation marker revised global route';
+    final replacement = DataBankDocumentVersion(
+      id: replacementId,
+      documentId: global.document.id,
+      versionNumber: 2,
+      supersedesVersionId: global.version.id,
+      originalFileName: 'global-revised.md',
+      mediaType: 'text/markdown',
+      byteSize: replacementText.length,
+      contentHash: DataBankContentHash(
+        algorithm: DataBankHashAlgorithm.sha256,
+        digest: 'b' * 64,
+      ),
+      importedAt: DateTime.utc(2026, 8, 8, 13),
+      processingState: DataBankProcessingState.ready,
+      indexState: DataBankIndexState.indexed,
+    );
+    await dataBankRepository.replaceCurrentVersion(
+      documentId: global.document.id,
+      expectedCurrentVersionId: global.version.id,
+      replacement: replacement,
+    );
+    final replacementSectionId = '$replacementId-section';
+    final replacementLocator = DataBankSourceLocator(
+      documentVersionId: replacementId,
+      sectionId: replacementSectionId,
+      chapter: 'Revised Route',
+      startOffset: 0,
+      endOffset: replacementText.length,
+    );
+    await dataBankRepository.replaceSections(replacementId, [
+      DataBankSection(
+        id: replacementSectionId,
+        documentVersionId: replacementId,
+        kind: DataBankSectionKind.chapter,
+        title: 'Revised Route',
+        ordinal: 0,
+        locator: replacementLocator,
+      ),
+    ]);
+    await dataBankRepository.replaceChunks(replacementId, [
+      DataBankTextChunk(
+        id: '$replacementId-chunk',
+        documentVersionId: replacementId,
+        sectionId: replacementSectionId,
+        ordinal: 0,
+        text: replacementText,
+        locator: replacementLocator,
+      ),
+    ]);
+    await library.setDocumentEnabled(character.document.id, false);
+
+    await notifier.sendMessage('navigation marker', _config);
+
+    final secondContext =
+        _latestContext(await chatRepository.getMessages(chatId));
+    expect(
+      secondContext.sources.map((source) => source.citation.documentId),
+      isNot(contains(character.document.id)),
+    );
+    final revisedSource = secondContext.sources.singleWhere(
+      (source) => source.citation.documentId == global.document.id,
+    );
+    expect(revisedSource.citation.documentVersionId, replacementId);
+    expect(revisedSource.citation.quote, replacementText);
+    expect(
+      secondContext.sources.map((source) => source.citation.documentVersionId),
+      isNot(contains(global.version.id)),
+    );
+
+    final chatManagedDirectory = Directory(
+      path.join(temporary.path, 'data_bank', chat.document.id),
+    );
+    expect(chatManagedDirectory.existsSync(), isTrue);
+    await library.deleteDocument(chat.document.id);
+    expect(chatManagedDirectory.existsSync(), isFalse);
+
+    await notifier.sendMessage('navigation marker', _config);
+
+    final thirdContext =
+        _latestContext(await chatRepository.getMessages(chatId));
+    expect(thirdContext.sources, hasLength(1));
+    expect(thirdContext.sources.single.citation.documentId, global.document.id);
+    expect(await dataBankRepository.getDocument(chat.document.id), isNull);
+    expect(await dataBankRepository.getChunk(chatChunkId), isNull);
+
+    container.read(dataBankContextSettingsProvider.notifier).setEnabled(false);
+    await notifier.sendMessage('navigation marker', _config);
+
+    final assembly = container.read(lastContextAssemblyProvider);
+    expect(assembly?.traces.single.status, ContextContributionStatus.disabled);
+    expect(
+      _joinedPrompt(llmService.requests.last),
+      isNot(contains('Relevant Data Bank sources')),
+    );
+    final lastSaved = (await chatRepository.getMessages(chatId)).last;
+    expect(
+      dataBankContextForSwipe(lastSaved.metadata, lastSaved.currentSwipeIndex),
+      isNull,
+    );
+  });
+}
+
+File _writeDocument(Directory input, String name, String contents) {
+  return File(path.join(input.path, name))..writeAsStringSync(contents);
+}
+
+DataBankContextSnapshot _latestContext(
+  List<chat_models.ChatMessage> messages,
+) {
+  final message = messages.last;
+  return dataBankContextForSwipe(message.metadata, message.currentSwipeIndex)!;
+}
+
+String _joinedPrompt(List<ChatMessageMap> messages) {
+  return messages
+      .map((message) => message['content'])
+      .whereType<String>()
+      .join('\n');
+}
+
+const _config = LLMConfig(
+  provider: LLMProvider.openAICompatible,
+  model: 'test-model',
+  apiKey: '',
+  apiUrl: 'http://localhost',
+  contextLength: 8192,
+  maxTokens: 256,
+  streamEnabled: false,
+  autoSummarizeEnabled: false,
+);
+
+final class _RecordingLLMService extends LLMService {
+  final List<List<ChatMessageMap>> requests = [];
+
+  @override
+  Future<LLMResponse> generateWithReasoning(
+    List<Map<String, dynamic>> messages,
+    LLMConfig config,
+  ) async {
+    requests.add(
+      messages.map((message) => Map<String, dynamic>.from(message)).toList(),
+    );
+    return const LLMResponse(content: 'Answer from verified sources.');
+  }
+}

--- a/test/data_bank_citation_preview_test.dart
+++ b/test/data_bank_citation_preview_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:native_tavern/data/models/chat.dart';
+import 'package:native_tavern/data/models/data_bank.dart';
+import 'package:native_tavern/data/models/data_bank_context.dart';
+import 'package:native_tavern/presentation/widgets/chat/data_bank_citation_preview.dart';
+
+void main() {
+  testWidgets('reply preview opens exact document and locator details',
+      (tester) async {
+    final locator = DataBankSourceLocator(
+      documentVersionId: 'version-2',
+      sectionId: 'section-2',
+      chapter: 'Safe Harbor',
+      pageStart: 7,
+      startOffset: 320,
+      endOffset: 390,
+    );
+    final chunk = DataBankTextChunk(
+      id: 'chunk-2',
+      documentVersionId: 'version-2',
+      sectionId: 'section-2',
+      ordinal: 0,
+      text: 'Ships enter through the eastern channel.',
+      locator: locator,
+    );
+    final snapshot = DataBankContextSnapshot(
+      sessionId: 'session-2',
+      originalQuery: 'eastern channel',
+      queries: const ['eastern channel'],
+      mode: DataBankRetrievalMode.semanticReranked,
+      sources: [
+        DataBankContextSource(
+          label: 'D1',
+          documentName: 'harbor-guide.pdf',
+          snippet: 'eastern channel',
+          injectedText: chunk.text,
+          citation: chunk.toCitation('document-2'),
+        ),
+      ],
+    );
+    final message = ChatMessage(
+      id: 'message-1',
+      chatId: 'chat-1',
+      role: MessageRole.assistant,
+      content: 'Use the eastern channel.',
+      timestamp: DateTime.utc(2026, 8, 8),
+      swipes: const ['Use the eastern channel.'],
+      metadata: appendDataBankContextMetadata(
+        metadata: const {},
+        existingSwipeCount: 0,
+        snapshot: snapshot,
+      ),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: DataBankCitationPreview(message: message),
+        ),
+      ),
+    );
+
+    expect(find.text('1 Data Bank source'), findsOneWidget);
+    await tester.tap(find.byKey(const Key('data-bank-citations-message-1')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('[D1] harbor-guide.pdf'), findsOneWidget);
+    expect(find.text('Safe Harbor | p. 7 | chars 320-390'), findsOneWidget);
+    expect(find.text(chunk.text), findsOneWidget);
+    expect(find.text('Hybrid semantic reranking'), findsOneWidget);
+  });
+}

--- a/test/data_bank_context_service_test.dart
+++ b/test/data_bank_context_service_test.dart
@@ -1,0 +1,351 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:native_tavern/data/models/data_bank.dart';
+import 'package:native_tavern/data/models/data_bank_context.dart';
+import 'package:native_tavern/data/models/vector_storage.dart';
+import 'package:native_tavern/domain/repositories/data_bank_repository.dart';
+import 'package:native_tavern/domain/services/chat_generation_pipeline.dart';
+import 'package:native_tavern/domain/services/data_bank_context_service.dart';
+import 'package:native_tavern/domain/services/llm_service.dart';
+import 'package:native_tavern/domain/services/tokenizer_service.dart';
+
+void main() {
+  test('disabled contributor leaves the assembled prompt byte-for-byte intact',
+      () async {
+    final repository = _SearchRepository({});
+    final contributor = DataBankContextContributor(
+      service: DataBankContextService(repository: repository),
+      settings: () => const DataBankContextSettings(enabled: false),
+      embeddingSettings: () => const VectorStorageSettings(),
+    );
+    final registry = ChatExtensionRegistry()..registerContributor(contributor);
+    final pipeline = ChatGenerationPipeline(registry: registry);
+    final session = pipeline.startSession(
+      chatId: 'chat-1',
+      characterId: 'character-1',
+      mode: ChatGenerationMode.send,
+      config: _config,
+    );
+    final baseline = <ChatMessageMap>[
+      {'role': 'system', 'content': 'Stay in character.'},
+      {'role': 'user', 'content': 'eastern harbor'},
+    ];
+
+    final assembly = await session.assemble(baseline);
+
+    expect(assembly.messages, baseline);
+    expect(assembly.traces.single.status, ContextContributionStatus.disabled);
+    expect(repository.queries, isEmpty);
+    session.close();
+    await pipeline.dispose();
+  });
+
+  test('rewrites into fused local queries and applies scope and diversity',
+      () async {
+    final repository = _SearchRepository({
+      'Where is it?': [
+        _result('a-1', 'document-a', rank: -4),
+        _result('a-2', 'document-a', rank: -3),
+        _result('b-1', 'document-b', rank: -2),
+      ],
+      'eastern harbor': [
+        _result('c-1', 'document-c', rank: -8),
+      ],
+    });
+    final service = DataBankContextService(repository: repository);
+
+    final payload = await service.retrieve(
+      request: _request(const [
+        {'role': 'user', 'content': 'eastern harbor'},
+        {'role': 'assistant', 'content': 'It is near the cliffs.'},
+        {'role': 'user', 'content': 'Where is it?'},
+      ]),
+      settings: const DataBankContextSettings(
+        queryRewriteEnabled: true,
+        topK: 3,
+        maxChunksPerDocument: 1,
+        maxTokens: 800,
+      ),
+      embeddingSettings: const VectorStorageSettings(),
+    );
+
+    expect(payload.snapshot.queries, ['Where is it?', 'eastern harbor']);
+    expect(
+      payload.snapshot.sources
+          .map((source) => source.citation.documentId)
+          .toSet(),
+      {'document-a', 'document-b', 'document-c'},
+    );
+    expect(payload.prompt, contains('Document: document-a.md'));
+    expect(payload.prompt, contains('chapter "Reference"'));
+    expect(payload.prompt, contains('page 7'));
+    expect(
+      repository.filters,
+      everyElement(
+        isA<DataBankSearchFilter>()
+            .having((filter) => filter.includeUnbound, 'includeUnbound', false)
+            .having(
+                (filter) => filter.characterId, 'characterId', 'character-1')
+            .having((filter) => filter.chatId, 'chatId', 'chat-1'),
+      ),
+    );
+  });
+
+  test('semantic reranking changes hybrid order', () async {
+    final repository = _SearchRepository({
+      'compass': [
+        _result('local-first', 'document-a', rank: -10),
+        _result('semantic-first', 'document-b', rank: -2),
+      ],
+    });
+    final service = DataBankContextService(
+      repository: repository,
+      embedBatch: (texts, settings) async => [
+        [1, 0],
+        [0, 1],
+        [1, 0],
+      ],
+    );
+
+    final payload = await service.retrieve(
+      request: _request(const [
+        {'role': 'user', 'content': 'compass'},
+      ]),
+      settings: const DataBankContextSettings(
+        semanticRerankingEnabled: true,
+        semanticWeight: 0.9,
+        topK: 2,
+      ),
+      embeddingSettings: const VectorStorageSettings(
+        embeddingProvider: EmbeddingProvider.custom,
+        embeddingEndpoint: 'http://localhost:11434/v1',
+      ),
+    );
+
+    expect(payload.snapshot.mode, DataBankRetrievalMode.semanticReranked);
+    expect(payload.snapshot.sources.first.citation.chunkId, 'semantic-first');
+  });
+
+  test('embedding failure preserves original FTS order', () async {
+    final repository = _SearchRepository({
+      'offline archive': [
+        _result('fts-first', 'document-a', rank: -10),
+        _result('fts-second', 'document-b', rank: -2),
+      ],
+    });
+    final service = DataBankContextService(
+      repository: repository,
+      embedBatch: (texts, settings) async => throw StateError('offline'),
+    );
+
+    final payload = await service.retrieve(
+      request: _request(const [
+        {'role': 'user', 'content': 'offline archive'},
+      ]),
+      settings: const DataBankContextSettings(
+        semanticRerankingEnabled: true,
+        topK: 2,
+      ),
+      embeddingSettings: const VectorStorageSettings(),
+    );
+
+    expect(payload.snapshot.mode, DataBankRetrievalMode.semanticFallback);
+    expect(payload.snapshot.fallbackReason, contains('offline'));
+    expect(
+      payload.snapshot.sources.map((source) => source.citation.chunkId),
+      ['fts-first', 'fts-second'],
+    );
+  });
+
+  test('assembled source text stays inside the contributor token budget',
+      () async {
+    final repository = _SearchRepository({
+      'large reference': [
+        _result(
+          'large',
+          'large-document',
+          rank: -10,
+          text: List.filled(400, 'large reference passage').join(' '),
+        ),
+      ],
+    });
+    final service = DataBankContextService(repository: repository);
+
+    final payload = await service.retrieve(
+      request: _request(const [
+        {'role': 'user', 'content': 'large reference'},
+      ]),
+      settings: const DataBankContextSettings(maxTokens: 180),
+      embeddingSettings: const VectorStorageSettings(),
+    );
+
+    expect(payload.snapshot.sources, hasLength(1));
+    expect(
+        payload.snapshot.sources.single.injectedText, contains('[truncated]'));
+    expect(
+      TokenizerService().estimateTokenCount(payload.prompt!) + 4,
+      lessThanOrEqualTo(180),
+    );
+  });
+
+  test('citation metadata remains aligned when swipes are appended or removed',
+      () {
+    final first = _snapshot('session-1', _result('chunk-1', 'document-a'));
+    final second = _snapshot('session-2', _result('chunk-2', 'document-b'));
+    var metadata = appendDataBankContextMetadata(
+      metadata: const {},
+      existingSwipeCount: 0,
+      snapshot: first,
+    );
+    metadata = appendDataBankContextMetadata(
+      metadata: metadata,
+      existingSwipeCount: 1,
+      snapshot: second,
+    );
+
+    expect(dataBankContextForSwipe(metadata, 0)?.sessionId, 'session-1');
+    expect(dataBankContextForSwipe(metadata, 1)?.sessionId, 'session-2');
+
+    metadata = removeDataBankContextMetadataAt(
+      metadata: metadata,
+      swipeIndex: 0,
+    );
+    expect(dataBankContextForSwipe(metadata, 0)?.sessionId, 'session-2');
+  });
+
+  test('section-only locators retain a useful citation location', () async {
+    final locator = DataBankSourceLocator(
+      documentVersionId: 'version-1',
+      sectionId: 'section-1',
+    );
+    final chunk = DataBankTextChunk(
+      id: 'chunk-1',
+      documentVersionId: 'version-1',
+      sectionId: 'section-1',
+      ordinal: 0,
+      text: 'Section-only reference.',
+      locator: locator,
+    );
+    final result = DataBankSearchResult(
+      chunk: chunk,
+      citation: chunk.toCitation('document-1'),
+      documentName: 'reference.md',
+      snippet: chunk.text,
+      rank: -1,
+    );
+    final service = DataBankContextService(
+      repository: _SearchRepository({
+        'reference': [result],
+      }),
+    );
+
+    final payload = await service.retrieve(
+      request: _request(const [
+        {'role': 'user', 'content': 'reference'},
+      ]),
+      settings: const DataBankContextSettings(),
+      embeddingSettings: const VectorStorageSettings(),
+    );
+
+    expect(payload.snapshot.sources.single.locationLabel, 'Section section-1');
+    expect(payload.prompt, contains('Location: section section-1'));
+  });
+}
+
+const _config = LLMConfig(
+  provider: LLMProvider.openAICompatible,
+  model: 'test-model',
+  apiKey: '',
+  apiUrl: 'http://localhost',
+  contextLength: 4096,
+  maxTokens: 256,
+  streamEnabled: false,
+  autoSummarizeEnabled: false,
+);
+
+ChatContextRequest _request(List<ChatMessageMap> messages) {
+  return ChatContextRequest(
+    sessionId: 'session-1',
+    chatId: 'chat-1',
+    characterId: 'character-1',
+    mode: ChatGenerationMode.send,
+    baseMessages: messages,
+    inputTokenBudget: 4096,
+    availableContributionTokens: 2048,
+    cancellationToken: ChatCancellationToken(),
+  );
+}
+
+DataBankContextSnapshot _snapshot(
+  String sessionId,
+  DataBankSearchResult result,
+) {
+  return DataBankContextSnapshot(
+    sessionId: sessionId,
+    originalQuery: 'query',
+    queries: const ['query'],
+    mode: DataBankRetrievalMode.localFts,
+    sources: [
+      DataBankContextSource(
+        label: 'D1',
+        documentName: result.documentName,
+        snippet: result.snippet,
+        injectedText: result.chunk.text,
+        citation: result.citation,
+      ),
+    ],
+  );
+}
+
+DataBankSearchResult _result(
+  String chunkId,
+  String documentId, {
+  double rank = -1,
+  String? text,
+}) {
+  final content = text ?? 'The eastern channel is safe before dawn.';
+  final locator = DataBankSourceLocator(
+    documentVersionId: '$documentId-version',
+    sectionId: '$documentId-section',
+    chapter: 'Reference',
+    pageStart: 7,
+    startOffset: 10,
+    endOffset: 10 + content.length,
+  );
+  final chunk = DataBankTextChunk(
+    id: chunkId,
+    documentVersionId: '$documentId-version',
+    sectionId: '$documentId-section',
+    ordinal: 0,
+    text: content,
+    locator: locator,
+  );
+  return DataBankSearchResult(
+    chunk: chunk,
+    citation: chunk.toCitation(documentId),
+    documentName: '$documentId.md',
+    snippet: content,
+    rank: rank,
+  );
+}
+
+final class _SearchRepository implements DataBankSearchRepository {
+  final Map<String, List<DataBankSearchResult>> results;
+  final List<String> queries = [];
+  final List<DataBankSearchFilter> filters = [];
+
+  _SearchRepository(this.results);
+
+  @override
+  Future<void> rebuildSearchIndex() async {}
+
+  @override
+  Future<List<DataBankSearchResult>> search(
+    String query, {
+    int topK = 20,
+    DataBankSearchFilter filter = const DataBankSearchFilter(),
+  }) async {
+    queries.add(query);
+    filters.add(filter);
+    return (results[query] ?? const []).take(topK).toList(growable: false);
+  }
+}

--- a/test/data_bank_screen_test.dart
+++ b/test/data_bank_screen_test.dart
@@ -4,11 +4,15 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:native_tavern/data/models/data_bank.dart';
+import 'package:native_tavern/data/models/data_bank_context.dart';
 import 'package:native_tavern/domain/repositories/data_bank_repository.dart';
 import 'package:native_tavern/domain/services/data_bank_ingestion_service.dart';
 import 'package:native_tavern/domain/services/data_bank_library_service.dart';
 import 'package:native_tavern/presentation/controllers/data_bank_library_controller.dart';
+import 'package:native_tavern/presentation/providers/data_bank_providers.dart';
+import 'package:native_tavern/presentation/providers/settings_providers.dart';
 import 'package:native_tavern/presentation/screens/data_bank/data_bank_screen.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
   testWidgets('management screen exposes document states and real actions',
@@ -61,6 +65,78 @@ void main() {
 
     expect(operations.deletedIds, ['ready']);
     expect(find.text('ready.md'), findsNothing);
+  });
+
+  testWidgets('chat retrieval settings and citation diagnostics are operable',
+      (tester) async {
+    SharedPreferences.setMockInitialValues({});
+    final preferences = await SharedPreferences.getInstance();
+    final controller = DataBankLibraryController(_FakeDataBankOperations());
+    final chunk = _chunk('ready');
+    final diagnostics = DataBankContextSnapshot(
+      sessionId: 'session-1',
+      originalQuery: 'eastern channel',
+      queries: const ['eastern channel'],
+      mode: DataBankRetrievalMode.localFts,
+      sources: [
+        DataBankContextSource(
+          label: 'D1',
+          documentName: 'ready.md',
+          snippet: 'Eastern channel match',
+          injectedText: chunk.text,
+          citation: chunk.toCitation('ready'),
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(preferences),
+          lastDataBankContextProvider.overrideWith((ref) => diagnostics),
+        ],
+        child: MaterialApp(
+          home: DataBankScreen(
+            controller: controller,
+            fileGateway: const _NullFileGateway(),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('data-bank-context-settings')));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const Key('data-bank-context-enabled')), findsOneWidget);
+    expect(find.byKey(const Key('data-bank-query-rewrite')), findsOneWidget);
+    expect(
+      find.byKey(const Key('data-bank-semantic-reranking')),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.byKey(const Key('data-bank-query-rewrite')));
+    await tester.pumpAndSettle();
+    final stored = preferences.getString('data_bank_context_settings');
+    expect(stored, contains('"queryRewriteEnabled":true'));
+
+    await tester.scrollUntilVisible(
+      find.byKey(const Key('data-bank-retrieval-diagnostics')),
+      300,
+      scrollable: find.byType(Scrollable).last,
+    );
+    await tester.pumpAndSettle();
+    expect(
+      find.byKey(const Key('data-bank-retrieval-diagnostics')),
+      findsOneWidget,
+    );
+    expect(find.text('ready.md'), findsOneWidget);
+    expect(find.textContaining('chars 0-42'), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('data-bank-open-diagnostics')));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const Key('data-bank-citation-list')), findsOneWidget);
+    expect(
+        find.textContaining('Ships use the eastern channel'), findsOneWidget);
   });
 }
 

--- a/test/database_migration_harness_test.dart
+++ b/test/database_migration_harness_test.dart
@@ -2,7 +2,9 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:native_tavern/data/models/long_term_memory.dart';
+import 'package:native_tavern/data/repositories/drift_data_bank_repository.dart';
 import 'package:native_tavern/data/repositories/drift_long_term_memory_repository.dart';
+import 'package:native_tavern/domain/repositories/data_bank_repository.dart';
 import 'package:native_tavern/domain/services/database_backup_service.dart';
 
 import 'support/database_migration_harness.dart';
@@ -159,6 +161,29 @@ void main() {
     expect(await readSchemaVersion(database), 15);
     expect(matches.map((result) => result.memory.id), ['memory-1']);
     expect(matches.single.memory.source.sourceMessageIds, ['message-1']);
+  });
+
+  test('existing v15 data recovers a missing Data Bank search index', () async {
+    final file = File('${harness.directory.path}/data_bank_fts.sqlite');
+    var database = harness.openWithProductionMigrations(file);
+    await seedCurrentRepresentativeData(database);
+    await database.customStatement('DROP TABLE data_bank_text_chunks_fts');
+    await harness.close(database);
+
+    database = harness.openWithProductionMigrations(file);
+    final repository = DriftDataBankRepository(database);
+    final matches = await repository.search(
+      'Fixture source',
+      filter: const DataBankSearchFilter.forContext(
+        characterId: 'character-1',
+        chatId: 'chat-1',
+      ),
+    );
+
+    expect(await readSchemaVersion(database), 15);
+    expect(matches.map((result) => result.chunk.id), ['chunk-1']);
+    expect(matches.single.citation.documentId, 'document-1');
+    expect(matches.single.citation.documentVersionId, 'version-1');
   });
 
   test('failed v15 migration rolls back every new table', () async {


### PR DESCRIPTION
## Summary

- F07: register a production Data Bank context contributor with binding-aware local retrieval, token budgets, source diversity, persisted per-swipe citations, and citation previews in standard and visual-novel chat.
- F08: add optional conversation query expansion and hybrid embedding reranking using existing embedding settings, with deterministic fallback to the original FTS order on missing configuration or external failures.
- F09: cover real import, Drift persistence, FTS retrieval, chat injection, citation accuracy, binding lifecycle, disable/delete cleanup, version replacement, duplicate import, large content budgets, and migration/index recovery.

## Verification

- flutter test: 320 passed, 2 conditional PDFium tests skipped because PDFIUM_MODULE_PATH is not configured.
- Changed-file analysis: no new errors or warnings; existing lint findings remain in the large chat files.
- git diff --check: clean.

Closes #31
