### PR TITLE
feat(mcp): add client discovery and management UI

### DIFF
--- a/lib/domain/models/built_in_tool.dart
+++ b/lib/domain/models/built_in_tool.dart
@@ -11,6 +11,8 @@ enum ToolDataScope {
   worldInfoContent,
   imagePrompt,
   generatedImage,
+  mcpToolArguments,
+  mcpToolResult,
 }
 
 enum ToolAuthorizationSource { none, userSettings, oneTimeApproval, dryRun }

--- a/lib/domain/models/mcp.dart
+++ b/lib/domain/models/mcp.dart
@@ -1,0 +1,393 @@
+import 'dart:convert';
+
+import 'package:crypto/crypto.dart';
+import 'package:native_tavern/domain/models/built_in_tool.dart';
+import 'package:native_tavern/domain/models/tool_calling.dart';
+
+enum McpTransportType { streamableHttp, legacySse }
+
+enum McpConnectionStatus {
+  disabled,
+  disconnected,
+  connecting,
+  connected,
+  reconnecting,
+  error,
+}
+
+enum McpToolPermission { askEveryTime, alwaysAllow, denied }
+
+enum McpApprovalDecision { allowOnce, alwaysAllow, deny, cancel }
+
+enum McpActivityKind {
+  configured,
+  connected,
+  disconnected,
+  discovery,
+  permission,
+  error,
+  cancelled,
+}
+
+final class McpException implements Exception {
+  const McpException(this.code, this.message);
+
+  final String code;
+  final String message;
+
+  @override
+  String toString() => 'MCP error [$code]: $message';
+}
+
+final class McpServerConfig {
+  McpServerConfig({
+    required String id,
+    required String name,
+    required Uri endpoint,
+    this.transport = McpTransportType.streamableHttp,
+    this.enabled = false,
+    this.allowInsecureHttp = false,
+    Duration connectTimeout = const Duration(seconds: 15),
+    Duration requestTimeout = const Duration(seconds: 30),
+  })  : id = _validateId(id),
+        name = _validateName(name),
+        endpoint = _validateEndpoint(endpoint, allowInsecureHttp),
+        connectTimeout = _validateDuration(connectTimeout, 'connect'),
+        requestTimeout = _validateDuration(requestTimeout, 'request');
+
+  final String id;
+  final String name;
+  final Uri endpoint;
+  final McpTransportType transport;
+  final bool enabled;
+  final bool allowInsecureHttp;
+  final Duration connectTimeout;
+  final Duration requestTimeout;
+
+  String get displayEndpoint => endpoint.hasQuery
+      ? '${endpoint.origin}${endpoint.path}'
+      : endpoint.toString();
+
+  McpServerConfig copyWith({
+    String? name,
+    Uri? endpoint,
+    McpTransportType? transport,
+    bool? enabled,
+    bool? allowInsecureHttp,
+    Duration? connectTimeout,
+    Duration? requestTimeout,
+  }) {
+    return McpServerConfig(
+      id: id,
+      name: name ?? this.name,
+      endpoint: endpoint ?? this.endpoint,
+      transport: transport ?? this.transport,
+      enabled: enabled ?? this.enabled,
+      allowInsecureHttp: allowInsecureHttp ?? this.allowInsecureHttp,
+      connectTimeout: connectTimeout ?? this.connectTimeout,
+      requestTimeout: requestTimeout ?? this.requestTimeout,
+    );
+  }
+
+  factory McpServerConfig.fromJson(Map<String, dynamic> json) {
+    return McpServerConfig(
+      id: json['id'] as String,
+      name: json['name'] as String,
+      endpoint: Uri.parse(json['endpoint'] as String),
+      transport: McpTransportType.values.firstWhere(
+        (candidate) => candidate.name == json['transport'],
+      ),
+      enabled: json['enabled'] as bool? ?? false,
+      allowInsecureHttp: json['allowInsecureHttp'] as bool? ?? false,
+      connectTimeout: Duration(
+        milliseconds: json['connectTimeoutMs'] as int? ?? 15000,
+      ),
+      requestTimeout: Duration(
+        milliseconds: json['requestTimeoutMs'] as int? ?? 30000,
+      ),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'name': name,
+        'endpoint': endpoint.toString(),
+        'transport': transport.name,
+        'enabled': enabled,
+        'allowInsecureHttp': allowInsecureHttp,
+        'connectTimeoutMs': connectTimeout.inMilliseconds,
+        'requestTimeoutMs': requestTimeout.inMilliseconds,
+      };
+
+  static String _validateId(String source) {
+    final value = source.trim();
+    if (!RegExp(r'^[A-Za-z0-9_-]{1,64}$').hasMatch(value)) {
+      throw const McpException(
+        'invalid_server_id',
+        'Server IDs may only contain letters, numbers, dashes, and underscores.',
+      );
+    }
+    return value;
+  }
+
+  static String _validateName(String source) {
+    final value = source.trim();
+    if (value.isEmpty || value.length > 80) {
+      throw const McpException(
+        'invalid_server_name',
+        'Server names must contain 1-80 characters.',
+      );
+    }
+    return value;
+  }
+
+  static Uri _validateEndpoint(Uri source, bool allowInsecureHttp) {
+    final scheme = source.scheme.toLowerCase();
+    if (!source.isAbsolute ||
+        !source.hasAuthority ||
+        (scheme != 'http' && scheme != 'https') ||
+        source.userInfo.isNotEmpty ||
+        source.fragment.isNotEmpty) {
+      throw const McpException(
+        'invalid_endpoint',
+        'Use an absolute HTTP(S) URL without credentials or a fragment.',
+      );
+    }
+    if (source.queryParameters.keys.any(_looksSensitive)) {
+      throw const McpException(
+        'credential_in_url',
+        'Put credentials in the token field, not in the server URL.',
+      );
+    }
+    if (scheme == 'http' && !_isLoopback(source.host) && !allowInsecureHttp) {
+      throw const McpException(
+        'insecure_endpoint',
+        'Non-loopback HTTP requires explicit insecure transport approval.',
+      );
+    }
+    return source;
+  }
+
+  static Duration _validateDuration(Duration value, String kind) {
+    if (value <= Duration.zero) {
+      throw McpException(
+        'invalid_${kind}_timeout',
+        'The $kind timeout must be greater than zero.',
+      );
+    }
+    return value;
+  }
+}
+
+final class McpToolDescriptor {
+  McpToolDescriptor({
+    required this.serverId,
+    required this.name,
+    required this.title,
+    required this.description,
+    required Map<String, dynamic> inputSchema,
+    required this.accessLevel,
+    required this.destructiveHint,
+    required this.openWorldHint,
+  }) : inputSchema = copyToolJsonObject(inputSchema);
+
+  final String serverId;
+  final String name;
+  final String title;
+  final String description;
+  final Map<String, dynamic> inputSchema;
+  final ToolAccessLevel accessLevel;
+  final bool destructiveHint;
+  final bool openWorldHint;
+
+  String get permissionKey => '$serverId::$name';
+
+  String get qualifiedName {
+    final server = serverId.replaceAll(RegExp('[^A-Za-z0-9_]'), '_');
+    final normalizedTool = name.replaceAll(RegExp('[^A-Za-z0-9_]'), '_');
+    final tool = normalizedTool.isEmpty ? 'tool' : normalizedTool;
+    final readable = 'mcp_${server}_$tool';
+    final digest = sha256
+        .convert(utf8.encode('$serverId\u0000$name'))
+        .toString()
+        .substring(0, 12);
+    final prefix = readable.length <= 51 ? readable : readable.substring(0, 51);
+    return '${prefix}_$digest';
+  }
+}
+
+final class McpToolPermissionRecord {
+  const McpToolPermissionRecord({
+    required this.serverId,
+    required this.toolName,
+    required this.permission,
+  });
+
+  final String serverId;
+  final String toolName;
+  final McpToolPermission permission;
+
+  String get key => '$serverId::$toolName';
+
+  factory McpToolPermissionRecord.fromJson(Map<String, dynamic> json) {
+    return McpToolPermissionRecord(
+      serverId: json['serverId'] as String,
+      toolName: json['toolName'] as String,
+      permission: McpToolPermission.values.firstWhere(
+        (candidate) => candidate.name == json['permission'],
+      ),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'serverId': serverId,
+        'toolName': toolName,
+        'permission': permission.name,
+      };
+}
+
+final class McpStoredSettings {
+  McpStoredSettings({
+    this.enabled = false,
+    Iterable<McpServerConfig> servers = const [],
+    Iterable<McpToolPermissionRecord> permissions = const [],
+  })  : servers = List.unmodifiable(servers),
+        permissions = List.unmodifiable(permissions);
+
+  final bool enabled;
+  final List<McpServerConfig> servers;
+  final List<McpToolPermissionRecord> permissions;
+
+  factory McpStoredSettings.fromJson(Map<String, dynamic> json) {
+    return McpStoredSettings(
+      enabled: json['enabled'] as bool? ?? false,
+      servers: (json['servers'] as List<dynamic>? ?? const [])
+          .map((item) => McpServerConfig.fromJson(
+                Map<String, dynamic>.from(item as Map),
+              )),
+      permissions: (json['permissions'] as List<dynamic>? ?? const [])
+          .map((item) => McpToolPermissionRecord.fromJson(
+                Map<String, dynamic>.from(item as Map),
+              )),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'version': 1,
+        'enabled': enabled,
+        'servers': servers.map((server) => server.toJson()).toList(),
+        'permissions':
+            permissions.map((permission) => permission.toJson()).toList(),
+      };
+}
+
+final class McpServerSnapshot {
+  McpServerSnapshot({
+    required this.config,
+    this.status = McpConnectionStatus.disconnected,
+    Iterable<McpToolDescriptor> tools = const [],
+    this.serverImplementation,
+    this.serverVersion,
+    this.protocolVersion,
+    this.errorCode,
+    this.errorMessage,
+    this.connectedAt,
+  }) : tools = List.unmodifiable(tools);
+
+  final McpServerConfig config;
+  final McpConnectionStatus status;
+  final List<McpToolDescriptor> tools;
+  final String? serverImplementation;
+  final String? serverVersion;
+  final String? protocolVersion;
+  final String? errorCode;
+  final String? errorMessage;
+  final DateTime? connectedAt;
+
+  bool get isConnected => status == McpConnectionStatus.connected;
+
+  McpServerSnapshot copyWith({
+    McpServerConfig? config,
+    McpConnectionStatus? status,
+    List<McpToolDescriptor>? tools,
+    bool clearTools = false,
+    String? serverImplementation,
+    String? serverVersion,
+    String? protocolVersion,
+    String? errorCode,
+    String? errorMessage,
+    bool clearError = false,
+    DateTime? connectedAt,
+    bool clearConnectedAt = false,
+  }) {
+    return McpServerSnapshot(
+      config: config ?? this.config,
+      status: status ?? this.status,
+      tools: clearTools ? const [] : (tools ?? this.tools),
+      serverImplementation: serverImplementation ?? this.serverImplementation,
+      serverVersion: serverVersion ?? this.serverVersion,
+      protocolVersion: protocolVersion ?? this.protocolVersion,
+      errorCode: clearError ? null : (errorCode ?? this.errorCode),
+      errorMessage: clearError ? null : (errorMessage ?? this.errorMessage),
+      connectedAt: clearConnectedAt ? null : (connectedAt ?? this.connectedAt),
+    );
+  }
+}
+
+final class McpActivityRecord {
+  const McpActivityRecord({
+    required this.timestamp,
+    required this.serverId,
+    required this.kind,
+    required this.message,
+    this.toolName,
+    this.errorCode,
+  });
+
+  final DateTime timestamp;
+  final String serverId;
+  final McpActivityKind kind;
+  final String message;
+  final String? toolName;
+  final String? errorCode;
+
+  factory McpActivityRecord.fromJson(Map<String, dynamic> json) {
+    return McpActivityRecord(
+      timestamp: DateTime.parse(json['timestamp'] as String),
+      serverId: json['serverId'] as String,
+      kind: McpActivityKind.values.firstWhere(
+        (candidate) => candidate.name == json['kind'],
+      ),
+      message: json['message'] as String,
+      toolName: json['toolName'] as String?,
+      errorCode: json['errorCode'] as String?,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'timestamp': timestamp.toUtc().toIso8601String(),
+        'serverId': serverId,
+        'kind': kind.name,
+        'message': message,
+        if (toolName != null) 'toolName': toolName,
+        if (errorCode != null) 'errorCode': errorCode,
+      };
+}
+
+bool _looksSensitive(String source) {
+  final key = source.toLowerCase().replaceAll(RegExp('[^a-z0-9]'), '');
+  return key.contains('token') ||
+      key.contains('key') ||
+      key.contains('secret') ||
+      key.contains('password') ||
+      key.contains('credential') ||
+      key.contains('authorization');
+}
+
+bool _isLoopback(String source) {
+  final host = source.toLowerCase();
+  return host == 'localhost' ||
+      host == '127.0.0.1' ||
+      host == '::1' ||
+      host == '[::1]';
+}

--- a/lib/domain/repositories/mcp_repository.dart
+++ b/lib/domain/repositories/mcp_repository.dart
@@ -1,0 +1,197 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:native_tavern/domain/models/mcp.dart';
+import 'package:path/path.dart' as p;
+
+abstract interface class McpSettingsRepository {
+  Future<McpStoredSettings> load();
+
+  Future<void> save(McpStoredSettings settings);
+}
+
+final class FileMcpSettingsRepository implements McpSettingsRepository {
+  FileMcpSettingsRepository({required this.dataPath});
+
+  final String dataPath;
+  Future<void> _writeTail = Future.value();
+
+  File get _file => File(p.join(dataPath, 'mcp', 'settings.json'));
+
+  @override
+  Future<McpStoredSettings> load() async {
+    await _writeTail;
+    final file = _file;
+    if (!file.existsSync()) return McpStoredSettings();
+    try {
+      final decoded = jsonDecode(await file.readAsString());
+      if (decoded is! Map<String, dynamic>) {
+        throw const FormatException('MCP settings root must be an object.');
+      }
+      return McpStoredSettings.fromJson(decoded);
+    } on FormatException catch (error) {
+      throw McpException('invalid_settings', error.message);
+    } on TypeError {
+      throw const McpException(
+        'invalid_settings',
+        'Stored MCP settings have an invalid shape.',
+      );
+    } on StateError {
+      throw const McpException(
+        'invalid_settings',
+        'Stored MCP settings contain an unsupported value.',
+      );
+    }
+  }
+
+  @override
+  Future<void> save(McpStoredSettings settings) {
+    final operation = _writeTail.then((_) async {
+      final file = _file;
+      await file.parent.create(recursive: true);
+      final temporary = File('${file.path}.tmp');
+      await temporary.writeAsString(
+        const JsonEncoder.withIndent('  ').convert(settings.toJson()),
+        flush: true,
+      );
+      await temporary.rename(file.path);
+    });
+    _writeTail = operation.catchError((Object _) {});
+    return operation;
+  }
+}
+
+final class MemoryMcpSettingsRepository implements McpSettingsRepository {
+  MemoryMcpSettingsRepository([McpStoredSettings? initial])
+      : value = initial ?? McpStoredSettings();
+
+  McpStoredSettings value;
+
+  @override
+  Future<McpStoredSettings> load() async => value;
+
+  @override
+  Future<void> save(McpStoredSettings settings) async => value = settings;
+}
+
+abstract interface class McpCredentialRepository {
+  Future<String?> readToken(String serverId);
+
+  Future<void> writeToken(String serverId, String token);
+
+  Future<void> deleteToken(String serverId);
+}
+
+final class SecureMcpCredentialRepository implements McpCredentialRepository {
+  const SecureMcpCredentialRepository({
+    FlutterSecureStorage storage = const FlutterSecureStorage(),
+  }) : _storage = storage;
+
+  final FlutterSecureStorage _storage;
+
+  String _key(String serverId) => 'native_tavern.mcp.$serverId.token';
+
+  @override
+  Future<String?> readToken(String serverId) =>
+      _storage.read(key: _key(serverId));
+
+  @override
+  Future<void> writeToken(String serverId, String token) async {
+    final value = token.trim();
+    if (value.isEmpty) {
+      await deleteToken(serverId);
+      return;
+    }
+    await _storage.write(key: _key(serverId), value: value);
+  }
+
+  @override
+  Future<void> deleteToken(String serverId) =>
+      _storage.delete(key: _key(serverId));
+}
+
+final class MemoryMcpCredentialRepository implements McpCredentialRepository {
+  final Map<String, String> values = {};
+
+  @override
+  Future<String?> readToken(String serverId) async => values[serverId];
+
+  @override
+  Future<void> writeToken(String serverId, String token) async {
+    if (token.trim().isEmpty) {
+      values.remove(serverId);
+    } else {
+      values[serverId] = token.trim();
+    }
+  }
+
+  @override
+  Future<void> deleteToken(String serverId) async => values.remove(serverId);
+}
+
+abstract interface class McpActivityRepository {
+  Future<void> record(McpActivityRecord record);
+
+  Future<List<McpActivityRecord>> readRecent({int limit = 100});
+}
+
+final class FileMcpActivityRepository implements McpActivityRepository {
+  FileMcpActivityRepository({required this.dataPath});
+
+  final String dataPath;
+  Future<void> _writeTail = Future.value();
+
+  File get _file => File(p.join(dataPath, 'audit', 'mcp_activity.jsonl'));
+
+  @override
+  Future<void> record(McpActivityRecord record) {
+    final operation = _writeTail.then((_) async {
+      final file = _file;
+      await file.parent.create(recursive: true);
+      await file.writeAsString(
+        '${jsonEncode(record.toJson())}\n',
+        mode: FileMode.append,
+        flush: true,
+      );
+    });
+    _writeTail = operation.catchError((Object _) {});
+    return operation;
+  }
+
+  @override
+  Future<List<McpActivityRecord>> readRecent({int limit = 100}) async {
+    if (limit <= 0) return const [];
+    await _writeTail;
+    final file = _file;
+    if (!file.existsSync()) return const [];
+    final result = <McpActivityRecord>[];
+    for (final line in (await file.readAsLines()).reversed) {
+      if (result.length >= limit) break;
+      if (line.trim().isEmpty) continue;
+      try {
+        result.add(McpActivityRecord.fromJson(
+          Map<String, dynamic>.from(jsonDecode(line) as Map),
+        ));
+      } catch (_) {
+        continue;
+      }
+    }
+    return result;
+  }
+}
+
+final class MemoryMcpActivityRepository implements McpActivityRepository {
+  final List<McpActivityRecord> records = [];
+
+  @override
+  Future<void> record(McpActivityRecord record) async => records.add(record);
+
+  @override
+  Future<List<McpActivityRecord>> readRecent({int limit = 100}) async {
+    if (limit <= 0) return const [];
+    final start = (records.length - limit).clamp(0, records.length);
+    return records.sublist(start).reversed.toList(growable: false);
+  }
+}

--- a/lib/domain/services/mcp/mcp_client_manager.dart
+++ b/lib/domain/services/mcp/mcp_client_manager.dart
@@ -1,0 +1,760 @@
+import 'dart:async';
+
+import 'package:native_tavern/domain/models/built_in_tool.dart';
+import 'package:native_tavern/domain/models/mcp.dart';
+import 'package:native_tavern/domain/models/tool_calling.dart';
+import 'package:native_tavern/domain/repositories/mcp_repository.dart';
+import 'package:native_tavern/domain/services/capability_registry.dart';
+import 'package:native_tavern/domain/services/mcp/mcp_protocol_client.dart';
+import 'package:native_tavern/domain/services/tool_calling/tool_execution_audit_service.dart';
+
+typedef McpApprovalHandler = Future<McpApprovalDecision> Function(
+  ToolExecutionPreview preview,
+);
+
+final class McpClientManager {
+  McpClientManager({
+    required McpSettingsRepository settingsRepository,
+    required McpCredentialRepository credentialRepository,
+    required McpActivityRepository activityRepository,
+    required ToolExecutionAuditRepository toolAuditRepository,
+    McpProtocolClientFactory protocolClientFactory =
+        const McpDartProtocolClientFactory(),
+    DateTime Function()? clock,
+  })  : _settingsRepository = settingsRepository,
+        _credentialRepository = credentialRepository,
+        _activityRepository = activityRepository,
+        _toolAuditRepository = toolAuditRepository,
+        _protocolClientFactory = protocolClientFactory,
+        _clock = clock ?? DateTime.now;
+
+  final McpSettingsRepository _settingsRepository;
+  final McpCredentialRepository _credentialRepository;
+  final McpActivityRepository _activityRepository;
+  final ToolExecutionAuditRepository _toolAuditRepository;
+  final McpProtocolClientFactory _protocolClientFactory;
+  final DateTime Function() _clock;
+  final StreamController<void> _changes = StreamController.broadcast();
+  final Map<String, McpProtocolSession> _sessions = {};
+  final Map<String, ToolCancellationController> _operations = {};
+  final Map<String, McpServerSnapshot> _snapshots = {};
+  Future<void>? _initializing;
+  McpStoredSettings _settings = McpStoredSettings();
+  bool _initialized = false;
+  bool _closed = false;
+
+  Stream<void> get changes => _changes.stream;
+  bool get enabled => _settings.enabled;
+  List<McpServerConfig> get servers => List.unmodifiable(_settings.servers);
+  List<McpServerSnapshot> get snapshots => _settings.servers
+      .map((server) => _snapshotFor(server))
+      .toList(growable: false);
+
+  List<McpToolDescriptor> get discoveredTools => snapshots
+      .where((snapshot) => snapshot.isConnected)
+      .expand((snapshot) => snapshot.tools)
+      .toList(growable: false);
+
+  Future<void> initialize() {
+    if (_initialized) return Future.value();
+    final current = _initializing;
+    if (current != null) return current;
+    final operation = _initialize();
+    _initializing = operation;
+    return operation.whenComplete(() => _initializing = null);
+  }
+
+  Future<void> _initialize() async {
+    _requireOpen();
+    _settings = await _settingsRepository.load();
+    _snapshots
+      ..clear()
+      ..addEntries(_settings.servers.map((server) => MapEntry(
+            server.id,
+            McpServerSnapshot(
+              config: server,
+              status: !_settings.enabled || !server.enabled
+                  ? McpConnectionStatus.disabled
+                  : McpConnectionStatus.disconnected,
+            ),
+          )));
+    _initialized = true;
+    _notify();
+  }
+
+  McpServerSnapshot snapshot(String serverId) {
+    final config = _server(serverId);
+    return _snapshotFor(config);
+  }
+
+  McpToolPermission permissionFor(String serverId, String toolName) {
+    for (final permission in _settings.permissions) {
+      if (permission.serverId == serverId && permission.toolName == toolName) {
+        return permission.permission;
+      }
+    }
+    return McpToolPermission.askEveryTime;
+  }
+
+  bool hasNameCollision(McpToolDescriptor tool) {
+    return discoveredTools
+            .where((candidate) => candidate.name == tool.name)
+            .map((candidate) => candidate.serverId)
+            .toSet()
+            .length >
+        1;
+  }
+
+  Future<void> setEnabled(bool value) async {
+    await initialize();
+    if (_settings.enabled == value) return;
+    if (!value) await disconnectAll();
+    _settings = McpStoredSettings(
+      enabled: value,
+      servers: _settings.servers,
+      permissions: _settings.permissions,
+    );
+    for (final server in _settings.servers) {
+      final current = _snapshotFor(server);
+      _snapshots[server.id] = current.copyWith(
+        status: !value || !server.enabled
+            ? McpConnectionStatus.disabled
+            : McpConnectionStatus.disconnected,
+        clearError: true,
+      );
+    }
+    await _save();
+    _notify();
+  }
+
+  Future<void> upsertServer(
+    McpServerConfig config, {
+    String? bearerToken,
+    bool clearCredential = false,
+  }) async {
+    await initialize();
+    final existing =
+        _settings.servers.where((server) => server.id == config.id).firstOrNull;
+    if (existing != null &&
+        (existing.endpoint != config.endpoint ||
+            existing.transport != config.transport)) {
+      await disconnect(config.id);
+    }
+    final servers = [..._settings.servers];
+    final index = servers.indexWhere((server) => server.id == config.id);
+    if (index < 0) {
+      servers.add(config);
+    } else {
+      servers[index] = config;
+    }
+    servers.sort((left, right) => left.name.compareTo(right.name));
+    _settings = McpStoredSettings(
+      enabled: _settings.enabled,
+      servers: servers,
+      permissions: _settings.permissions,
+    );
+    if (clearCredential) {
+      await _credentialRepository.deleteToken(config.id);
+    } else if (bearerToken != null) {
+      await _credentialRepository.writeToken(config.id, bearerToken);
+    }
+    final current = _snapshots[config.id];
+    _snapshots[config.id] =
+        (current ?? McpServerSnapshot(config: config)).copyWith(
+      config: config,
+      status: !_settings.enabled || !config.enabled
+          ? McpConnectionStatus.disabled
+          : current?.status ?? McpConnectionStatus.disconnected,
+      clearError: true,
+    );
+    await _save();
+    await _record(
+      config.id,
+      McpActivityKind.configured,
+      existing == null ? 'Server added.' : 'Server configuration updated.',
+    );
+    if (!config.enabled) await disconnect(config.id);
+    _notify();
+  }
+
+  Future<void> setServerEnabled(String serverId, bool value) async {
+    await initialize();
+    final config = _server(serverId).copyWith(enabled: value);
+    await upsertServer(config);
+  }
+
+  Future<void> removeServer(String serverId) async {
+    await initialize();
+    _server(serverId);
+    await disconnect(serverId);
+    await _credentialRepository.deleteToken(serverId);
+    _settings = McpStoredSettings(
+      enabled: _settings.enabled,
+      servers:
+          _settings.servers.where((server) => server.id != serverId).toList(),
+      permissions: _settings.permissions
+          .where((permission) => permission.serverId != serverId)
+          .toList(),
+    );
+    _snapshots.remove(serverId);
+    await _save();
+    await _record(serverId, McpActivityKind.configured, 'Server removed.');
+    _notify();
+  }
+
+  Future<void> connect(String serverId, {bool reconnecting = false}) async {
+    await initialize();
+    final config = _server(serverId);
+    if (!_settings.enabled) {
+      throw const McpException(
+        'feature_disabled',
+        'Enable MCP before connecting a server.',
+      );
+    }
+    if (!config.enabled) {
+      throw const McpException(
+        'server_disabled',
+        'Enable this server before connecting.',
+      );
+    }
+    await _sessions.remove(serverId)?.close();
+    _operations.remove(serverId)?.cancel('Superseded by a new connection.');
+    final operation = ToolCancellationController();
+    _operations[serverId] = operation;
+    _snapshots[serverId] = _snapshotFor(config).copyWith(
+      status: reconnecting
+          ? McpConnectionStatus.reconnecting
+          : McpConnectionStatus.connecting,
+      clearError: true,
+      clearTools: true,
+      clearConnectedAt: true,
+    );
+    _notify();
+    try {
+      final token = await _credentialRepository.readToken(serverId);
+      final session = await _protocolClientFactory.connect(
+        config: config,
+        bearerToken: token,
+        cancellationToken: operation.token,
+        onToolsChanged: () => _refreshAfterNotification(serverId),
+        onError: (error) => _handleProtocolError(serverId, error),
+      );
+      operation.token.throwIfCancelled();
+      _sessions[serverId] = session;
+      final tools = await session.listTools(
+        cancellationToken: operation.token,
+        timeout: config.requestTimeout,
+      );
+      operation.token.throwIfCancelled();
+      _snapshots[serverId] = _snapshotFor(config).copyWith(
+        status: McpConnectionStatus.connected,
+        tools: tools,
+        serverImplementation: session.serverImplementation,
+        serverVersion: session.serverVersion,
+        protocolVersion: session.protocolVersion,
+        connectedAt: _clock().toUtc(),
+        clearError: true,
+      );
+      await _record(
+        serverId,
+        McpActivityKind.connected,
+        'Connected and discovered ${tools.length} tool(s).',
+      );
+    } catch (error) {
+      await _sessions.remove(serverId)?.close();
+      final mapped = _mapError(error);
+      _snapshots[serverId] = _snapshotFor(config).copyWith(
+        status: mapped.code == 'cancelled'
+            ? McpConnectionStatus.disconnected
+            : McpConnectionStatus.error,
+        clearTools: true,
+        errorCode: mapped.code,
+        errorMessage: mapped.message,
+        clearConnectedAt: true,
+      );
+      await _record(
+        serverId,
+        mapped.code == 'cancelled'
+            ? McpActivityKind.cancelled
+            : McpActivityKind.error,
+        mapped.message,
+        errorCode: mapped.code,
+      );
+      rethrow;
+    } finally {
+      if (identical(_operations[serverId], operation)) {
+        _operations.remove(serverId);
+      }
+      _notify();
+    }
+  }
+
+  Future<void> reconnect(String serverId) async {
+    await disconnect(serverId);
+    await connect(serverId, reconnecting: true);
+  }
+
+  Future<void> refreshTools(String serverId) async {
+    await initialize();
+    final config = _server(serverId);
+    final session = _sessions[serverId];
+    if (session == null) {
+      throw const McpException(
+        'not_connected',
+        'Connect the server before refreshing tools.',
+      );
+    }
+    _operations.remove(serverId)?.cancel('Superseded by tool refresh.');
+    final operation = ToolCancellationController();
+    _operations[serverId] = operation;
+    try {
+      final tools = await session.listTools(
+        cancellationToken: operation.token,
+        timeout: config.requestTimeout,
+      );
+      _snapshots[serverId] = _snapshotFor(config).copyWith(
+        status: McpConnectionStatus.connected,
+        tools: tools,
+        clearError: true,
+      );
+      await _record(
+        serverId,
+        McpActivityKind.discovery,
+        'Tool discovery refreshed: ${tools.length} tool(s).',
+      );
+    } catch (error) {
+      final mapped = _mapError(error);
+      _snapshots[serverId] = _snapshotFor(config).copyWith(
+        status: mapped.code == 'cancelled'
+            ? McpConnectionStatus.connected
+            : McpConnectionStatus.error,
+        errorCode: mapped.code,
+        errorMessage: mapped.message,
+      );
+      await _record(
+        serverId,
+        mapped.code == 'cancelled'
+            ? McpActivityKind.cancelled
+            : McpActivityKind.error,
+        mapped.message,
+        errorCode: mapped.code,
+      );
+      rethrow;
+    } finally {
+      if (identical(_operations[serverId], operation)) {
+        _operations.remove(serverId);
+      }
+      _notify();
+    }
+  }
+
+  void cancelOperation(String serverId, [String reason = 'Cancelled by user']) {
+    _operations[serverId]?.cancel(reason);
+  }
+
+  Future<void> disconnect(String serverId) async {
+    if (!_initialized) return;
+    final config =
+        _settings.servers.where((server) => server.id == serverId).firstOrNull;
+    if (config == null) return;
+    _operations.remove(serverId)?.cancel('Server disconnected.');
+    final session = _sessions.remove(serverId);
+    if (session != null) {
+      try {
+        await session.close().timeout(const Duration(seconds: 5));
+      } catch (_) {
+        // Local state is still released even if the remote close fails.
+      }
+      await _record(
+        serverId,
+        McpActivityKind.disconnected,
+        'Server disconnected.',
+      );
+    }
+    _snapshots[serverId] = _snapshotFor(config).copyWith(
+      status: !_settings.enabled || !config.enabled
+          ? McpConnectionStatus.disabled
+          : McpConnectionStatus.disconnected,
+      clearTools: true,
+      clearError: true,
+      clearConnectedAt: true,
+    );
+    _notify();
+  }
+
+  Future<void> disconnectAll() async {
+    for (final serverId in {..._sessions.keys, ..._operations.keys}) {
+      await disconnect(serverId);
+    }
+  }
+
+  Future<void> setToolPermission(
+    String serverId,
+    String toolName,
+    McpToolPermission permission,
+  ) async {
+    await initialize();
+    _server(serverId);
+    final permissions = _settings.permissions
+        .where((entry) =>
+            !(entry.serverId == serverId && entry.toolName == toolName))
+        .toList();
+    if (permission != McpToolPermission.askEveryTime) {
+      permissions.add(McpToolPermissionRecord(
+        serverId: serverId,
+        toolName: toolName,
+        permission: permission,
+      ));
+    }
+    _settings = McpStoredSettings(
+      enabled: _settings.enabled,
+      servers: _settings.servers,
+      permissions: permissions,
+    );
+    await _save();
+    await _record(
+      serverId,
+      McpActivityKind.permission,
+      'Tool permission changed to ${permission.name}.',
+      toolName: toolName,
+    );
+    _notify();
+  }
+
+  Future<ToolResultMessage> executeTool({
+    required String serverId,
+    required ToolCall call,
+    required ToolInvocationContext invocationContext,
+    McpApprovalHandler? requestApproval,
+  }) async {
+    await initialize();
+    final started = Stopwatch()..start();
+    final snapshot = this.snapshot(serverId);
+    final tool = snapshot.tools
+        .where((candidate) =>
+            candidate.name == call.name || candidate.qualifiedName == call.name)
+        .firstOrNull;
+    if (!snapshot.isConnected || tool == null) {
+      return _finishTool(
+        call: call,
+        tool: tool,
+        serverId: serverId,
+        started: started,
+        source: ToolAuthorizationSource.none,
+        outcome: ToolExecutionOutcome.denied,
+        status: ToolResultStatus.failed,
+        output: const {'error': 'MCP tool is unavailable.'},
+        errorCode: 'tool_unavailable',
+      );
+    }
+    if (call.status != ToolCallStatus.ready) {
+      return _finishTool(
+        call: call,
+        tool: tool,
+        serverId: serverId,
+        started: started,
+        source: ToolAuthorizationSource.none,
+        outcome: ToolExecutionOutcome.denied,
+        status: ToolResultStatus.failed,
+        output: const {'error': 'Tool arguments are invalid.'},
+        errorCode: 'invalid_arguments',
+      );
+    }
+
+    var permission = permissionFor(serverId, tool.name);
+    var source = ToolAuthorizationSource.none;
+    if (permission == McpToolPermission.denied) {
+      return _finishTool(
+        call: call,
+        tool: tool,
+        serverId: serverId,
+        started: started,
+        source: source,
+        outcome: ToolExecutionOutcome.denied,
+        status: ToolResultStatus.failed,
+        output: const {'error': 'User denied this MCP tool.'},
+        errorCode: 'permission_denied',
+      );
+    }
+    if (permission == McpToolPermission.alwaysAllow) {
+      source = ToolAuthorizationSource.userSettings;
+    } else {
+      final preview = ToolExecutionPreview(
+        callId: call.id,
+        toolName: tool.qualifiedName,
+        accessLevel: tool.accessLevel,
+        target: 'mcp:$serverId/${tool.name}',
+        parameters: call.arguments,
+        requiredCapabilities: const [CapabilityId.mcp],
+        dataScopes: const [ToolDataScope.mcpToolArguments],
+        requiresConfirmation: true,
+        supportsDryRun: false,
+        dryRun: false,
+      );
+      final decision = requestApproval == null
+          ? McpApprovalDecision.deny
+          : await requestApproval(preview);
+      switch (decision) {
+        case McpApprovalDecision.allowOnce:
+          source = ToolAuthorizationSource.oneTimeApproval;
+        case McpApprovalDecision.alwaysAllow:
+          permission = McpToolPermission.alwaysAllow;
+          await setToolPermission(serverId, tool.name, permission);
+          source = ToolAuthorizationSource.userSettings;
+        case McpApprovalDecision.deny:
+          return _finishTool(
+            call: call,
+            tool: tool,
+            serverId: serverId,
+            started: started,
+            source: ToolAuthorizationSource.none,
+            outcome: ToolExecutionOutcome.denied,
+            status: ToolResultStatus.failed,
+            output: const {'error': 'User denied this MCP tool call.'},
+            errorCode: 'permission_denied',
+          );
+        case McpApprovalDecision.cancel:
+          return _finishTool(
+            call: call,
+            tool: tool,
+            serverId: serverId,
+            started: started,
+            source: ToolAuthorizationSource.none,
+            outcome: ToolExecutionOutcome.cancelled,
+            status: ToolResultStatus.cancelled,
+            output: const {'error': 'Tool call cancelled by user.'},
+            errorCode: 'cancelled',
+          );
+      }
+    }
+
+    try {
+      invocationContext.cancellationToken.throwIfCancelled();
+      final output = await _sessions[serverId]!.callTool(
+        name: tool.name,
+        arguments: call.arguments,
+        cancellationToken: invocationContext.cancellationToken,
+        timeout: snapshot.config.requestTimeout,
+      );
+      final isError = output['isError'] == true;
+      return _finishTool(
+        call: call,
+        tool: tool,
+        serverId: serverId,
+        started: started,
+        source: source,
+        outcome: isError
+            ? ToolExecutionOutcome.failed
+            : ToolExecutionOutcome.succeeded,
+        status: isError ? ToolResultStatus.failed : ToolResultStatus.succeeded,
+        output: output,
+        errorCode: isError ? 'remote_tool_error' : null,
+      );
+    } catch (error) {
+      final mapped = _mapError(error);
+      final cancelled = mapped.code == 'cancelled' ||
+          invocationContext.cancellationToken.isCancelled;
+      return _finishTool(
+        call: call,
+        tool: tool,
+        serverId: serverId,
+        started: started,
+        source: source,
+        outcome: cancelled
+            ? ToolExecutionOutcome.cancelled
+            : ToolExecutionOutcome.failed,
+        status:
+            cancelled ? ToolResultStatus.cancelled : ToolResultStatus.failed,
+        output: {'error': mapped.message},
+        errorCode: cancelled ? 'cancelled' : mapped.code,
+      );
+    }
+  }
+
+  Future<List<McpActivityRecord>> readRecentActivity({int limit = 100}) =>
+      _activityRepository.readRecent(limit: limit);
+
+  Future<void> close() async {
+    if (_closed) return;
+    await disconnectAll();
+    _closed = true;
+    await _changes.close();
+  }
+
+  Future<ToolResultMessage> _finishTool({
+    required ToolCall call,
+    required McpToolDescriptor? tool,
+    required String serverId,
+    required Stopwatch started,
+    required ToolAuthorizationSource source,
+    required ToolExecutionOutcome outcome,
+    required ToolResultStatus status,
+    required Object? output,
+    String? errorCode,
+  }) async {
+    final descriptor = tool;
+    await _toolAuditRepository.record(ToolExecutionAuditRecord(
+      timestamp: _clock().toUtc(),
+      callIdFingerprint: fingerprintToolCallId(call.id),
+      toolName: descriptor?.qualifiedName ?? call.name,
+      accessLevel:
+          descriptor?.accessLevel ?? ToolAccessLevel.externalSideEffect,
+      parameterSummary: summarizeToolArguments(call.arguments),
+      target: descriptor == null
+          ? 'mcp:$serverId/unavailable'
+          : 'mcp:$serverId/${descriptor.name}',
+      authorizationSource: source,
+      result: outcome,
+      errorCode: errorCode,
+      durationMilliseconds: started.elapsedMilliseconds,
+    ));
+    return ToolResultMessage(
+      callId: call.id,
+      toolName: descriptor?.qualifiedName ?? _safeToolName(call.name),
+      output: output,
+      status: status,
+    );
+  }
+
+  Future<void> _refreshAfterNotification(String serverId) async {
+    if (_closed || !_sessions.containsKey(serverId)) return;
+    try {
+      await refreshTools(serverId);
+    } catch (_) {
+      // refreshTools exposes a sanitized error in state and activity logs.
+    }
+  }
+
+  void _handleProtocolError(String serverId, Object error) {
+    if (_closed || !_snapshots.containsKey(serverId)) return;
+    final mapped = _mapError(error);
+    final current = _snapshots[serverId]!;
+    _snapshots[serverId] = current.copyWith(
+      status: McpConnectionStatus.error,
+      errorCode: mapped.code,
+      errorMessage: mapped.message,
+    );
+    unawaited(_record(
+      serverId,
+      McpActivityKind.error,
+      mapped.message,
+      errorCode: mapped.code,
+    ));
+    _notify();
+  }
+
+  McpServerConfig _server(String serverId) {
+    return _settings.servers
+        .where((server) => server.id == serverId)
+        .firstOrNullOrThrow(
+          const McpException('server_not_found', 'MCP server not found.'),
+        );
+  }
+
+  McpServerSnapshot _snapshotFor(McpServerConfig config) {
+    return _snapshots[config.id] ??
+        McpServerSnapshot(
+          config: config,
+          status: !_settings.enabled || !config.enabled
+              ? McpConnectionStatus.disabled
+              : McpConnectionStatus.disconnected,
+        );
+  }
+
+  Future<void> _save() => _settingsRepository.save(_settings);
+
+  Future<void> _record(
+    String serverId,
+    McpActivityKind kind,
+    String message, {
+    String? toolName,
+    String? errorCode,
+  }) {
+    return _activityRepository.record(McpActivityRecord(
+      timestamp: _clock().toUtc(),
+      serverId: serverId,
+      kind: kind,
+      message: sanitizeMcpDiagnostic(message),
+      toolName: toolName,
+      errorCode: errorCode,
+    ));
+  }
+
+  void _notify() {
+    if (!_closed) _changes.add(null);
+  }
+
+  void _requireOpen() {
+    if (_closed) {
+      throw const McpException('manager_closed', 'MCP manager is closed.');
+    }
+  }
+}
+
+extension<T> on Iterable<T> {
+  T? get firstOrNull {
+    final iterator = this.iterator;
+    return iterator.moveNext() ? iterator.current : null;
+  }
+
+  T firstOrNullOrThrow(Object error) {
+    final value = firstOrNull;
+    if (value == null) throw error;
+    return value;
+  }
+}
+
+McpException _mapError(Object error) {
+  if (error is McpException) return error;
+  if (error is ToolProtocolException && error.code == 'cancelled') {
+    return const McpException('cancelled', 'Operation cancelled.');
+  }
+  if (error is TimeoutException) {
+    return const McpException('timeout', 'The MCP operation timed out.');
+  }
+  final text = error.toString().toLowerCase();
+  if (text.contains('abort') || text.contains('cancel')) {
+    return const McpException('cancelled', 'Operation cancelled.');
+  }
+  if (text.contains('unauthorized') || text.contains('401')) {
+    return const McpException(
+      'unauthorized',
+      'Authentication failed. Check the server token.',
+    );
+  }
+  if (text.contains('socket') || text.contains('connection refused')) {
+    return const McpException(
+      'connection_failed',
+      'Could not reach the MCP server.',
+    );
+  }
+  return McpException(
+    'protocol_error',
+    sanitizeMcpDiagnostic(error.toString()),
+  );
+}
+
+String sanitizeMcpDiagnostic(String source) {
+  var result = source
+      .replaceAll(RegExp(r'Bearer\s+[^\s,;]+', caseSensitive: false),
+          'Bearer [redacted]')
+      .replaceAllMapped(
+        RegExp(r'https?://[^\s?]+\?[^\s]+', caseSensitive: false),
+        (match) => '${match.group(0)!.split('?').first}?[redacted]',
+      )
+      .replaceAll(
+        RegExp(
+          r'(token|secret|password|api[_-]?key|authorization)\s*[:=]\s*[^\s,;]+',
+          caseSensitive: false,
+        ),
+        r'$1=[redacted]',
+      );
+  if (result.length > 500) result = '${result.substring(0, 500)}...';
+  return result;
+}
+
+String _safeToolName(String source) {
+  final normalized = source.replaceAll(RegExp('[^A-Za-z0-9_-]'), '_');
+  final value = normalized.isEmpty ? 'mcp_tool' : normalized;
+  return value.length <= 64 ? value : value.substring(0, 64);
+}

--- a/lib/domain/services/mcp/mcp_protocol_client.dart
+++ b/lib/domain/services/mcp/mcp_protocol_client.dart
@@ -1,0 +1,261 @@
+import 'dart:async';
+
+import 'package:mcp_dart/mcp_dart.dart' as sdk;
+import 'package:native_tavern/domain/models/built_in_tool.dart';
+import 'package:native_tavern/domain/models/mcp.dart';
+import 'package:native_tavern/domain/models/tool_calling.dart';
+
+typedef McpToolsChangedCallback = FutureOr<void> Function();
+typedef McpProtocolErrorCallback = void Function(Object error);
+
+abstract interface class McpProtocolSession {
+  String? get serverImplementation;
+  String? get serverVersion;
+  String? get protocolVersion;
+
+  Future<List<McpToolDescriptor>> listTools({
+    required ToolCancellationToken cancellationToken,
+    required Duration timeout,
+  });
+
+  Future<Map<String, dynamic>> callTool({
+    required String name,
+    required Map<String, dynamic> arguments,
+    required ToolCancellationToken cancellationToken,
+    required Duration timeout,
+  });
+
+  Future<void> close();
+}
+
+abstract interface class McpProtocolClientFactory {
+  Future<McpProtocolSession> connect({
+    required McpServerConfig config,
+    required String? bearerToken,
+    required ToolCancellationToken cancellationToken,
+    required McpToolsChangedCallback onToolsChanged,
+    required McpProtocolErrorCallback onError,
+  });
+}
+
+final class McpDartProtocolClientFactory implements McpProtocolClientFactory {
+  const McpDartProtocolClientFactory();
+
+  @override
+  Future<McpProtocolSession> connect({
+    required McpServerConfig config,
+    required String? bearerToken,
+    required ToolCancellationToken cancellationToken,
+    required McpToolsChangedCallback onToolsChanged,
+    required McpProtocolErrorCallback onError,
+  }) async {
+    cancellationToken.throwIfCancelled();
+    final client = sdk.McpClient(
+      const sdk.Implementation(
+        name: 'NativeTavern',
+        version: '0.1.9',
+      ),
+      options: sdk.McpClientOptions(
+        protocol: config.transport == McpTransportType.legacySse
+            ? sdk.McpProtocol.legacy
+            : sdk.McpProtocol.stable,
+      ),
+    );
+    client.onerror = onError;
+    client.setNotificationHandler<sdk.JsonRpcToolListChangedNotification>(
+      sdk.Method.notificationsToolsListChanged,
+      (_) async => onToolsChanged(),
+      (params, meta) => sdk.JsonRpcToolListChangedNotification.fromJson({
+        'jsonrpc': sdk.jsonRpcVersion,
+        'method': sdk.Method.notificationsToolsListChanged,
+        if (params != null) 'params': params,
+        if (meta != null) '_meta': meta,
+      }),
+    );
+
+    final headers = <String, dynamic>{
+      if (bearerToken?.trim().isNotEmpty == true)
+        'Authorization': 'Bearer ${bearerToken!.trim()}',
+    };
+    final sdk.Transport transport;
+    if (config.transport == McpTransportType.legacySse) {
+      // ignore: deprecated_member_use
+      transport = sdk.SseClientTransport(
+        config.endpoint,
+        // ignore: deprecated_member_use
+        opts: sdk.SseClientTransportOptions(
+          headers: headers.map((key, value) => MapEntry(key, '$value')),
+        ),
+      );
+    } else {
+      transport = sdk.StreamableHttpClientTransport(
+        config.endpoint,
+        opts: sdk.StreamableHttpClientTransportOptions(
+          requestInit: headers.isEmpty ? null : {'headers': headers},
+          reconnectionOptions: const sdk.StreamableHttpReconnectionOptions(
+            initialReconnectionDelay: 500,
+            maxReconnectionDelay: 10000,
+            reconnectionDelayGrowFactor: 1.8,
+            maxRetries: 4,
+          ),
+        ),
+      );
+    }
+
+    var cancelled = false;
+    cancellationToken.whenCancelled((reason) {
+      cancelled = true;
+      unawaited(client.close());
+    });
+    try {
+      await client.connect(transport).timeout(config.connectTimeout);
+      if (cancelled) {
+        throw McpException(
+          'cancelled',
+          cancellationToken.reason?.toString() ?? 'Connection cancelled.',
+        );
+      }
+      return _McpDartProtocolSession(config.id, client);
+    } on TimeoutException {
+      await client.close();
+      if (cancelled || cancellationToken.isCancelled) {
+        throw McpException(
+          'cancelled',
+          cancellationToken.reason?.toString() ?? 'Connection cancelled.',
+        );
+      }
+      throw McpException(
+        'connection_timeout',
+        'Connection timed out after ${config.connectTimeout.inSeconds} seconds.',
+      );
+    } catch (_) {
+      await client.close();
+      if (cancelled || cancellationToken.isCancelled) {
+        throw McpException(
+          'cancelled',
+          cancellationToken.reason?.toString() ?? 'Connection cancelled.',
+        );
+      }
+      rethrow;
+    }
+  }
+}
+
+final class _McpDartProtocolSession implements McpProtocolSession {
+  _McpDartProtocolSession(this.serverId, this._client);
+
+  final String serverId;
+  final sdk.McpClient _client;
+  bool _closed = false;
+
+  @override
+  String? get serverImplementation => _client.getServerVersion()?.name;
+
+  @override
+  String? get serverVersion => _client.getServerVersion()?.version;
+
+  @override
+  String? get protocolVersion => _client.getProtocolVersion();
+
+  @override
+  Future<List<McpToolDescriptor>> listTools({
+    required ToolCancellationToken cancellationToken,
+    required Duration timeout,
+  }) async {
+    _requireOpen();
+    final abort = _abortFor(cancellationToken);
+    final tools = <McpToolDescriptor>[];
+    final cursors = <String>{};
+    String? cursor;
+    for (var page = 0; page < 100; page++) {
+      final result = await _client.listTools(
+        params: cursor == null ? null : sdk.ListToolsRequest(cursor: cursor),
+        options: sdk.RequestOptions(
+          signal: abort.signal,
+          timeout: timeout,
+          maxTotalTimeout: timeout,
+        ),
+      );
+      tools.addAll(result.tools.map(_mapTool));
+      final next = result.nextCursor;
+      if (next == null) return List.unmodifiable(tools);
+      if (!cursors.add(next)) {
+        throw const McpException(
+          'repeated_cursor',
+          'The server repeated a tools/list cursor.',
+        );
+      }
+      cursor = next;
+    }
+    throw const McpException(
+      'pagination_limit',
+      'Tool discovery exceeded 100 pages.',
+    );
+  }
+
+  @override
+  Future<Map<String, dynamic>> callTool({
+    required String name,
+    required Map<String, dynamic> arguments,
+    required ToolCancellationToken cancellationToken,
+    required Duration timeout,
+  }) async {
+    _requireOpen();
+    final abort = _abortFor(cancellationToken);
+    final result = await _client.callTool(
+      sdk.CallToolRequest(name: name, arguments: arguments),
+      options: sdk.RequestOptions(
+        signal: abort.signal,
+        timeout: timeout,
+        maxTotalTimeout: timeout,
+      ),
+    );
+    return Map<String, dynamic>.from(result.toJson());
+  }
+
+  @override
+  Future<void> close() async {
+    if (_closed) return;
+    _closed = true;
+    await _client.close();
+  }
+
+  void _requireOpen() {
+    if (_closed || !_client.isConnected) {
+      throw const McpException(
+        'not_connected',
+        'The MCP server is not connected.',
+      );
+    }
+  }
+
+  sdk.BasicAbortController _abortFor(ToolCancellationToken token) {
+    token.throwIfCancelled();
+    final controller = sdk.BasicAbortController();
+    token.whenCancelled(controller.abort);
+    return controller;
+  }
+
+  McpToolDescriptor _mapTool(sdk.Tool tool) {
+    final annotations = tool.annotations;
+    final readOnly = annotations?.readOnlyHint == true;
+    final openWorld = annotations?.openWorldHint ?? true;
+    final accessLevel = readOnly
+        ? ToolAccessLevel.readOnly
+        : openWorld
+            ? ToolAccessLevel.externalSideEffect
+            : ToolAccessLevel.write;
+    return McpToolDescriptor(
+      serverId: serverId,
+      name: tool.name,
+      title: tool.title ?? annotations?.title ?? tool.name,
+      description: tool.description?.trim().isNotEmpty == true
+          ? tool.description!.trim()
+          : 'No description provided by the server.',
+      inputSchema: tool.inputSchema.toJson(),
+      accessLevel: accessLevel,
+      destructiveHint: annotations?.destructiveHint ?? true,
+      openWorldHint: openWorld,
+    );
+  }
+}

--- a/lib/presentation/providers/mcp_providers.dart
+++ b/lib/presentation/providers/mcp_providers.dart
@@ -1,0 +1,193 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:native_tavern/core/services/initialization_service.dart';
+import 'package:native_tavern/domain/models/mcp.dart';
+import 'package:native_tavern/domain/repositories/mcp_repository.dart';
+import 'package:native_tavern/domain/services/mcp/mcp_client_manager.dart';
+import 'package:native_tavern/domain/services/tool_calling/tool_execution_audit_service.dart';
+
+final mcpSettingsRepositoryProvider = Provider<McpSettingsRepository>((ref) {
+  return FileMcpSettingsRepository(dataPath: ref.watch(dataPathProvider));
+});
+
+final mcpCredentialRepositoryProvider =
+    Provider<McpCredentialRepository>((ref) {
+  return const SecureMcpCredentialRepository();
+});
+
+final mcpActivityRepositoryProvider = Provider<McpActivityRepository>((ref) {
+  return FileMcpActivityRepository(dataPath: ref.watch(dataPathProvider));
+});
+
+final toolExecutionAuditRepositoryProvider =
+    Provider<ToolExecutionAuditRepository>((ref) {
+  return FileToolExecutionAuditRepository(
+    dataPath: ref.watch(dataPathProvider),
+  );
+});
+
+final mcpClientManagerProvider = Provider<McpClientManager>((ref) {
+  final manager = McpClientManager(
+    settingsRepository: ref.watch(mcpSettingsRepositoryProvider),
+    credentialRepository: ref.watch(mcpCredentialRepositoryProvider),
+    activityRepository: ref.watch(mcpActivityRepositoryProvider),
+    toolAuditRepository: ref.watch(toolExecutionAuditRepositoryProvider),
+  );
+  ref.onDispose(() => unawaited(manager.close()));
+  return manager;
+});
+
+final class McpManagementState {
+  const McpManagementState({
+    this.loading = true,
+    this.enabled = false,
+    this.servers = const [],
+    this.activity = const [],
+    this.error,
+  });
+
+  final bool loading;
+  final bool enabled;
+  final List<McpServerSnapshot> servers;
+  final List<McpActivityRecord> activity;
+  final String? error;
+
+  McpManagementState copyWith({
+    bool? loading,
+    bool? enabled,
+    List<McpServerSnapshot>? servers,
+    List<McpActivityRecord>? activity,
+    String? error,
+    bool clearError = false,
+  }) {
+    return McpManagementState(
+      loading: loading ?? this.loading,
+      enabled: enabled ?? this.enabled,
+      servers: servers ?? this.servers,
+      activity: activity ?? this.activity,
+      error: clearError ? null : (error ?? this.error),
+    );
+  }
+}
+
+final class McpManagementController extends StateNotifier<McpManagementState> {
+  McpManagementController(this._manager) : super(const McpManagementState()) {
+    _subscription = _manager.changes.listen((_) => unawaited(_synchronize()));
+    unawaited(load());
+  }
+
+  final McpClientManager _manager;
+  late final StreamSubscription<void> _subscription;
+  Future<void>? _loading;
+
+  McpClientManager get manager => _manager;
+
+  Future<void> load() {
+    final current = _loading;
+    if (current != null) return current;
+    final operation = _load();
+    _loading = operation;
+    return operation.whenComplete(() => _loading = null);
+  }
+
+  Future<void> _load() async {
+    state = state.copyWith(loading: true, clearError: true);
+    try {
+      await _manager.initialize();
+      await _synchronize();
+      state = state.copyWith(loading: false, clearError: true);
+    } catch (error) {
+      state = state.copyWith(
+        loading: false,
+        error: sanitizeMcpDiagnostic(error.toString()),
+      );
+    }
+  }
+
+  Future<void> setEnabled(bool enabled) =>
+      _run(() => _manager.setEnabled(enabled));
+
+  Future<void> saveServer(
+    McpServerConfig config, {
+    String? bearerToken,
+    bool clearCredential = false,
+  }) {
+    return _run(() => _manager.upsertServer(
+          config,
+          bearerToken: bearerToken,
+          clearCredential: clearCredential,
+        ));
+  }
+
+  Future<void> setServerEnabled(String serverId, bool enabled) =>
+      _run(() => _manager.setServerEnabled(serverId, enabled));
+
+  Future<void> removeServer(String serverId) =>
+      _run(() => _manager.removeServer(serverId));
+
+  Future<void> connect(String serverId) =>
+      _run(() => _manager.connect(serverId));
+
+  Future<void> reconnect(String serverId) =>
+      _run(() => _manager.reconnect(serverId));
+
+  Future<void> disconnect(String serverId) =>
+      _run(() => _manager.disconnect(serverId));
+
+  Future<void> refreshTools(String serverId) =>
+      _run(() => _manager.refreshTools(serverId));
+
+  void cancelOperation(String serverId) => _manager.cancelOperation(serverId);
+
+  Future<void> setToolPermission(
+    String serverId,
+    String toolName,
+    McpToolPermission permission,
+  ) {
+    return _run(
+      () => _manager.setToolPermission(serverId, toolName, permission),
+    );
+  }
+
+  McpToolPermission permissionFor(String serverId, String toolName) =>
+      _manager.permissionFor(serverId, toolName);
+
+  bool hasNameCollision(McpToolDescriptor tool) =>
+      _manager.hasNameCollision(tool);
+
+  Future<void> refreshActivity() => _synchronize();
+
+  Future<void> _run(Future<void> Function() operation) async {
+    state = state.copyWith(clearError: true);
+    try {
+      await operation();
+      await _synchronize();
+    } catch (error) {
+      await _synchronize();
+      state = state.copyWith(error: sanitizeMcpDiagnostic(error.toString()));
+      rethrow;
+    }
+  }
+
+  Future<void> _synchronize() async {
+    final activity = await _manager.readRecentActivity(limit: 100);
+    if (!mounted) return;
+    state = state.copyWith(
+      enabled: _manager.enabled,
+      servers: _manager.snapshots,
+      activity: activity,
+    );
+  }
+
+  @override
+  void dispose() {
+    unawaited(_subscription.cancel());
+    super.dispose();
+  }
+}
+
+final mcpManagementProvider =
+    StateNotifierProvider<McpManagementController, McpManagementState>((ref) {
+  return McpManagementController(ref.watch(mcpClientManagerProvider));
+});

--- a/lib/presentation/router/app_router.dart
+++ b/lib/presentation/router/app_router.dart
@@ -30,6 +30,7 @@ import 'package:native_tavern/presentation/screens/settings/tokenizer_settings_s
 import 'package:native_tavern/presentation/screens/settings/vector_storage_settings_screen.dart';
 import 'package:native_tavern/presentation/screens/settings/capability_diagnostics_screen.dart';
 import 'package:native_tavern/presentation/screens/settings/memory_inbox_screen.dart';
+import 'package:native_tavern/presentation/screens/settings/mcp_settings_screen.dart';
 import 'package:native_tavern/presentation/widgets/chat/logprobs_panel.dart';
 import 'package:native_tavern/presentation/screens/ai_config/ai_config_screen.dart';
 import 'package:native_tavern/presentation/screens/import/import_screen.dart';
@@ -82,6 +83,7 @@ abstract class AppRoutes {
   static const vectorStorageSettings = '/vector-storage-settings';
   static const capabilityDiagnostics = '/capability-diagnostics';
   static const memoryInbox = '/memory-inbox';
+  static const mcpSettings = '/mcp-settings';
 }
 
 /// Navigation keys for nested navigation
@@ -384,6 +386,12 @@ final appRouterProvider = Provider<GoRouter>((ref) {
         name: 'capabilityDiagnostics',
         parentNavigatorKey: _rootNavigatorKey,
         builder: (context, state) => const CapabilityDiagnosticsScreen(),
+      ),
+      GoRoute(
+        path: AppRoutes.mcpSettings,
+        name: 'mcpSettings',
+        parentNavigatorKey: _rootNavigatorKey,
+        builder: (context, state) => const McpSettingsScreen(),
       ),
     ],
     errorBuilder: (context, state) => Scaffold(

--- a/lib/presentation/screens/settings/mcp_settings_screen.dart
+++ b/lib/presentation/screens/settings/mcp_settings_screen.dart
@@ -1,0 +1,764 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:native_tavern/domain/models/built_in_tool.dart';
+import 'package:native_tavern/domain/models/mcp.dart';
+import 'package:native_tavern/domain/services/mcp/mcp_client_manager.dart';
+import 'package:native_tavern/presentation/providers/mcp_providers.dart';
+import 'package:native_tavern/presentation/theme/app_theme.dart';
+import 'package:uuid/uuid.dart';
+
+class McpSettingsScreen extends ConsumerWidget {
+  const McpSettingsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(mcpManagementProvider);
+    final controller = ref.read(mcpManagementProvider.notifier);
+    return DefaultTabController(
+      length: 2,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('MCP servers'),
+          actions: [
+            IconButton(
+              key: const Key('mcp-add-server'),
+              onPressed: () => _editServer(context, controller),
+              icon: const Icon(Icons.add),
+              tooltip: 'Add server',
+            ),
+          ],
+          bottom: const TabBar(
+            tabs: [
+              Tab(icon: Icon(Icons.dns_outlined), text: 'Servers'),
+              Tab(icon: Icon(Icons.receipt_long_outlined), text: 'Activity'),
+            ],
+          ),
+        ),
+        body: Column(
+          children: [
+            SwitchListTile(
+              key: const Key('mcp-master-toggle'),
+              secondary: const Icon(Icons.extension_outlined),
+              title: const Text('Model Context Protocol'),
+              subtitle: Text(state.enabled ? 'Enabled' : 'Disabled'),
+              value: state.enabled,
+              onChanged: state.loading
+                  ? null
+                  : (value) => _guard(
+                        context,
+                        () => controller.setEnabled(value),
+                      ),
+            ),
+            if (state.error != null)
+              Container(
+                key: const Key('mcp-error-banner'),
+                width: double.infinity,
+                color: Colors.red.withValues(alpha: 0.12),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 16,
+                  vertical: 8,
+                ),
+                child: Text(
+                  state.error!,
+                  maxLines: 3,
+                  overflow: TextOverflow.ellipsis,
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: Colors.red.shade300,
+                      ),
+                ),
+              ),
+            const Divider(height: 1),
+            Expanded(
+              child: state.loading && state.servers.isEmpty
+                  ? const Center(child: CircularProgressIndicator())
+                  : TabBarView(
+                      children: [
+                        _ServerList(
+                          state: state,
+                          controller: controller,
+                        ),
+                        _ActivityList(records: state.activity),
+                      ],
+                    ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _editServer(
+    BuildContext context,
+    McpManagementController controller, [
+    McpServerConfig? existing,
+  ]) async {
+    final result = await showDialog<_McpServerEditResult>(
+      context: context,
+      builder: (_) => _McpServerEditorDialog(existing: existing),
+    );
+    if (result == null || !context.mounted) return;
+    await _guard(
+      context,
+      () => controller.saveServer(
+        result.config,
+        bearerToken: result.bearerToken,
+        clearCredential: result.clearCredential,
+      ),
+    );
+  }
+
+  static Future<void> _guard(
+    BuildContext context,
+    Future<void> Function() operation,
+  ) async {
+    try {
+      await operation();
+    } catch (error) {
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(sanitizeMcpDiagnostic(error.toString()))),
+      );
+    }
+  }
+}
+
+class _ServerList extends StatelessWidget {
+  const _ServerList({required this.state, required this.controller});
+
+  final McpManagementState state;
+  final McpManagementController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    if (state.servers.isEmpty) {
+      return const _EmptyState(
+        icon: Icons.dns_outlined,
+        title: 'No MCP servers',
+      );
+    }
+    return RefreshIndicator(
+      onRefresh: controller.refreshActivity,
+      child: ListView.separated(
+        key: const Key('mcp-server-list'),
+        physics: const AlwaysScrollableScrollPhysics(),
+        itemCount: state.servers.length,
+        separatorBuilder: (_, __) => const Divider(height: 1),
+        itemBuilder: (context, index) {
+          return _ServerTile(
+            snapshot: state.servers[index],
+            globallyEnabled: state.enabled,
+            controller: controller,
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _ServerTile extends StatelessWidget {
+  const _ServerTile({
+    required this.snapshot,
+    required this.globallyEnabled,
+    required this.controller,
+  });
+
+  final McpServerSnapshot snapshot;
+  final bool globallyEnabled;
+  final McpManagementController controller;
+
+  bool get _busy =>
+      snapshot.status == McpConnectionStatus.connecting ||
+      snapshot.status == McpConnectionStatus.reconnecting;
+
+  @override
+  Widget build(BuildContext context) {
+    final config = snapshot.config;
+    return ExpansionTile(
+      key: Key('mcp-server-${config.id}'),
+      leading: Icon(
+        _statusIcon(snapshot.status),
+        color: _statusColor(snapshot.status),
+      ),
+      title: Text(
+        config.name,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+      subtitle: Text(
+        '${_statusLabel(snapshot.status)}  ${config.displayEndpoint}',
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+      trailing: Switch(
+        key: Key('mcp-server-toggle-${config.id}'),
+        value: config.enabled,
+        onChanged: (value) => McpSettingsScreen._guard(
+          context,
+          () => controller.setServerEnabled(config.id, value),
+        ),
+      ),
+      children: [
+        if (snapshot.errorMessage != null)
+          ListTile(
+            dense: true,
+            leading: const Icon(Icons.error_outline, color: Colors.red),
+            title: Text(snapshot.errorMessage!),
+            subtitle: snapshot.errorCode == null
+                ? null
+                : Text('Code: ${snapshot.errorCode}'),
+          ),
+        if (snapshot.serverImplementation != null)
+          ListTile(
+            dense: true,
+            leading: const Icon(Icons.info_outline),
+            title: Text(
+              '${snapshot.serverImplementation} ${snapshot.serverVersion ?? ''}'
+                  .trim(),
+            ),
+            subtitle: Text('Protocol ${snapshot.protocolVersion ?? 'unknown'}'),
+          ),
+        Padding(
+          padding: const EdgeInsets.fromLTRB(12, 0, 12, 8),
+          child: Row(
+            children: [
+              if (_busy)
+                _ActionIcon(
+                  key: Key('mcp-cancel-${config.id}'),
+                  icon: Icons.stop_circle_outlined,
+                  tooltip: 'Cancel',
+                  onPressed: () => controller.cancelOperation(config.id),
+                )
+              else if (snapshot.isConnected) ...[
+                _ActionIcon(
+                  key: Key('mcp-disconnect-${config.id}'),
+                  icon: Icons.link_off,
+                  tooltip: 'Disconnect',
+                  onPressed: () => McpSettingsScreen._guard(
+                    context,
+                    () => controller.disconnect(config.id),
+                  ),
+                ),
+                _ActionIcon(
+                  key: Key('mcp-refresh-${config.id}'),
+                  icon: Icons.refresh,
+                  tooltip: 'Refresh tools',
+                  onPressed: () => McpSettingsScreen._guard(
+                    context,
+                    () => controller.refreshTools(config.id),
+                  ),
+                ),
+                _ActionIcon(
+                  key: Key('mcp-reconnect-${config.id}'),
+                  icon: Icons.sync,
+                  tooltip: 'Reconnect',
+                  onPressed: () => McpSettingsScreen._guard(
+                    context,
+                    () => controller.reconnect(config.id),
+                  ),
+                ),
+              ] else
+                _ActionIcon(
+                  key: Key('mcp-connect-${config.id}'),
+                  icon: Icons.link,
+                  tooltip: 'Connect',
+                  onPressed: globallyEnabled && config.enabled
+                      ? () => McpSettingsScreen._guard(
+                            context,
+                            () => controller.connect(config.id),
+                          )
+                      : null,
+                ),
+              const Spacer(),
+              _ActionIcon(
+                key: Key('mcp-edit-${config.id}'),
+                icon: Icons.edit_outlined,
+                tooltip: 'Edit server',
+                onPressed: () => _edit(context),
+              ),
+              _ActionIcon(
+                key: Key('mcp-delete-${config.id}'),
+                icon: Icons.delete_outline,
+                tooltip: 'Remove server',
+                onPressed: () => _remove(context),
+              ),
+            ],
+          ),
+        ),
+        if (snapshot.isConnected && snapshot.tools.isEmpty)
+          const ListTile(
+            dense: true,
+            leading: Icon(Icons.extension_off_outlined),
+            title: Text('No tools discovered'),
+          ),
+        ...snapshot.tools.map(
+          (tool) => _ToolTile(tool: tool, controller: controller),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _edit(BuildContext context) async {
+    final result = await showDialog<_McpServerEditResult>(
+      context: context,
+      builder: (_) => _McpServerEditorDialog(existing: snapshot.config),
+    );
+    if (result == null || !context.mounted) return;
+    await McpSettingsScreen._guard(
+      context,
+      () => controller.saveServer(
+        result.config,
+        bearerToken: result.bearerToken,
+        clearCredential: result.clearCredential,
+      ),
+    );
+  }
+
+  Future<void> _remove(BuildContext context) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('Remove MCP server?'),
+        content: Text(snapshot.config.name),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext, false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(dialogContext, true),
+            child: const Text('Remove'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true || !context.mounted) return;
+    await McpSettingsScreen._guard(
+      context,
+      () => controller.removeServer(snapshot.config.id),
+    );
+  }
+}
+
+class _ToolTile extends StatelessWidget {
+  const _ToolTile({required this.tool, required this.controller});
+
+  final McpToolDescriptor tool;
+  final McpManagementController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    final permission = controller.permissionFor(tool.serverId, tool.name);
+    final collision = controller.hasNameCollision(tool);
+    return ListTile(
+      key: Key('mcp-tool-${tool.serverId}-${tool.name}'),
+      dense: true,
+      contentPadding: const EdgeInsets.only(left: 28, right: 8),
+      leading: Icon(_accessIcon(tool.accessLevel), size: 20),
+      title: Text(
+        collision ? '${tool.title} (${tool.qualifiedName})' : tool.title,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+      subtitle: Text(
+        '${_accessLabel(tool.accessLevel)}  ${_permissionLabel(permission)}\n'
+        '${tool.description}',
+        maxLines: 3,
+        overflow: TextOverflow.ellipsis,
+      ),
+      trailing: PopupMenuButton<McpToolPermission>(
+        key: Key('mcp-permission-${tool.serverId}-${tool.name}'),
+        tooltip: 'Tool permission',
+        initialValue: permission,
+        icon: Icon(_permissionIcon(permission)),
+        onSelected: (value) => McpSettingsScreen._guard(
+          context,
+          () => controller.setToolPermission(tool.serverId, tool.name, value),
+        ),
+        itemBuilder: (_) => const [
+          PopupMenuItem(
+            value: McpToolPermission.askEveryTime,
+            child: Row(
+              children: [
+                Icon(Icons.help_outline),
+                SizedBox(width: 12),
+                Text('Ask every time'),
+              ],
+            ),
+          ),
+          PopupMenuItem(
+            value: McpToolPermission.alwaysAllow,
+            child: Row(
+              children: [
+                Icon(Icons.verified_user_outlined),
+                SizedBox(width: 12),
+                Text('Always allow'),
+              ],
+            ),
+          ),
+          PopupMenuItem(
+            value: McpToolPermission.denied,
+            child: Row(
+              children: [
+                Icon(Icons.block),
+                SizedBox(width: 12),
+                Text('Denied'),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ActivityList extends StatelessWidget {
+  const _ActivityList({required this.records});
+
+  final List<McpActivityRecord> records;
+
+  @override
+  Widget build(BuildContext context) {
+    if (records.isEmpty) {
+      return const _EmptyState(
+        icon: Icons.receipt_long_outlined,
+        title: 'No MCP activity',
+      );
+    }
+    return ListView.separated(
+      key: const Key('mcp-activity-list'),
+      itemCount: records.length,
+      separatorBuilder: (_, __) => const Divider(height: 1),
+      itemBuilder: (context, index) {
+        final record = records[index];
+        return ListTile(
+          dense: true,
+          leading: Icon(_activityIcon(record.kind), size: 20),
+          title: Text(
+            record.message,
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+          ),
+          subtitle: Text(
+            '${record.serverId}${record.toolName == null ? '' : '  ${record.toolName}'}',
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+          trailing: Text(
+            _timeLabel(record.timestamp.toLocal()),
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: AppTheme.textMuted,
+                ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _McpServerEditorDialog extends StatefulWidget {
+  const _McpServerEditorDialog({this.existing});
+
+  final McpServerConfig? existing;
+
+  @override
+  State<_McpServerEditorDialog> createState() => _McpServerEditorDialogState();
+}
+
+class _McpServerEditorDialogState extends State<_McpServerEditorDialog> {
+  late final TextEditingController _nameController;
+  late final TextEditingController _endpointController;
+  late final TextEditingController _tokenController;
+  late McpTransportType _transport;
+  late bool _enabled;
+  late bool _allowInsecure;
+  bool _clearCredential = false;
+  bool _obscureToken = true;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    final existing = widget.existing;
+    _nameController = TextEditingController(text: existing?.name ?? '');
+    _endpointController =
+        TextEditingController(text: existing?.endpoint.toString() ?? '');
+    _tokenController = TextEditingController();
+    _transport = existing?.transport ?? McpTransportType.streamableHttp;
+    _enabled = existing?.enabled ?? false;
+    _allowInsecure = existing?.allowInsecureHttp ?? false;
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _endpointController.dispose();
+    _tokenController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      insetPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 24),
+      title:
+          Text(widget.existing == null ? 'Add MCP server' : 'Edit MCP server'),
+      content: SizedBox(
+        width: 480,
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              TextField(
+                key: const Key('mcp-server-name'),
+                controller: _nameController,
+                decoration: const InputDecoration(labelText: 'Name'),
+                textInputAction: TextInputAction.next,
+              ),
+              const SizedBox(height: 12),
+              TextField(
+                key: const Key('mcp-server-endpoint'),
+                controller: _endpointController,
+                decoration: const InputDecoration(labelText: 'MCP endpoint'),
+                keyboardType: TextInputType.url,
+                autocorrect: false,
+              ),
+              const SizedBox(height: 12),
+              DropdownButtonFormField<McpTransportType>(
+                key: const Key('mcp-server-transport'),
+                initialValue: _transport,
+                decoration: const InputDecoration(labelText: 'Transport'),
+                items: const [
+                  DropdownMenuItem(
+                    value: McpTransportType.streamableHttp,
+                    child: Text('Streamable HTTP'),
+                  ),
+                  DropdownMenuItem(
+                    value: McpTransportType.legacySse,
+                    child: Text('Legacy HTTP + SSE'),
+                  ),
+                ],
+                onChanged: (value) {
+                  if (value != null) setState(() => _transport = value);
+                },
+              ),
+              const SizedBox(height: 12),
+              TextField(
+                key: const Key('mcp-server-token'),
+                controller: _tokenController,
+                obscureText: _obscureToken,
+                autocorrect: false,
+                enableSuggestions: false,
+                decoration: InputDecoration(
+                  labelText: 'Bearer token',
+                  suffixIcon: IconButton(
+                    onPressed: () =>
+                        setState(() => _obscureToken = !_obscureToken),
+                    icon: Icon(
+                      _obscureToken ? Icons.visibility : Icons.visibility_off,
+                    ),
+                    tooltip: _obscureToken ? 'Show token' : 'Hide token',
+                  ),
+                ),
+              ),
+              if (widget.existing != null)
+                CheckboxListTile(
+                  key: const Key('mcp-clear-token'),
+                  contentPadding: EdgeInsets.zero,
+                  title: const Text('Remove stored token'),
+                  value: _clearCredential,
+                  onChanged: (value) =>
+                      setState(() => _clearCredential = value ?? false),
+                ),
+              SwitchListTile(
+                key: const Key('mcp-allow-insecure'),
+                contentPadding: EdgeInsets.zero,
+                title: const Text('Allow insecure HTTP'),
+                value: _allowInsecure,
+                onChanged: (value) => setState(() => _allowInsecure = value),
+              ),
+              SwitchListTile(
+                key: const Key('mcp-server-enabled'),
+                contentPadding: EdgeInsets.zero,
+                title: const Text('Server enabled'),
+                value: _enabled,
+                onChanged: (value) => setState(() => _enabled = value),
+              ),
+              if (_error != null)
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    _error!,
+                    style: TextStyle(color: Colors.red.shade300),
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          key: const Key('mcp-save-server'),
+          onPressed: _submit,
+          child: const Text('Save'),
+        ),
+      ],
+    );
+  }
+
+  void _submit() {
+    try {
+      final config = McpServerConfig(
+        id: widget.existing?.id ?? const Uuid().v4(),
+        name: _nameController.text,
+        endpoint: Uri.parse(_endpointController.text.trim()),
+        transport: _transport,
+        enabled: _enabled,
+        allowInsecureHttp: _allowInsecure,
+        connectTimeout:
+            widget.existing?.connectTimeout ?? const Duration(seconds: 15),
+        requestTimeout:
+            widget.existing?.requestTimeout ?? const Duration(seconds: 30),
+      );
+      Navigator.pop(
+        context,
+        _McpServerEditResult(
+          config: config,
+          bearerToken: _tokenController.text.trim().isEmpty
+              ? null
+              : _tokenController.text,
+          clearCredential: _clearCredential,
+        ),
+      );
+    } catch (error) {
+      setState(() => _error = sanitizeMcpDiagnostic(error.toString()));
+    }
+  }
+}
+
+final class _McpServerEditResult {
+  const _McpServerEditResult({
+    required this.config,
+    required this.bearerToken,
+    required this.clearCredential,
+  });
+
+  final McpServerConfig config;
+  final String? bearerToken;
+  final bool clearCredential;
+}
+
+class _ActionIcon extends StatelessWidget {
+  const _ActionIcon({
+    super.key,
+    required this.icon,
+    required this.tooltip,
+    required this.onPressed,
+  });
+
+  final IconData icon;
+  final String tooltip;
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox.square(
+      dimension: 42,
+      child: IconButton(
+        onPressed: onPressed,
+        icon: Icon(icon),
+        tooltip: tooltip,
+      ),
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  const _EmptyState({required this.icon, required this.title});
+
+  final IconData icon;
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 44, color: AppTheme.textMuted),
+          const SizedBox(height: 12),
+          Text(title, style: Theme.of(context).textTheme.titleMedium),
+        ],
+      ),
+    );
+  }
+}
+
+IconData _statusIcon(McpConnectionStatus status) => switch (status) {
+      McpConnectionStatus.disabled => Icons.pause_circle_outline,
+      McpConnectionStatus.disconnected => Icons.link_off,
+      McpConnectionStatus.connecting => Icons.pending_outlined,
+      McpConnectionStatus.connected => Icons.check_circle_outline,
+      McpConnectionStatus.reconnecting => Icons.sync,
+      McpConnectionStatus.error => Icons.error_outline,
+    };
+
+Color _statusColor(McpConnectionStatus status) => switch (status) {
+      McpConnectionStatus.connected => Colors.green,
+      McpConnectionStatus.error => Colors.red,
+      McpConnectionStatus.connecting ||
+      McpConnectionStatus.reconnecting =>
+        Colors.orange,
+      _ => AppTheme.textMuted,
+    };
+
+String _statusLabel(McpConnectionStatus status) => switch (status) {
+      McpConnectionStatus.disabled => 'Disabled',
+      McpConnectionStatus.disconnected => 'Disconnected',
+      McpConnectionStatus.connecting => 'Connecting',
+      McpConnectionStatus.connected => 'Connected',
+      McpConnectionStatus.reconnecting => 'Reconnecting',
+      McpConnectionStatus.error => 'Error',
+    };
+
+IconData _accessIcon(ToolAccessLevel access) => switch (access) {
+      ToolAccessLevel.readOnly => Icons.visibility_outlined,
+      ToolAccessLevel.write => Icons.edit_note_outlined,
+      ToolAccessLevel.externalSideEffect => Icons.public_outlined,
+    };
+
+String _accessLabel(ToolAccessLevel access) => switch (access) {
+      ToolAccessLevel.readOnly => 'Read-only hint',
+      ToolAccessLevel.write => 'Write-capable',
+      ToolAccessLevel.externalSideEffect => 'External side effect',
+    };
+
+IconData _permissionIcon(McpToolPermission permission) => switch (permission) {
+      McpToolPermission.askEveryTime => Icons.help_outline,
+      McpToolPermission.alwaysAllow => Icons.verified_user_outlined,
+      McpToolPermission.denied => Icons.block,
+    };
+
+String _permissionLabel(McpToolPermission permission) => switch (permission) {
+      McpToolPermission.askEveryTime => 'Ask every time',
+      McpToolPermission.alwaysAllow => 'Always allow',
+      McpToolPermission.denied => 'Denied',
+    };
+
+IconData _activityIcon(McpActivityKind kind) => switch (kind) {
+      McpActivityKind.configured => Icons.settings_outlined,
+      McpActivityKind.connected => Icons.link,
+      McpActivityKind.disconnected => Icons.link_off,
+      McpActivityKind.discovery => Icons.manage_search,
+      McpActivityKind.permission => Icons.shield_outlined,
+      McpActivityKind.error => Icons.error_outline,
+      McpActivityKind.cancelled => Icons.cancel_outlined,
+    };
+
+String _timeLabel(DateTime time) {
+  String two(int value) => value.toString().padLeft(2, '0');
+  return '${two(time.month)}/${two(time.day)} ${two(time.hour)}:${two(time.minute)}';
+}

--- a/lib/presentation/screens/settings/settings_screen.dart
+++ b/lib/presentation/screens/settings/settings_screen.dart
@@ -133,6 +133,15 @@ class SettingsScreen extends ConsumerWidget {
             onTap: () => context.push(AppRoutes.capabilityDiagnostics),
           ),
           ListTile(
+            key: const Key('mcp-settings-tile'),
+            leading: const Icon(Icons.extension_outlined),
+            title: const Text('MCP servers'),
+            subtitle:
+                const Text('Connections, tools, permissions, and activity'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () => context.push(AppRoutes.mcpSettings),
+          ),
+          ListTile(
             leading: const Icon(Icons.find_replace),
             title: Text(l10n.regex),
             trailing: const Icon(Icons.chevron_right),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -539,6 +539,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.6.1"
+  flutter_secure_storage:
+    dependency: "direct main"
+    description:
+      name: flutter_secure_storage
+      sha256: "9cad52d75ebc511adfae3d447d5d13da15a55a92c9410e50f67335b6d21d16ea"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.2.4"
+  flutter_secure_storage_linux:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_linux
+      sha256: be76c1d24a97d0b98f8b54bce6b481a380a6590df992d0098f868ad54dc8f688
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.3"
+  flutter_secure_storage_macos:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_macos
+      sha256: "6c0a2795a2d1de26ae202a0d78527d163f4acbb11cde4c75c670f3a0fc064247"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.3"
+  flutter_secure_storage_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_platform_interface
+      sha256: cf91ad32ce5adef6fba4d736a542baca9daf3beac4db2d04be350b87f69ac4a8
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
+  flutter_secure_storage_web:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_web
+      sha256: f4ebff989b4f07b2656fb16b47852c0aab9fed9b4ec1c70103368337bc1886a9
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
+  flutter_secure_storage_windows:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_windows
+      sha256: b20b07cb5ed4ed74fc567b78a72936203f587eba460af1df11281c9326cd3709
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.2"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -801,10 +849,10 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "0.6.7"
   json_annotation:
     dependency: "direct main"
     description:
@@ -909,6 +957,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.11.1"
+  mcp_dart:
+    dependency: "direct main"
+    description:
+      name: mcp_dart
+      sha256: "66a17878b76faee9655b8f74e9852fa9f2811e26a9aa8ec2ac2637f0324be3e8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
   meta:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,12 +28,14 @@ dependencies:
   path_provider: ^2.1.1
   path: ^1.8.3
   shared_preferences: ^2.2.2
+  flutter_secure_storage: ^9.2.4
   
   # File Picker
   file_picker: ^8.0.0
   
   # Networking
   dio: ^5.4.0
+  mcp_dart: ^2.4.0
   
   # Image Processing
   image: ^4.1.3

--- a/test/mcp_client_manager_test.dart
+++ b/test/mcp_client_manager_test.dart
@@ -1,0 +1,503 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:native_tavern/domain/models/built_in_tool.dart';
+import 'package:native_tavern/domain/models/mcp.dart';
+import 'package:native_tavern/domain/models/tool_calling.dart';
+import 'package:native_tavern/domain/repositories/mcp_repository.dart';
+import 'package:native_tavern/domain/services/mcp/mcp_client_manager.dart';
+import 'package:native_tavern/domain/services/mcp/mcp_protocol_client.dart';
+import 'package:native_tavern/domain/services/tool_calling/tool_execution_audit_service.dart';
+
+void main() {
+  group('MCP configuration', () {
+    test('rejects credentials in URLs and requires explicit insecure approval',
+        () {
+      expect(
+        () => McpServerConfig(
+          id: 'server',
+          name: 'Server',
+          endpoint: Uri.parse('https://token@example.com/mcp'),
+        ),
+        throwsA(isA<McpException>()),
+      );
+      expect(
+        () => McpServerConfig(
+          id: 'server',
+          name: 'Server',
+          endpoint: Uri.parse('https://example.com/mcp?token=secret'),
+        ),
+        throwsA(isA<McpException>()),
+      );
+      expect(
+        () => McpServerConfig(
+          id: 'server',
+          name: 'Server',
+          endpoint: Uri.parse('http://192.168.1.4/mcp'),
+        ),
+        throwsA(
+          isA<McpException>().having(
+            (error) => error.code,
+            'code',
+            'insecure_endpoint',
+          ),
+        ),
+      );
+      expect(
+        McpServerConfig(
+          id: 'server',
+          name: 'Server',
+          endpoint: Uri.parse('http://192.168.1.4/mcp'),
+          allowInsecureHttp: true,
+        ).displayEndpoint,
+        'http://192.168.1.4/mcp',
+      );
+      expect(
+        McpServerConfig(
+          id: 'server',
+          name: 'Server',
+          endpoint: Uri.parse('https://example.com/mcp?tenant=private'),
+        ).displayEndpoint,
+        'https://example.com/mcp',
+      );
+      expect(
+        () => McpServerConfig(
+          id: 'server',
+          name: 'Server',
+          endpoint: Uri.parse('https://example.com/mcp'),
+          requestTimeout: Duration.zero,
+        ),
+        throwsA(
+          isA<McpException>().having(
+            (error) => error.code,
+            'code',
+            'invalid_request_timeout',
+          ),
+        ),
+      );
+    });
+
+    test('persists settings atomically without storing credentials', () async {
+      final directory = await Directory.systemTemp.createTemp('mcp-settings-');
+      addTearDown(() => directory.delete(recursive: true));
+      final repository = FileMcpSettingsRepository(dataPath: directory.path);
+      final credentialRepository = MemoryMcpCredentialRepository();
+      final config = _config('one');
+
+      await repository.save(McpStoredSettings(
+        enabled: true,
+        servers: [config],
+        permissions: const [
+          McpToolPermissionRecord(
+            serverId: 'one',
+            toolName: 'search',
+            permission: McpToolPermission.alwaysAllow,
+          ),
+        ],
+      ));
+      await credentialRepository.writeToken('one', 'super-secret-token');
+
+      final file = File('${directory.path}/mcp/settings.json');
+      final source = await file.readAsString();
+      expect(source, isNot(contains('super-secret-token')));
+      final restored = await repository.load();
+      expect(restored.enabled, isTrue);
+      expect(restored.servers.single.id, 'one');
+      expect(
+        restored.permissions.single.permission,
+        McpToolPermission.alwaysAllow,
+      );
+    });
+  });
+
+  group('McpClientManager', () {
+    late MemoryMcpSettingsRepository settings;
+    late MemoryMcpCredentialRepository credentials;
+    late MemoryMcpActivityRepository activity;
+    late MemoryToolExecutionAuditRepository toolAudit;
+    late _FakeProtocolFactory factory;
+    late McpClientManager manager;
+
+    setUp(() {
+      settings = MemoryMcpSettingsRepository();
+      credentials = MemoryMcpCredentialRepository();
+      activity = MemoryMcpActivityRepository();
+      toolAudit = MemoryToolExecutionAuditRepository();
+      factory = _FakeProtocolFactory();
+      manager = McpClientManager(
+        settingsRepository: settings,
+        credentialRepository: credentials,
+        activityRepository: activity,
+        toolAuditRepository: toolAudit,
+        protocolClientFactory: factory,
+      );
+      addTearDown(manager.close);
+    });
+
+    test('never connects in the background after loading enabled settings',
+        () async {
+      settings.value = McpStoredSettings(
+        enabled: true,
+        servers: [_config('one')],
+      );
+
+      await manager.initialize();
+
+      expect(factory.connectCount, 0);
+      expect(manager.snapshot('one').status, McpConnectionStatus.disconnected);
+    });
+
+    test(
+        'connects explicitly, discovers tools, refreshes changes, and reconnects',
+        () async {
+      final first = _FakeProtocolSession(tools: [_tool('one', 'search')]);
+      final second = _FakeProtocolSession(
+        tools: [_tool('one', 'search'), _tool('one', 'write_note')],
+      );
+      factory.sessions.addAll([first, second]);
+      await manager.upsertServer(_config('one'), bearerToken: 'secret-token');
+      await manager.setEnabled(true);
+
+      await manager.connect('one');
+
+      expect(factory.connectCount, 1);
+      expect(factory.tokens.single, 'secret-token');
+      expect(manager.snapshot('one').isConnected, isTrue);
+      expect(
+          manager.snapshot('one').tools.map((tool) => tool.name), ['search']);
+      first.tools = [_tool('one', 'search'), _tool('one', 'new_tool')];
+      await factory.triggerToolsChanged('one');
+      expect(
+        manager.snapshot('one').tools.map((tool) => tool.name),
+        ['search', 'new_tool'],
+      );
+
+      await manager.reconnect('one');
+
+      expect(first.closed, isTrue);
+      expect(factory.connectCount, 2);
+      expect(manager.snapshot('one').tools, hasLength(2));
+      expect(
+        activity.records.map((record) => record.message).join(' '),
+        isNot(contains('secret-token')),
+      );
+    });
+
+    test('detects tool name collisions across connected servers', () async {
+      factory.sessions.addAll([
+        _FakeProtocolSession(tools: [_tool('one', 'search')]),
+        _FakeProtocolSession(tools: [_tool('two', 'search')]),
+      ]);
+      await manager.upsertServer(_config('one'));
+      await manager.upsertServer(_config('two'));
+      await manager.setEnabled(true);
+      await manager.connect('one');
+      await manager.connect('two');
+
+      final tools = manager.discoveredTools;
+      expect(tools, hasLength(2));
+      expect(tools.every(manager.hasNameCollision), isTrue);
+      expect(tools.map((tool) => tool.qualifiedName).toSet(), hasLength(2));
+      expect(tools.every((tool) => tool.qualifiedName.length <= 64), isTrue);
+      final punctuationNames = [
+        _tool('one', 'read.value'),
+        _tool('one', 'read/value'),
+      ];
+      expect(
+        punctuationNames.map((tool) => tool.qualifiedName).toSet(),
+        hasLength(2),
+      );
+    });
+
+    test('cancels an in-flight connection and releases session state',
+        () async {
+      factory.blockConnections = true;
+      await manager.upsertServer(_config('one'));
+      await manager.setEnabled(true);
+      final connecting = manager.connect('one');
+      await factory.connectStarted.future;
+
+      manager.cancelOperation('one');
+
+      await expectLater(connecting, throwsA(isA<McpException>()));
+      expect(manager.snapshot('one').status, McpConnectionStatus.disconnected);
+      expect(manager.snapshot('one').tools, isEmpty);
+      expect(activity.records.last.kind, McpActivityKind.cancelled);
+    });
+
+    test('supports one-time, permanent, revoked, and cancelled tool access',
+        () async {
+      final session = _FakeProtocolSession(tools: [_tool('one', 'search')]);
+      factory.sessions.add(session);
+      await manager.upsertServer(_config('one'));
+      await manager.setEnabled(true);
+      await manager.connect('one');
+      final call = ToolCall.ready(
+        id: 'call-1',
+        name: session.tools.single.qualifiedName,
+        arguments: const {'query': 'private text'},
+        rawArguments: '{"query":"private text"}',
+      );
+
+      var result = await manager.executeTool(
+        serverId: 'one',
+        call: call,
+        invocationContext: _context(),
+      );
+      expect(result.status, ToolResultStatus.failed);
+      expect(session.callCount, 0);
+
+      result = await manager.executeTool(
+        serverId: 'one',
+        call: call,
+        invocationContext: _context(),
+        requestApproval: (_) async => McpApprovalDecision.cancel,
+      );
+      expect(result.status, ToolResultStatus.cancelled);
+      expect(session.callCount, 0);
+
+      result = await manager.executeTool(
+        serverId: 'one',
+        call: call,
+        invocationContext: _context(),
+        requestApproval: (_) async => McpApprovalDecision.allowOnce,
+      );
+      expect(result.status, ToolResultStatus.succeeded);
+      expect(session.callCount, 1);
+      expect(
+        manager.permissionFor('one', 'search'),
+        McpToolPermission.askEveryTime,
+      );
+
+      result = await manager.executeTool(
+        serverId: 'one',
+        call: call,
+        invocationContext: _context(),
+        requestApproval: (_) async => McpApprovalDecision.alwaysAllow,
+      );
+      expect(result.status, ToolResultStatus.succeeded);
+      expect(
+        manager.permissionFor('one', 'search'),
+        McpToolPermission.alwaysAllow,
+      );
+      await manager.executeTool(
+        serverId: 'one',
+        call: call,
+        invocationContext: _context(),
+      );
+      expect(session.callCount, 3);
+
+      await manager.setToolPermission(
+        'one',
+        'search',
+        McpToolPermission.askEveryTime,
+      );
+      result = await manager.executeTool(
+        serverId: 'one',
+        call: call,
+        invocationContext: _context(),
+      );
+      expect(result.status, ToolResultStatus.failed);
+      expect(session.callCount, 3);
+
+      await manager.setToolPermission(
+        'one',
+        'search',
+        McpToolPermission.denied,
+      );
+      result = await manager.executeTool(
+        serverId: 'one',
+        call: call,
+        invocationContext: _context(),
+      );
+      expect(result.status, ToolResultStatus.failed);
+      expect(session.callCount, 3);
+      final audits = await toolAudit.readRecent(limit: 10);
+      expect(audits, hasLength(7));
+      expect(
+        audits[4].parameterSummary['query'],
+        isNot('private text'),
+      );
+    });
+
+    test('propagates cancellation into an in-flight remote tool call',
+        () async {
+      final session = _FakeProtocolSession(
+        tools: [_tool('one', 'search')],
+        blockCalls: true,
+      );
+      factory.sessions.add(session);
+      await manager.upsertServer(_config('one'));
+      await manager.setEnabled(true);
+      await manager.connect('one');
+      await manager.setToolPermission(
+        'one',
+        'search',
+        McpToolPermission.alwaysAllow,
+      );
+      final cancellation = ToolCancellationController();
+      final execution = manager.executeTool(
+        serverId: 'one',
+        call: ToolCall.ready(
+          id: 'call-cancel',
+          name: 'search',
+          arguments: const {},
+          rawArguments: '{}',
+        ),
+        invocationContext: ToolInvocationContext(
+          maxDepth: 2,
+          cancellationToken: cancellation.token,
+        ),
+      );
+      await session.callStarted.future;
+
+      cancellation.cancel('Stop');
+      final result = await execution;
+
+      expect(result.status, ToolResultStatus.cancelled);
+      expect(
+        (await toolAudit.readRecent(limit: 1)).single.result,
+        ToolExecutionOutcome.cancelled,
+      );
+    });
+
+    test(
+        'disabling MCP closes sessions and removing a server deletes its token',
+        () async {
+      final session = _FakeProtocolSession(tools: [_tool('one', 'search')]);
+      factory.sessions.add(session);
+      await manager.upsertServer(_config('one'), bearerToken: 'secret');
+      await manager.setEnabled(true);
+      await manager.connect('one');
+
+      await manager.setEnabled(false);
+      expect(session.closed, isTrue);
+      expect(manager.snapshot('one').status, McpConnectionStatus.disabled);
+
+      await manager.removeServer('one');
+      expect(await credentials.readToken('one'), isNull);
+      expect(manager.servers, isEmpty);
+    });
+  });
+}
+
+McpServerConfig _config(String id) => McpServerConfig(
+      id: id,
+      name: 'Server $id',
+      endpoint: Uri.parse('http://localhost:9000/mcp'),
+      enabled: true,
+    );
+
+McpToolDescriptor _tool(String serverId, String name) => McpToolDescriptor(
+      serverId: serverId,
+      name: name,
+      title: name,
+      description: 'Test tool',
+      inputSchema: const {'type': 'object'},
+      accessLevel: ToolAccessLevel.externalSideEffect,
+      destructiveHint: true,
+      openWorldHint: true,
+    );
+
+ToolInvocationContext _context() => ToolInvocationContext(
+      maxDepth: 2,
+      cancellationToken: ToolCancellationController().token,
+    );
+
+final class _FakeProtocolFactory implements McpProtocolClientFactory {
+  final List<_FakeProtocolSession> sessions = [];
+  final List<String?> tokens = [];
+  final Map<String, McpToolsChangedCallback> changedCallbacks = {};
+  final Completer<void> connectStarted = Completer<void>();
+  int connectCount = 0;
+  bool blockConnections = false;
+
+  @override
+  Future<McpProtocolSession> connect({
+    required McpServerConfig config,
+    required String? bearerToken,
+    required ToolCancellationToken cancellationToken,
+    required McpToolsChangedCallback onToolsChanged,
+    required McpProtocolErrorCallback onError,
+  }) async {
+    connectCount++;
+    tokens.add(bearerToken);
+    changedCallbacks[config.id] = onToolsChanged;
+    if (blockConnections) {
+      if (!connectStarted.isCompleted) connectStarted.complete();
+      final cancelled = Completer<void>();
+      cancellationToken.whenCancelled((_) {
+        if (!cancelled.isCompleted) cancelled.complete();
+      });
+      await cancelled.future;
+      throw const McpException('cancelled', 'Connection cancelled.');
+    }
+    if (sessions.isEmpty) {
+      throw StateError('No fake session queued.');
+    }
+    return sessions.removeAt(0);
+  }
+
+  Future<void> triggerToolsChanged(String serverId) async {
+    await changedCallbacks[serverId]!();
+  }
+}
+
+final class _FakeProtocolSession implements McpProtocolSession {
+  _FakeProtocolSession({
+    required this.tools,
+    this.blockCalls = false,
+  });
+
+  List<McpToolDescriptor> tools;
+  final bool blockCalls;
+  final Completer<void> callStarted = Completer<void>();
+  bool closed = false;
+  int callCount = 0;
+
+  @override
+  String get protocolVersion => '2026-07-28';
+
+  @override
+  String get serverImplementation => 'Fake MCP';
+
+  @override
+  String get serverVersion => '1.0.0';
+
+  @override
+  Future<List<McpToolDescriptor>> listTools({
+    required ToolCancellationToken cancellationToken,
+    required Duration timeout,
+  }) async {
+    cancellationToken.throwIfCancelled();
+    return List.unmodifiable(tools);
+  }
+
+  @override
+  Future<Map<String, dynamic>> callTool({
+    required String name,
+    required Map<String, dynamic> arguments,
+    required ToolCancellationToken cancellationToken,
+    required Duration timeout,
+  }) async {
+    callCount++;
+    if (blockCalls) {
+      if (!callStarted.isCompleted) callStarted.complete();
+      final cancelled = Completer<void>();
+      cancellationToken.whenCancelled((_) {
+        if (!cancelled.isCompleted) cancelled.complete();
+      });
+      await cancelled.future;
+      throw const McpException('cancelled', 'Tool call cancelled.');
+    }
+    return {
+      'content': [
+        {'type': 'text', 'text': 'ok'},
+      ],
+    };
+  }
+
+  @override
+  Future<void> close() async => closed = true;
+}

--- a/test/mcp_protocol_end_to_end_test.dart
+++ b/test/mcp_protocol_end_to_end_test.dart
@@ -1,0 +1,140 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mcp_dart/mcp_dart.dart' as sdk;
+import 'package:native_tavern/domain/models/built_in_tool.dart';
+import 'package:native_tavern/domain/models/mcp.dart';
+import 'package:native_tavern/domain/models/tool_calling.dart';
+import 'package:native_tavern/domain/services/mcp/mcp_protocol_client.dart';
+
+void main() {
+  test('real Streamable HTTP handshake, discovery, call, cancel, and reconnect',
+      () async {
+    const bearerToken = 'test-bearer-token';
+    final slowStarted = Completer<void>();
+    var authenticatedRequests = 0;
+    final server = sdk.StreamableMcpServer(
+      host: 'localhost',
+      port: 0,
+      authenticator: (request) {
+        final accepted =
+            request.headers.value(HttpHeaders.authorizationHeader) ==
+                'Bearer $bearerToken';
+        if (accepted) authenticatedRequests++;
+        return accepted;
+      },
+      serverFactory: (_) {
+        final mcp = sdk.McpServer(
+          const sdk.Implementation(
+            name: 'NativeTavern MCP Test',
+            version: '1.2.3',
+          ),
+          options: const sdk.McpServerOptions(protocol: sdk.McpProtocol.stable),
+        );
+        mcp.registerTool(
+          'echo',
+          title: 'Echo',
+          description: 'Returns the supplied text.',
+          inputSchema: sdk.JsonSchema.object(
+            properties: {'text': sdk.JsonSchema.string()},
+            required: ['text'],
+          ),
+          annotations: const sdk.ToolAnnotations(
+            readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
+          ),
+          callback: (arguments, _) async => sdk.CallToolResult.fromContent([
+            sdk.TextContent(text: arguments['text'] as String),
+          ]),
+        );
+        mcp.registerTool(
+          'slow',
+          description: 'Waits until the client cancels.',
+          callback: (_, extra) async {
+            if (!slowStarted.isCompleted) slowStarted.complete();
+            await extra.signal.onAbort.first
+                .timeout(const Duration(seconds: 5));
+            return const sdk.CallToolResult(content: []);
+          },
+        );
+        return mcp;
+      },
+    );
+    await server.start();
+    addTearDown(server.stop);
+    final config = McpServerConfig(
+      id: 'real',
+      name: 'Real test server',
+      endpoint: Uri.parse(
+        'http://localhost:${server.boundPort}${server.path}',
+      ),
+      enabled: true,
+      connectTimeout: const Duration(seconds: 5),
+      requestTimeout: const Duration(seconds: 5),
+    );
+    const factory = McpDartProtocolClientFactory();
+    final connectionCancellation = ToolCancellationController();
+    final errors = <Object>[];
+    var toolsChanged = 0;
+    final session = await factory.connect(
+      config: config,
+      bearerToken: bearerToken,
+      cancellationToken: connectionCancellation.token,
+      onToolsChanged: () => toolsChanged++,
+      onError: errors.add,
+    );
+    addTearDown(session.close);
+
+    final tools = await session.listTools(
+      cancellationToken: ToolCancellationController().token,
+      timeout: const Duration(seconds: 5),
+    );
+    expect(session.serverImplementation, 'NativeTavern MCP Test');
+    expect(session.serverVersion, '1.2.3');
+    expect(session.protocolVersion, isNotEmpty);
+    expect(tools.map((tool) => tool.name).toSet(), {'echo', 'slow'});
+    expect(
+      tools.singleWhere((tool) => tool.name == 'echo').accessLevel,
+      ToolAccessLevel.readOnly,
+    );
+
+    final output = await session.callTool(
+      name: 'echo',
+      arguments: const {'text': 'hello'},
+      cancellationToken: ToolCancellationController().token,
+      timeout: const Duration(seconds: 5),
+    );
+    expect(output['content'], isA<List<dynamic>>());
+    expect('$output', contains('hello'));
+
+    final callCancellation = ToolCancellationController();
+    final slowCall = session.callTool(
+      name: 'slow',
+      arguments: const {},
+      cancellationToken: callCancellation.token,
+      timeout: const Duration(seconds: 5),
+    );
+    await slowStarted.future.timeout(const Duration(seconds: 5));
+    callCancellation.cancel('test cancellation');
+    await expectLater(slowCall, throwsA(anything));
+
+    await session.close();
+    final reconnected = await factory.connect(
+      config: config,
+      bearerToken: bearerToken,
+      cancellationToken: ToolCancellationController().token,
+      onToolsChanged: () => toolsChanged++,
+      onError: errors.add,
+    );
+    final reconnectedTools = await reconnected.listTools(
+      cancellationToken: ToolCancellationController().token,
+      timeout: const Duration(seconds: 5),
+    );
+    expect(reconnectedTools, hasLength(2));
+    expect(authenticatedRequests, greaterThan(3));
+    expect(errors, isEmpty);
+    await reconnected.close();
+  }, timeout: const Timeout(Duration(seconds: 30)));
+}

--- a/test/mcp_settings_screen_test.dart
+++ b/test/mcp_settings_screen_test.dart
@@ -1,0 +1,239 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:native_tavern/domain/models/built_in_tool.dart';
+import 'package:native_tavern/domain/models/mcp.dart';
+import 'package:native_tavern/domain/models/tool_calling.dart';
+import 'package:native_tavern/domain/repositories/mcp_repository.dart';
+import 'package:native_tavern/domain/services/mcp/mcp_client_manager.dart';
+import 'package:native_tavern/domain/services/mcp/mcp_protocol_client.dart';
+import 'package:native_tavern/domain/services/tool_calling/tool_execution_audit_service.dart';
+import 'package:native_tavern/presentation/providers/mcp_providers.dart';
+import 'package:native_tavern/presentation/screens/settings/mcp_settings_screen.dart';
+
+void main() {
+  testWidgets('manages a server, connection, permissions, and activity',
+      (tester) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    final credentials = MemoryMcpCredentialRepository();
+    final factory = _WidgetProtocolFactory();
+    final manager = McpClientManager(
+      settingsRepository: MemoryMcpSettingsRepository(),
+      credentialRepository: credentials,
+      activityRepository: MemoryMcpActivityRepository(),
+      toolAuditRepository: MemoryToolExecutionAuditRepository(),
+      protocolClientFactory: factory,
+    );
+    addTearDown(manager.close);
+
+    await tester.pumpWidget(ProviderScope(
+      overrides: [mcpClientManagerProvider.overrideWithValue(manager)],
+      child: const MaterialApp(home: McpSettingsScreen()),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(factory.connectCount, 0);
+    expect(find.text('No MCP servers'), findsOneWidget);
+    expect(tester.takeException(), isNull, reason: 'initial layout');
+    await tester.tap(find.byKey(const Key('mcp-master-toggle')));
+    await tester.pumpAndSettle();
+    expect(manager.enabled, isTrue);
+    expect(tester.takeException(), isNull, reason: 'master toggle');
+
+    await tester.tap(find.byKey(const Key('mcp-add-server')));
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull, reason: 'editor dialog');
+    await tester.enterText(
+      find.byKey(const Key('mcp-server-name')),
+      'Test MCP',
+    );
+    await tester.enterText(
+      find.byKey(const Key('mcp-server-endpoint')),
+      'http://localhost:7777/mcp',
+    );
+    await tester.enterText(
+      find.byKey(const Key('mcp-server-token')),
+      'widget-secret',
+    );
+    await tester.tap(find.byKey(const Key('mcp-server-enabled')));
+    expect(tester.takeException(), isNull, reason: 'editor values');
+    await tester.tap(find.byKey(const Key('mcp-save-server')));
+    await tester.pumpAndSettle();
+
+    final serverId = manager.servers.single.id;
+    expect(find.text('Test MCP'), findsOneWidget);
+    expect(await credentials.readToken(serverId), 'widget-secret');
+    expect(find.text('widget-secret'), findsNothing);
+    expect(tester.takeException(), isNull, reason: 'server list');
+    await tester.tap(find.text('Test MCP'));
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull, reason: 'expanded server');
+
+    await tester.tap(find.byKey(Key('mcp-connect-$serverId')));
+    await tester.pumpAndSettle();
+
+    expect(factory.connectCount, 1);
+    expect(factory.lastToken, 'widget-secret');
+    expect(find.textContaining('Connected'), findsWidgets);
+    expect(find.text('Echo'), findsOneWidget);
+    expect(tester.takeException(), isNull, reason: 'connected tools');
+    final permissionButton = find.byKey(Key('mcp-permission-$serverId-echo'));
+    await tester.tap(permissionButton);
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull, reason: 'permission menu');
+    await tester.tap(find.text('Always allow').last);
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull, reason: 'always permission');
+    expect(
+      manager.permissionFor(serverId, 'echo'),
+      McpToolPermission.alwaysAllow,
+    );
+
+    await tester.tap(permissionButton);
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull, reason: 'permission menu second');
+    await tester.tap(find.text('Denied').last);
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull, reason: 'denied permission');
+    expect(
+      manager.permissionFor(serverId, 'echo'),
+      McpToolPermission.denied,
+    );
+
+    await tester.tap(find.text('Activity'));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const Key('mcp-activity-list')), findsOneWidget);
+    expect(find.textContaining('Connected and discovered'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('shows and cancels an in-flight connection', (tester) async {
+    final settings = MemoryMcpSettingsRepository(McpStoredSettings(
+      enabled: true,
+      servers: [_config('blocked')],
+    ));
+    final factory = _WidgetProtocolFactory(blockConnection: true);
+    final manager = McpClientManager(
+      settingsRepository: settings,
+      credentialRepository: MemoryMcpCredentialRepository(),
+      activityRepository: MemoryMcpActivityRepository(),
+      toolAuditRepository: MemoryToolExecutionAuditRepository(),
+      protocolClientFactory: factory,
+    );
+    addTearDown(manager.close);
+    await tester.pumpWidget(ProviderScope(
+      overrides: [mcpClientManagerProvider.overrideWithValue(manager)],
+      child: const MaterialApp(home: McpSettingsScreen()),
+    ));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Server blocked'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('mcp-connect-blocked')));
+    await factory.started.future;
+    await tester.pump();
+    expect(find.byKey(const Key('mcp-cancel-blocked')), findsOneWidget);
+    await tester.tap(find.byKey(const Key('mcp-cancel-blocked')));
+    await tester.pumpAndSettle();
+
+    expect(
+      manager.snapshot('blocked').status,
+      McpConnectionStatus.disconnected,
+    );
+    expect(tester.takeException(), isNull);
+  });
+}
+
+McpServerConfig _config(String id) => McpServerConfig(
+      id: id,
+      name: 'Server $id',
+      endpoint: Uri.parse('http://localhost:7777/mcp'),
+      enabled: true,
+    );
+
+final class _WidgetProtocolFactory implements McpProtocolClientFactory {
+  _WidgetProtocolFactory({this.blockConnection = false});
+
+  final bool blockConnection;
+  final Completer<void> started = Completer<void>();
+  int connectCount = 0;
+  String? lastToken;
+
+  @override
+  Future<McpProtocolSession> connect({
+    required McpServerConfig config,
+    required String? bearerToken,
+    required ToolCancellationToken cancellationToken,
+    required McpToolsChangedCallback onToolsChanged,
+    required McpProtocolErrorCallback onError,
+  }) async {
+    connectCount++;
+    lastToken = bearerToken;
+    if (blockConnection) {
+      if (!started.isCompleted) started.complete();
+      final cancelled = Completer<void>();
+      cancellationToken.whenCancelled((_) {
+        if (!cancelled.isCompleted) cancelled.complete();
+      });
+      await cancelled.future;
+      throw const McpException('cancelled', 'Connection cancelled.');
+    }
+    return _WidgetProtocolSession(config.id);
+  }
+}
+
+final class _WidgetProtocolSession implements McpProtocolSession {
+  _WidgetProtocolSession(this.serverId);
+
+  final String serverId;
+
+  @override
+  String get protocolVersion => '2026-07-28';
+
+  @override
+  String get serverImplementation => 'Widget MCP';
+
+  @override
+  String get serverVersion => '1.0.0';
+
+  @override
+  Future<List<McpToolDescriptor>> listTools({
+    required ToolCancellationToken cancellationToken,
+    required Duration timeout,
+  }) async {
+    return [
+      McpToolDescriptor(
+        serverId: serverId,
+        name: 'echo',
+        title: 'Echo',
+        description: 'Echo test tool',
+        inputSchema: const {'type': 'object'},
+        accessLevel: ToolAccessLevel.readOnly,
+        destructiveHint: false,
+        openWorldHint: false,
+      ),
+    ];
+  }
+
+  @override
+  Future<Map<String, dynamic>> callTool({
+    required String name,
+    required Map<String, dynamic> arguments,
+    required ToolCancellationToken cancellationToken,
+    required Duration timeout,
+  }) async {
+    return const {
+      'content': [
+        {'type': 'text', 'text': 'ok'},
+      ],
+    };
+  }
+
+  @override
+  Future<void> close() async {}
+}


### PR DESCRIPTION
## Summary

- add opt-in MCP configuration, secure bearer-token storage, Streamable HTTP and explicit legacy SSE transports
- implement authenticated initialization, paginated discovery, refresh, timeout, cancellation, reconnect, shutdown, collision-safe tool names, permissions, and redacted audit activity
- add responsive MCP settings UI for server lifecycle, connection state, discovered tools, permission revocation, errors, and activity

## Roadmap completion

- G07 MCP client and discovery: complete. Production transport and protocol paths cover server identity, initialization, discovery, timeout, cancellation, reconnection, tools/list changes, and shutdown.
- G08 MCP management UI: complete. Users explicitly enable MCP, add and enable servers, connect, inspect tools and risk levels, choose ask/always/denied permissions, revoke access, remove servers, and inspect recent activity.

## Safety boundaries

- MCP and every server default to disabled; loading saved configuration never initiates a background connection.
- Non-loopback HTTP requires explicit approval. URL credentials, fragments, and sensitive query keys are rejected.
- Bearer tokens use platform secure storage and are excluded from configuration and diagnostic logs.
- Tool annotations only inform displayed risk. Unknown and side-effectful tools remain confirmation-gated by default.

## Verification

- `flutter test` (332 passed, 2 skipped)
- `flutter test test/mcp_client_manager_test.dart test/mcp_protocol_end_to_end_test.dart test/mcp_settings_screen_test.dart` (12 passed)
- targeted `flutter analyze` over all changed Dart files (no issues)
- full `flutter analyze` remains blocked by 1,110 pre-existing repository diagnostics; no diagnostics are in this change

Closes #34