### PR TITLE
feat(memory): add contextual retrieval and explanations

### DIFF
--- a/lib/domain/services/chat_generation_pipeline.dart
+++ b/lib/domain/services/chat_generation_pipeline.dart
@@ -35,6 +35,8 @@ enum ContextContributionStatus {
   skippedNoBudget,
 }
 
+enum ContextContributionItemStatus { included, truncated, dropped }
+
 enum GenerationMiddlewarePhase {
   before,
   transform,
@@ -82,10 +84,13 @@ class ChatContextRequest {
     required this.inputTokenBudget,
     required this.availableContributionTokens,
     required this.cancellationToken,
+    int? conversationStartIndex,
     this.characterId,
     this.groupId,
     Map<String, Object?> metadata = const {},
-  })  : baseMessages = _immutableMessages(baseMessages),
+  })  : conversationStartIndex = conversationStartIndex ??
+            _defaultConversationStartIndex(baseMessages),
+        baseMessages = _immutableMessages(baseMessages),
         metadata = Map<String, Object?>.unmodifiable(metadata);
 
   final String sessionId;
@@ -96,6 +101,7 @@ class ChatContextRequest {
   final List<ChatMessageMap> baseMessages;
   final int inputTokenBudget;
   final int availableContributionTokens;
+  final int conversationStartIndex;
   final ChatCancellationToken cancellationToken;
   final Map<String, Object?> metadata;
 
@@ -113,6 +119,7 @@ class ChatContextRequest {
       inputTokenBudget: inputTokenBudget,
       availableContributionTokens:
           availableContributionTokens ?? this.availableContributionTokens,
+      conversationStartIndex: conversationStartIndex,
       cancellationToken: cancellationToken,
       metadata: metadata,
     );
@@ -123,10 +130,20 @@ class ContextContribution {
   ContextContribution({
     required List<ChatMessageMap> messages,
     this.placement = ContextContributionPlacement.beforeConversation,
-  }) : messages = _immutableMessages(messages);
+    List<String> itemIds = const [],
+    Map<String, Object?> metadata = const {},
+  })  : assert(
+          itemIds.isEmpty || itemIds.length == messages.length,
+          'itemIds must be empty or align one-to-one with messages.',
+        ),
+        messages = _immutableMessages(messages),
+        itemIds = List<String>.unmodifiable(itemIds),
+        metadata = _immutableMetadata(metadata);
 
   final List<ChatMessageMap> messages;
   final ContextContributionPlacement placement;
+  final List<String> itemIds;
+  final Map<String, Object?> metadata;
 }
 
 abstract class ContextContributor {
@@ -139,6 +156,20 @@ abstract class ContextContributor {
   Future<ContextContribution> contribute(ChatContextRequest request);
 
   FutureOr<void> onCancelled(ChatContextRequest request) {}
+}
+
+class ContextContributionItemTrace {
+  const ContextContributionItemTrace({
+    required this.itemId,
+    required this.status,
+    required this.originalTokens,
+    required this.usedTokens,
+  });
+
+  final String itemId;
+  final ContextContributionItemStatus status;
+  final int originalTokens;
+  final int usedTokens;
 }
 
 class ContextContributionTrace {
@@ -154,9 +185,14 @@ class ContextContributionTrace {
     required this.droppedMessageCount,
     required this.elapsed,
     required List<ChatMessageMap> injectedMessages,
+    List<ContextContributionItemTrace> itemTraces = const [],
+    Map<String, Object?> metadata = const {},
     this.placement,
     this.error,
-  }) : injectedMessages = _immutableMessages(injectedMessages);
+  })  : injectedMessages = _immutableMessages(injectedMessages),
+        itemTraces =
+            List<ContextContributionItemTrace>.unmodifiable(itemTraces),
+        metadata = _immutableMetadata(metadata);
 
   final String contributorId;
   final int order;
@@ -170,12 +206,16 @@ class ContextContributionTrace {
   final int droppedMessageCount;
   final Duration elapsed;
   final List<ChatMessageMap> injectedMessages;
+  final List<ContextContributionItemTrace> itemTraces;
+  final Map<String, Object?> metadata;
   final String? error;
 }
 
 class ContextAssemblyResult {
   ContextAssemblyResult({
     required this.sessionId,
+    required this.chatId,
+    required this.mode,
     required List<ChatMessageMap> baseMessages,
     required List<ChatMessageMap> messages,
     required this.inputTokenBudget,
@@ -185,11 +225,17 @@ class ContextAssemblyResult {
     required this.startedAt,
     required this.completedAt,
     required this.cancelled,
+    this.characterId,
+    this.groupId,
   })  : baseMessages = _immutableMessages(baseMessages),
         messages = _immutableMessages(messages),
         traces = List<ContextContributionTrace>.unmodifiable(traces);
 
   final String sessionId;
+  final String chatId;
+  final String? characterId;
+  final String? groupId;
+  final ChatGenerationMode mode;
   final List<ChatMessageMap> baseMessages;
   final List<ChatMessageMap> messages;
   final int inputTokenBudget;
@@ -528,11 +574,30 @@ class ChatGenerationPipeline {
   _FittedContribution _fitContribution(
     List<ChatMessageMap> messages,
     int tokenBudget,
+    List<String> itemIds,
   ) {
     final fitted = <ChatMessageMap>[];
+    final itemTraces = <ContextContributionItemTrace>[];
     var remaining = max(0, tokenBudget);
     var truncated = 0;
     var dropped = 0;
+
+    void recordItem(
+      int index,
+      ContextContributionItemStatus status,
+      int originalTokens,
+      int usedTokens,
+    ) {
+      if (itemIds.isEmpty) return;
+      itemTraces.add(
+        ContextContributionItemTrace(
+          itemId: itemIds[index],
+          status: status,
+          originalTokens: originalTokens,
+          usedTokens: usedTokens,
+        ),
+      );
+    }
 
     for (var index = 0; index < messages.length; index++) {
       final message = Map<String, dynamic>.from(messages[index]);
@@ -540,6 +605,12 @@ class ChatGenerationPipeline {
       if (tokens <= remaining) {
         fitted.add(message);
         remaining -= tokens;
+        recordItem(
+          index,
+          ContextContributionItemStatus.included,
+          tokens,
+          tokens,
+        );
         continue;
       }
 
@@ -563,14 +634,33 @@ class ChatGenerationPipeline {
               '${content.substring(0, candidateLength)}$marker';
         }
         if (_estimateMessage(message) <= remaining) {
+          final usedTokens = _estimateMessage(message);
           fitted.add(message);
-          remaining -= _estimateMessage(message);
+          remaining -= usedTokens;
           truncated++;
+          recordItem(
+            index,
+            ContextContributionItemStatus.truncated,
+            tokens,
+            usedTokens,
+          );
         } else {
           dropped++;
+          recordItem(index, ContextContributionItemStatus.dropped, tokens, 0);
         }
       } else {
         dropped++;
+        recordItem(index, ContextContributionItemStatus.dropped, tokens, 0);
+      }
+      for (var droppedIndex = index + 1;
+          droppedIndex < messages.length;
+          droppedIndex++) {
+        recordItem(
+          droppedIndex,
+          ContextContributionItemStatus.dropped,
+          _estimateMessage(messages[droppedIndex]),
+          0,
+        );
       }
       dropped += messages.length - index - 1;
       break;
@@ -581,6 +671,7 @@ class ChatGenerationPipeline {
       tokens: tokenBudget - remaining,
       truncatedMessages: truncated,
       droppedMessages: dropped,
+      itemTraces: itemTraces,
     );
   }
 }
@@ -614,11 +705,15 @@ class ChatGenerationSession {
   bool _cancellationNotified = false;
 
   Future<ContextAssemblyResult> assemble(
-    List<ChatMessageMap> baseMessages,
-  ) async {
+    List<ChatMessageMap> baseMessages, {
+    int? conversationStartIndex,
+  }) async {
     final startedAt = DateTime.now();
     final inputBudget = _pipeline._inputBudget(config);
     final immutableBase = _immutableMessages(baseMessages);
+    final resolvedConversationStartIndex = conversationStartIndex == null
+        ? immutableBase.indexWhere((message) => message['role'] != 'system')
+        : conversationStartIndex.clamp(0, immutableBase.length).toInt();
     final baseTokens = _pipeline._estimateMessages(immutableBase);
     var remaining = max(0, inputBudget - baseTokens);
     final traces = <ContextContributionTrace>[];
@@ -635,6 +730,9 @@ class ChatGenerationSession {
       baseMessages: immutableBase,
       inputTokenBudget: inputBudget,
       availableContributionTokens: remaining,
+      conversationStartIndex: resolvedConversationStartIndex < 0
+          ? immutableBase.length
+          : resolvedConversationStartIndex,
       cancellationToken: cancellationToken,
       metadata: metadata,
     );
@@ -697,8 +795,11 @@ class ChatGenerationSession {
 
         final originalTokens =
             _pipeline._estimateMessages(contribution.messages);
-        final fitted =
-            _pipeline._fitContribution(contribution.messages, allocation);
+        final fitted = _pipeline._fitContribution(
+          contribution.messages,
+          allocation,
+          contribution.itemIds,
+        );
         remaining -= fitted.tokens;
         switch (contribution.placement) {
           case ContextContributionPlacement.beforeBase:
@@ -721,6 +822,8 @@ class ChatGenerationSession {
           droppedMessageCount: fitted.droppedMessages,
           elapsed: stopwatch.elapsed,
           injectedMessages: fitted.messages,
+          itemTraces: fitted.itemTraces,
+          metadata: contribution.metadata,
         ));
       } catch (error) {
         traces.add(_emptyContributionTrace(
@@ -739,20 +842,18 @@ class ChatGenerationSession {
       ...beforeBase,
       ...immutableBase.map(_copyMessage),
     ];
-    final baseConversationIndex = immutableBase.indexWhere(
-      (message) => message['role'] != 'system',
-    );
     assembled.insertAll(
-      beforeBase.length +
-          (baseConversationIndex < 0
-              ? immutableBase.length
-              : baseConversationIndex),
+      beforeBase.length + request.conversationStartIndex,
       beforeConversation,
     );
     assembled.addAll(afterBase);
 
     final result = ContextAssemblyResult(
       sessionId: sessionId,
+      chatId: chatId,
+      characterId: characterId,
+      groupId: groupId,
+      mode: mode,
       baseMessages: immutableBase,
       messages: assembled,
       inputTokenBudget: inputBudget,
@@ -1210,12 +1311,14 @@ class _FittedContribution {
     required this.tokens,
     required this.truncatedMessages,
     required this.droppedMessages,
+    required this.itemTraces,
   });
 
   final List<ChatMessageMap> messages;
   final int tokens;
   final int truncatedMessages;
   final int droppedMessages;
+  final List<ContextContributionItemTrace> itemTraces;
 }
 
 class _ActiveMiddlewares {
@@ -1227,6 +1330,16 @@ class _ActiveMiddlewares {
 
 List<ChatMessageMap> _immutableMessages(Iterable<ChatMessageMap> messages) =>
     List<ChatMessageMap>.unmodifiable(messages.map(_copyMessage));
+
+int _defaultConversationStartIndex(List<ChatMessageMap> messages) {
+  final index = messages.indexWhere((message) => message['role'] != 'system');
+  return index < 0 ? messages.length : index;
+}
+
+Map<String, Object?> _immutableMetadata(Map<String, Object?> metadata) =>
+    Map<String, Object?>.unmodifiable(
+      metadata.map((key, value) => MapEntry(key, _copyValue(value))),
+    );
 
 ChatMessageMap _copyMessage(ChatMessageMap message) =>
     Map<String, dynamic>.unmodifiable(

--- a/lib/domain/services/long_term_memory_context_service.dart
+++ b/lib/domain/services/long_term_memory_context_service.dart
@@ -1,0 +1,343 @@
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:native_tavern/data/models/long_term_memory.dart';
+import 'package:native_tavern/domain/repositories/long_term_memory_repository.dart';
+import 'package:native_tavern/domain/services/chat_generation_pipeline.dart';
+
+typedef MemorySemanticScorer = Future<Map<String, double>> Function(
+  String query,
+  List<LongTermMemory> candidates,
+);
+
+typedef MemoryScopeResolver = Future<List<MemoryScope>> Function(
+    ChatContextRequest request);
+
+enum MemoryRetrievalMode { fts, hybrid, ftsFallback }
+
+enum MemorySemanticFallbackReason { timeout, unavailable, invalidResponse }
+
+final class MemoryContextMatch {
+  const MemoryContextMatch({
+    required this.memory,
+    required this.score,
+    this.ftsScore,
+    this.semanticScore,
+  });
+
+  final LongTermMemory memory;
+  final double score;
+  final double? ftsScore;
+  final double? semanticScore;
+}
+
+final class MemoryContextSelection {
+  const MemoryContextSelection({
+    required this.matches,
+    required this.mode,
+    required this.scopes,
+    required this.elapsed,
+    this.fallbackReason,
+  });
+
+  final List<MemoryContextMatch> matches;
+  final MemoryRetrievalMode mode;
+  final List<MemoryScope> scopes;
+  final Duration elapsed;
+  final MemorySemanticFallbackReason? fallbackReason;
+}
+
+/// Selects active, non-expired memories using local FTS and optional semantic
+/// reranking. Semantic failures never discard local matches.
+final class LongTermMemoryContextService {
+  LongTermMemoryContextService({
+    required LongTermMemoryRepository repository,
+    this.semanticTimeout = const Duration(seconds: 2),
+  }) : _repository = repository;
+
+  final LongTermMemoryRepository _repository;
+  final Duration semanticTimeout;
+
+  Future<MemoryContextSelection> select({
+    required String query,
+    required List<MemoryScope> scopes,
+    int topK = 8,
+    int semanticCandidateLimit = 100,
+    double semanticThreshold = 0.7,
+    MemorySemanticScorer? semanticScorer,
+  }) async {
+    if (topK <= 0) throw RangeError.range(topK, 1, null, 'topK');
+    if (semanticCandidateLimit <= 0) {
+      throw RangeError.range(
+        semanticCandidateLimit,
+        1,
+        null,
+        'semanticCandidateLimit',
+      );
+    }
+    final normalizedQuery = query.trim();
+    final distinctScopes = scopes.toSet().toList(growable: false);
+    final stopwatch = Stopwatch()..start();
+    if (normalizedQuery.isEmpty || distinctScopes.isEmpty) {
+      return MemoryContextSelection(
+        matches: const [],
+        mode: MemoryRetrievalMode.fts,
+        scopes: distinctScopes,
+        elapsed: stopwatch.elapsed,
+      );
+    }
+
+    final memories = <String, LongTermMemory>{};
+    final ftsScores = <String, double>{};
+    final perScopeLimit = math.max(20, topK * 3);
+    final ftsResults = await Future.wait([
+      for (final scope in distinctScopes)
+        _repository.search(normalizedQuery, scope: scope, topK: perScopeLimit),
+    ]);
+    for (var scopeIndex = 0; scopeIndex < ftsResults.length; scopeIndex++) {
+      final scopeBoost = math.max(0.85, 1 - (scopeIndex * 0.03));
+      final results = ftsResults[scopeIndex];
+      for (var resultIndex = 0; resultIndex < results.length; resultIndex++) {
+        final result = results[resultIndex];
+        memories[result.memory.id] = result.memory;
+        final reciprocalRank = scopeBoost / (resultIndex + 1);
+        final previous = ftsScores[result.memory.id];
+        if (previous == null || reciprocalRank > previous) {
+          ftsScores[result.memory.id] = reciprocalRank;
+        }
+      }
+    }
+
+    var mode = MemoryRetrievalMode.fts;
+    MemorySemanticFallbackReason? fallbackReason;
+    final semanticScores = <String, double>{};
+    if (semanticScorer != null) {
+      try {
+        final semanticPool = <String, LongTermMemory>{};
+        final scopedMemories = await Future.wait([
+          for (final scope in distinctScopes)
+            _repository.findByScope(scope, states: const {MemoryState.active}),
+        ]);
+        for (final results in scopedMemories) {
+          for (final memory in results) {
+            semanticPool[memory.id] = memory;
+          }
+        }
+        final candidates = semanticPool.values.toList()
+          ..sort(_compareSemanticCandidates);
+        final limitedCandidates =
+            candidates.take(semanticCandidateLimit).toList(growable: false);
+        final rawScores = limitedCandidates.isEmpty
+            ? const <String, double>{}
+            : await semanticScorer(
+                normalizedQuery,
+                limitedCandidates,
+              ).timeout(semanticTimeout);
+        final hasValidShape = rawScores.length == limitedCandidates.length &&
+            limitedCandidates.every(
+              (candidate) => rawScores[candidate.id]?.isFinite ?? false,
+            );
+        if (!hasValidShape) {
+          mode = MemoryRetrievalMode.ftsFallback;
+          fallbackReason = MemorySemanticFallbackReason.invalidResponse;
+        } else {
+          mode = MemoryRetrievalMode.hybrid;
+          for (final candidate in limitedCandidates) {
+            final score = rawScores[candidate.id]!.clamp(-1.0, 1.0).toDouble();
+            if (score < semanticThreshold) continue;
+            semanticScores[candidate.id] = score;
+            memories[candidate.id] = candidate;
+          }
+        }
+      } on TimeoutException {
+        mode = MemoryRetrievalMode.ftsFallback;
+        fallbackReason = MemorySemanticFallbackReason.timeout;
+      } catch (_) {
+        mode = MemoryRetrievalMode.ftsFallback;
+        fallbackReason = MemorySemanticFallbackReason.unavailable;
+      }
+    }
+
+    final matches = <MemoryContextMatch>[];
+    for (final memory in memories.values) {
+      final fts = ftsScores[memory.id];
+      final semantic = semanticScores[memory.id];
+      if (fts == null && semantic == null) continue;
+      final score = _combinedScore(
+        ftsScore: fts,
+        semanticScore: semantic,
+        importance: memory.importance,
+        semanticAvailable: mode == MemoryRetrievalMode.hybrid,
+      );
+      matches.add(
+        MemoryContextMatch(
+          memory: memory,
+          score: score,
+          ftsScore: fts,
+          semanticScore: semantic,
+        ),
+      );
+    }
+    matches.sort(_compareMatches);
+
+    return MemoryContextSelection(
+      matches: matches.take(topK).toList(growable: false),
+      mode: mode,
+      scopes: distinctScopes,
+      elapsed: stopwatch.elapsed,
+      fallbackReason: fallbackReason,
+    );
+  }
+
+  static double _combinedScore({
+    required double? ftsScore,
+    required double? semanticScore,
+    required double importance,
+    required bool semanticAvailable,
+  }) {
+    if (!semanticAvailable || semanticScore == null) {
+      return ((ftsScore ?? 0) * 0.85 + importance * 0.15)
+          .clamp(0.0, 1.0)
+          .toDouble();
+    }
+    if (ftsScore == null) {
+      return (semanticScore * 0.8 + importance * 0.2)
+          .clamp(0.0, 1.0)
+          .toDouble();
+    }
+    return (semanticScore * 0.55 + ftsScore * 0.35 + importance * 0.1)
+        .clamp(0.0, 1.0)
+        .toDouble();
+  }
+
+  static int _compareSemanticCandidates(
+    LongTermMemory left,
+    LongTermMemory right,
+  ) {
+    final byImportance = right.importance.compareTo(left.importance);
+    if (byImportance != 0) return byImportance;
+    final byUpdatedAt = right.updatedAt.compareTo(left.updatedAt);
+    if (byUpdatedAt != 0) return byUpdatedAt;
+    return left.id.compareTo(right.id);
+  }
+
+  static int _compareMatches(
+    MemoryContextMatch left,
+    MemoryContextMatch right,
+  ) {
+    final byScore = right.score.compareTo(left.score);
+    if (byScore != 0) return byScore;
+    final byImportance = right.memory.importance.compareTo(
+      left.memory.importance,
+    );
+    if (byImportance != 0) return byImportance;
+    final byUpdatedAt = right.memory.updatedAt.compareTo(left.memory.updatedAt);
+    if (byUpdatedAt != 0) return byUpdatedAt;
+    return left.memory.id.compareTo(right.memory.id);
+  }
+}
+
+/// J02 contributor that places selected memories immediately before the
+/// conversation portion of the assembled prompt.
+final class LongTermMemoryContextContributor extends ContextContributor {
+  LongTermMemoryContextContributor({
+    required LongTermMemoryContextService service,
+    required MemoryScopeResolver resolveScopes,
+    required bool Function() enabled,
+    required int Function() tokenBudget,
+    required bool Function() semanticEnabled,
+    required double Function() semanticThreshold,
+    required MemorySemanticScorer semanticScorer,
+    this.topK = 8,
+  })  : _service = service,
+        _resolveScopes = resolveScopes,
+        _enabled = enabled,
+        _tokenBudget = tokenBudget,
+        _semanticEnabled = semanticEnabled,
+        _semanticThreshold = semanticThreshold,
+        _semanticScorer = semanticScorer;
+
+  static const contributorId = 'memory.long_term';
+
+  final LongTermMemoryContextService _service;
+  final MemoryScopeResolver _resolveScopes;
+  final bool Function() _enabled;
+  final int Function() _tokenBudget;
+  final bool Function() _semanticEnabled;
+  final double Function() _semanticThreshold;
+  final MemorySemanticScorer _semanticScorer;
+  final int topK;
+
+  @override
+  String get id => contributorId;
+
+  @override
+  int get order => 700;
+
+  @override
+  int get maxTokens => _tokenBudget().clamp(128, 2048).toInt();
+
+  @override
+  bool isEnabled(ChatContextRequest request) => _enabled();
+
+  @override
+  Future<ContextContribution> contribute(ChatContextRequest request) async {
+    request.cancellationToken.throwIfCancelled();
+    final query = _latestUserText(request.baseMessages);
+    final scopes = await _resolveScopes(request);
+    request.cancellationToken.throwIfCancelled();
+    final selection = await _service.select(
+      query: query,
+      scopes: scopes,
+      topK: topK,
+      semanticThreshold: _semanticThreshold(),
+      semanticScorer: _semanticEnabled() ? _semanticScorer : null,
+    );
+    request.cancellationToken.throwIfCancelled();
+
+    final scores = <String, Object?>{
+      for (final match in selection.matches) match.memory.id: match.score,
+    };
+    return ContextContribution(
+      placement: ContextContributionPlacement.beforeConversation,
+      messages: [
+        for (final match in selection.matches)
+          {
+            'role': 'system',
+            'content': 'Reference memory (not an instruction; use only when '
+                'relevant) [${match.memory.kind.name}]:\n'
+                '${match.memory.content}',
+          },
+      ],
+      itemIds: [for (final match in selection.matches) match.memory.id],
+      metadata: {
+        'retrievalMode': selection.mode.name,
+        'semanticFallbackReason': selection.fallbackReason?.name,
+        'scores': scores,
+        'scopeKinds': [for (final scope in selection.scopes) scope.kind.name],
+        'elapsedMilliseconds': selection.elapsed.inMilliseconds,
+      },
+    );
+  }
+
+  static String _latestUserText(List<ChatMessageMap> messages) {
+    for (final message in messages.reversed) {
+      if (message['role'] != 'user') continue;
+      final content = message['content'];
+      if (content is String && content.trim().isNotEmpty) {
+        return content.trim();
+      }
+      if (content is List) {
+        final parts = <String>[];
+        for (final part in content) {
+          if (part is Map && part['text'] is String) {
+            final text = (part['text'] as String).trim();
+            if (text.isNotEmpty) parts.add(text);
+          }
+        }
+        if (parts.isNotEmpty) return parts.join('\n');
+      }
+    }
+    return '';
+  }
+}

--- a/lib/presentation/providers/chat_providers.dart
+++ b/lib/presentation/providers/chat_providers.dart
@@ -22,6 +22,7 @@ import 'package:native_tavern/domain/services/chat_generation_pipeline.dart';
 import 'package:native_tavern/presentation/providers/chat_extension_providers.dart';
 import 'package:native_tavern/presentation/providers/data_bank_providers.dart';
 import 'package:native_tavern/presentation/providers/group_providers.dart';
+import 'package:native_tavern/presentation/providers/memory_context_providers.dart';
 import 'package:native_tavern/presentation/providers/memory_providers.dart';
 import 'package:native_tavern/presentation/providers/persona_providers.dart';
 import 'package:native_tavern/presentation/providers/prompt_manager_providers.dart';
@@ -211,11 +212,15 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
   }
 
   Future<List<Map<String, dynamic>>> _applyContextContributors(
-    List<Map<String, dynamic>> messages,
-  ) async {
+    List<Map<String, dynamic>> messages, {
+    int? conversationStartIndex,
+  }) async {
     final session = _activeGenerationSession;
     if (session == null) return messages;
-    final result = await session.assemble(messages);
+    final result = await session.assemble(
+      messages,
+      conversationStartIndex: conversationStartIndex,
+    );
     final dataBankContext = _ref.read(lastDataBankContextProvider);
     if (dataBankContext?.sessionId == session.sessionId) {
       _pendingDataBankContext = dataBankContext!.sources.isEmpty
@@ -1591,6 +1596,7 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
         messages.add({'role': 'system', 'content': ragContext});
       }
     }
+    final conversationStartIndex = messages.length;
 
     // Prepare character depth prompt (ST extensions.depth_prompt)
     final depthPrompt = character?.depthPrompt;
@@ -1750,7 +1756,10 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
     }
     print('=== End Context Messages ===');
 
-    return _applyContextContributors(messages);
+    return _applyContextContributors(
+      messages,
+      conversationStartIndex: conversationStartIndex,
+    );
   }
 
   /// Build messages for a single prompt section
@@ -2195,6 +2204,7 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
         messages.add({'role': 'system', 'content': ragContext});
       }
     }
+    final conversationStartIndex = messages.length;
 
     // Prepare character depth prompt (ST extensions.depth_prompt)
     final depthPrompt = character?.depthPrompt;
@@ -2291,7 +2301,10 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
       messages.addAll(sectionMessages);
     }
 
-    return _applyContextContributors(messages);
+    return _applyContextContributors(
+      messages,
+      conversationStartIndex: conversationStartIndex,
+    );
   }
 
   /// Find matching World Info entries based on chat context
@@ -3042,6 +3055,7 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
     // Build system prompt for group chat
     final systemPrompt = await _buildGroupSystemPrompt(respondingCharacter);
     messages.add({'role': 'system', 'content': systemPrompt});
+    final conversationStartIndex = messages.length;
 
     // Add chat messages
     for (final msg in state.messages) {
@@ -3057,7 +3071,10 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
       }
     }
 
-    return _applyContextContributors(messages);
+    return _applyContextContributors(
+      messages,
+      conversationStartIndex: conversationStartIndex,
+    );
   }
 
   /// Build system prompt for group chat
@@ -3193,6 +3210,7 @@ class ActiveChatNotifier extends StateNotifier<ActiveChatState> {
 final activeChatProvider =
     StateNotifierProvider<ActiveChatNotifier, ActiveChatState>((ref) {
       ref.watch(dataBankContextRegistrationProvider);
+      ref.watch(longTermMemoryContextRegistrationProvider);
       final chatRepo = ref.watch(chatRepositoryProvider);
       final characterRepo = ref.watch(characterRepositoryProvider);
       final personaRepo = ref.watch(personaRepositoryProvider);

--- a/lib/presentation/providers/memory_context_providers.dart
+++ b/lib/presentation/providers/memory_context_providers.dart
@@ -1,0 +1,260 @@
+import 'dart:math' as math;
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:native_tavern/data/models/long_term_memory.dart';
+import 'package:native_tavern/data/models/persona.dart';
+import 'package:native_tavern/data/repositories/persona_repository.dart';
+import 'package:native_tavern/domain/services/chat_generation_pipeline.dart';
+import 'package:native_tavern/domain/services/long_term_memory_context_service.dart';
+import 'package:native_tavern/presentation/providers/chat_extension_providers.dart';
+import 'package:native_tavern/presentation/providers/memory_providers.dart';
+import 'package:native_tavern/presentation/providers/persona_providers.dart';
+import 'package:native_tavern/presentation/providers/settings_providers.dart';
+import 'package:native_tavern/presentation/providers/vector_storage_providers.dart';
+
+final longTermMemoryContextServiceProvider =
+    Provider<LongTermMemoryContextService>((ref) {
+  return LongTermMemoryContextService(
+    repository: ref.watch(longTermMemoryRepositoryProvider),
+  );
+});
+
+final longTermMemoryContextContributorProvider =
+    Provider<LongTermMemoryContextContributor>((ref) {
+  return LongTermMemoryContextContributor(
+    service: ref.watch(longTermMemoryContextServiceProvider),
+    resolveScopes: (request) => _resolveScopes(ref, request),
+    enabled: () => ref.read(appSettingsProvider).memoryContextEnabled,
+    tokenBudget: () => ref.read(appSettingsProvider).memoryContextTokenBudget,
+    semanticEnabled: () =>
+        ref.read(appSettingsProvider).memorySemanticSearchEnabled,
+    semanticThreshold: () =>
+        ref.read(vectorStorageSettingsProvider).similarityThreshold,
+    semanticScorer: (query, candidates) =>
+        _scoreSemantically(ref, query, candidates),
+  );
+});
+
+final longTermMemoryContextRegistrationProvider =
+    Provider<ChatExtensionRegistration>((ref) {
+  final registration =
+      ref.watch(chatExtensionRegistryProvider).registerContributor(
+            ref.watch(longTermMemoryContextContributorProvider),
+          );
+  ref.onDispose(registration.dispose);
+  return registration;
+});
+
+final class MemoryContextUsageItem {
+  const MemoryContextUsageItem({
+    required this.memory,
+    required this.status,
+    required this.score,
+    required this.originalTokens,
+    required this.usedTokens,
+  });
+
+  final LongTermMemory memory;
+  final ContextContributionItemStatus status;
+  final double score;
+  final int originalTokens;
+  final int usedTokens;
+}
+
+final class MemoryContextUsage {
+  const MemoryContextUsage({
+    required this.chatId,
+    required this.mode,
+    required this.status,
+    required this.items,
+    required this.allocatedTokens,
+    required this.usedTokens,
+    this.fallbackReason,
+  });
+
+  final String chatId;
+  final MemoryRetrievalMode mode;
+  final ContextContributionStatus status;
+  final List<MemoryContextUsageItem> items;
+  final int allocatedTokens;
+  final int usedTokens;
+  final MemorySemanticFallbackReason? fallbackReason;
+
+  int get includedCount => items
+      .where((item) => item.status != ContextContributionItemStatus.dropped)
+      .length;
+}
+
+final memoryContextUsageProvider =
+    FutureProvider.family<MemoryContextUsage?, String>((ref, chatId) async {
+  final assembly = ref.watch(lastContextAssemblyProvider);
+  if (assembly == null || assembly.chatId != chatId) return null;
+
+  ContextContributionTrace? trace;
+  for (final candidate in assembly.traces) {
+    if (candidate.contributorId ==
+        LongTermMemoryContextContributor.contributorId) {
+      trace = candidate;
+      break;
+    }
+  }
+  if (trace == null) return null;
+
+  final scores = <String, double>{};
+  final rawScores = trace.metadata['scores'];
+  if (rawScores is Map) {
+    for (final entry in rawScores.entries) {
+      final value = entry.value;
+      if (entry.key is String && value is num && value.isFinite) {
+        scores[entry.key as String] = value.toDouble();
+      }
+    }
+  }
+
+  final repository = ref.watch(longTermMemoryRepositoryProvider);
+  final items = <MemoryContextUsageItem>[];
+  for (final itemTrace in trace.itemTraces) {
+    final memory = await repository.getById(itemTrace.itemId);
+    if (memory == null) continue;
+    items.add(
+      MemoryContextUsageItem(
+        memory: memory,
+        status: itemTrace.status,
+        score: scores[itemTrace.itemId] ?? 0,
+        originalTokens: itemTrace.originalTokens,
+        usedTokens: itemTrace.usedTokens,
+      ),
+    );
+  }
+
+  final modeName = trace.metadata['retrievalMode'];
+  final mode = MemoryRetrievalMode.values.firstWhere(
+    (candidate) => candidate.name == modeName,
+    orElse: () => MemoryRetrievalMode.fts,
+  );
+  final fallbackName = trace.metadata['semanticFallbackReason'];
+  MemorySemanticFallbackReason? fallbackReason;
+  for (final candidate in MemorySemanticFallbackReason.values) {
+    if (candidate.name == fallbackName) {
+      fallbackReason = candidate;
+      break;
+    }
+  }
+  return MemoryContextUsage(
+    chatId: chatId,
+    mode: mode,
+    status: trace.status,
+    items: List<MemoryContextUsageItem>.unmodifiable(items),
+    allocatedTokens: trace.allocatedTokens,
+    usedTokens: trace.usedTokens,
+    fallbackReason: fallbackReason,
+  );
+});
+
+Future<List<MemoryScope>> _resolveScopes(
+  Ref ref,
+  ChatContextRequest request,
+) async {
+  final scopes = <MemoryScope>[MemoryScope.chat(request.chatId)];
+  final groupId = request.groupId;
+  if (groupId != null && groupId.trim().isNotEmpty) {
+    scopes.add(MemoryScope.group(groupId));
+  }
+
+  final characterId = request.characterId;
+  if (characterId != null && characterId.trim().isNotEmpty) {
+    final persona = await _resolvePersona(ref, request);
+    if (persona != null) {
+      scopes.add(
+        MemoryScope.characterPersona(
+          characterId: characterId,
+          personaId: persona.id,
+        ),
+      );
+    }
+    scopes.add(MemoryScope.character(characterId));
+  }
+  return scopes;
+}
+
+Future<Persona?> _resolvePersona(Ref ref, ChatContextRequest request) async {
+  final repository = ref.read(personaRepositoryProvider);
+  final personas = await repository.getAllPersonas();
+
+  Persona? connectedWhere(bool Function(PersonaConnection) matches) {
+    for (final persona in personas) {
+      if (persona.connections.any(matches)) return persona;
+    }
+    return null;
+  }
+
+  final byChat = connectedWhere(
+    (connection) => connection.chatId == request.chatId,
+  );
+  if (byChat != null) return byChat;
+  if (request.groupId case final groupId?) {
+    final byGroup = connectedWhere(
+      (connection) => connection.groupId == groupId,
+    );
+    if (byGroup != null) return byGroup;
+  }
+  if (request.characterId case final characterId?) {
+    final byCharacter = connectedWhere(
+      (connection) => connection.characterId == characterId,
+    );
+    if (byCharacter != null) return byCharacter;
+  }
+
+  final activeId = ref.read(activePersonaIdProvider);
+  if (activeId != null) {
+    final active = await repository.getPersona(activeId);
+    if (active != null) return active;
+  }
+  return repository.getDefaultPersona();
+}
+
+Future<Map<String, double>> _scoreSemantically(
+  Ref ref,
+  String query,
+  List<LongTermMemory> candidates,
+) async {
+  final settings = ref.read(vectorStorageSettingsProvider);
+  final embeddings = await ref.read(embeddingServiceProvider).embedBatch([
+    query,
+    ...candidates.map((memory) => memory.content),
+  ], settings);
+  if (embeddings.length != candidates.length + 1 || embeddings.first.isEmpty) {
+    throw const FormatException(
+      'Embedding response shape does not match input.',
+    );
+  }
+  final queryEmbedding = embeddings.first;
+  return {
+    for (var index = 0; index < candidates.length; index++)
+      candidates[index].id: _cosineSimilarity(
+        queryEmbedding,
+        embeddings[index + 1],
+      ),
+  };
+}
+
+double _cosineSimilarity(List<double> left, List<double> right) {
+  if (left.isEmpty || left.length != right.length) {
+    throw const FormatException('Embedding dimensions do not match.');
+  }
+  var dot = 0.0;
+  var leftNorm = 0.0;
+  var rightNorm = 0.0;
+  for (var index = 0; index < left.length; index++) {
+    final leftValue = left[index];
+    final rightValue = right[index];
+    if (!leftValue.isFinite || !rightValue.isFinite) {
+      throw const FormatException('Embedding contains a non-finite value.');
+    }
+    dot += leftValue * rightValue;
+    leftNorm += leftValue * leftValue;
+    rightNorm += rightValue * rightValue;
+  }
+  if (leftNorm == 0 || rightNorm == 0) return 0;
+  return dot / (math.sqrt(leftNorm) * math.sqrt(rightNorm));
+}

--- a/lib/presentation/providers/settings_providers.dart
+++ b/lib/presentation/providers/settings_providers.dart
@@ -674,6 +674,8 @@ final connectionProfilesProvider =
 
 /// App settings state
 class AppSettings {
+  static const memoryContextTokenBudgets = [256, 512, 1024, 2048];
+
   final String theme;
   final String language;
   final bool enableNotifications;
@@ -687,6 +689,9 @@ class AppSettings {
   final double backgroundOpacity;
   final String chatLayoutMode;
   final bool memoryAutoExtractionEnabled;
+  final bool memoryContextEnabled;
+  final bool memorySemanticSearchEnabled;
+  final int memoryContextTokenBudget;
 
   const AppSettings({
     this.theme = 'dark',
@@ -702,6 +707,9 @@ class AppSettings {
     this.backgroundOpacity = 1.0,
     this.chatLayoutMode = 'bubble',
     this.memoryAutoExtractionEnabled = false,
+    this.memoryContextEnabled = true,
+    this.memorySemanticSearchEnabled = false,
+    this.memoryContextTokenBudget = 512,
   });
 
   AppSettings copyWith({
@@ -718,6 +726,9 @@ class AppSettings {
     double? backgroundOpacity,
     String? chatLayoutMode,
     bool? memoryAutoExtractionEnabled,
+    bool? memoryContextEnabled,
+    bool? memorySemanticSearchEnabled,
+    int? memoryContextTokenBudget,
   }) {
     return AppSettings(
       theme: theme ?? this.theme,
@@ -736,6 +747,11 @@ class AppSettings {
       chatLayoutMode: chatLayoutMode ?? this.chatLayoutMode,
       memoryAutoExtractionEnabled:
           memoryAutoExtractionEnabled ?? this.memoryAutoExtractionEnabled,
+      memoryContextEnabled: memoryContextEnabled ?? this.memoryContextEnabled,
+      memorySemanticSearchEnabled:
+          memorySemanticSearchEnabled ?? this.memorySemanticSearchEnabled,
+      memoryContextTokenBudget:
+          memoryContextTokenBudget ?? this.memoryContextTokenBudget,
     );
   }
 
@@ -753,6 +769,9 @@ class AppSettings {
         'backgroundOpacity': backgroundOpacity,
         'chatLayoutMode': chatLayoutMode,
         'memoryAutoExtractionEnabled': memoryAutoExtractionEnabled,
+        'memoryContextEnabled': memoryContextEnabled,
+        'memorySemanticSearchEnabled': memorySemanticSearchEnabled,
+        'memoryContextTokenBudget': memoryContextTokenBudget,
       };
 
   factory AppSettings.fromJson(Map<String, dynamic> json) {
@@ -773,7 +792,17 @@ class AppSettings {
       chatLayoutMode: json['chatLayoutMode'] as String? ?? 'bubble',
       memoryAutoExtractionEnabled:
           json['memoryAutoExtractionEnabled'] as bool? ?? false,
+      memoryContextEnabled: json['memoryContextEnabled'] as bool? ?? true,
+      memorySemanticSearchEnabled:
+          json['memorySemanticSearchEnabled'] as bool? ?? false,
+      memoryContextTokenBudget: normalizeMemoryContextTokenBudget(
+        (json['memoryContextTokenBudget'] as num?)?.toInt(),
+      ),
     );
+  }
+
+  static int normalizeMemoryContextTokenBudget(int? value) {
+    return memoryContextTokenBudgets.contains(value) ? value! : 512;
   }
 }
 
@@ -900,6 +929,24 @@ class AppSettingsNotifier extends StateNotifier<AppSettings> {
 
   void updateMemoryAutoExtraction(bool enabled) {
     state = state.copyWith(memoryAutoExtractionEnabled: enabled);
+    _saveSettings();
+  }
+
+  void updateMemoryContext(bool enabled) {
+    state = state.copyWith(memoryContextEnabled: enabled);
+    _saveSettings();
+  }
+
+  void updateMemorySemanticSearch(bool enabled) {
+    state = state.copyWith(memorySemanticSearchEnabled: enabled);
+    _saveSettings();
+  }
+
+  void updateMemoryContextTokenBudget(int tokens) {
+    state = state.copyWith(
+      memoryContextTokenBudget:
+          AppSettings.normalizeMemoryContextTokenBudget(tokens),
+    );
     _saveSettings();
   }
 

--- a/lib/presentation/screens/chat/chat_screen.dart
+++ b/lib/presentation/screens/chat/chat_screen.dart
@@ -41,6 +41,7 @@ import 'package:native_tavern/presentation/widgets/chat/data_bank_citation_previ
 import 'package:native_tavern/presentation/widgets/chat/chat_background_widget.dart';
 import 'package:native_tavern/presentation/widgets/chat/chat_voice_input_button.dart';
 import 'package:native_tavern/presentation/widgets/chat/message_content_widget.dart';
+import 'package:native_tavern/presentation/widgets/chat/memory_context_usage_sheet.dart';
 import 'package:native_tavern/presentation/widgets/chat/quick_reply_bar.dart';
 import 'package:native_tavern/presentation/widgets/common/adaptive_popup_menu.dart';
 import 'package:native_tavern/presentation/widgets/chat/markdown_input_field.dart';
@@ -1353,6 +1354,15 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
                 contentPadding: EdgeInsets.zero,
               ),
             ),
+            const PopupMenuItem(
+              key: Key('memory-usage-menu'),
+              value: 'memory_usage',
+              child: ListTile(
+                leading: Icon(Icons.psychology_outlined),
+                title: Text('Memories used'),
+                contentPadding: EdgeInsets.zero,
+              ),
+            ),
             PopupMenuItem(
               value: 'export',
               child: ListTile(
@@ -1409,6 +1419,9 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
               case 'bookmarks':
                 _showBookmarksDialog(context);
                 break;
+              case 'memory_usage':
+                _showMemoryUsage();
+                break;
               case 'export':
                 _showExportDialog();
                 break;
@@ -1422,6 +1435,15 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
           },
         ),
       ],
+    );
+  }
+
+  void _showMemoryUsage() {
+    showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      showDragHandle: true,
+      builder: (context) => MemoryContextUsageSheet(chatId: widget.chatId),
     );
   }
 

--- a/lib/presentation/screens/settings/memory_inbox_screen.dart
+++ b/lib/presentation/screens/settings/memory_inbox_screen.dart
@@ -33,6 +33,12 @@ class _MemoryInboxScreenState extends ConsumerState<MemoryInboxScreen> {
         title: const Text('Memory inbox'),
         actions: [
           IconButton(
+            key: const Key('memory-context-settings'),
+            tooltip: 'Chat context',
+            onPressed: _showContextSettings,
+            icon: const Icon(Icons.psychology_outlined),
+          ),
+          IconButton(
             tooltip: 'Refresh',
             onPressed: inbox.isLoading
                 ? null
@@ -274,6 +280,74 @@ class _MemoryInboxScreenState extends ConsumerState<MemoryInboxScreen> {
               : () => _openSource(memory),
         );
       },
+    );
+  }
+
+  void _showContextSettings() {
+    showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      showDragHandle: true,
+      builder: (context) => Consumer(
+        builder: (context, ref, _) {
+          final settings = ref.watch(appSettingsProvider);
+          final notifier = ref.read(appSettingsProvider.notifier);
+          return SafeArea(
+            child: SingleChildScrollView(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  SwitchListTile(
+                    key: const Key('memory-context-switch'),
+                    secondary: const Icon(Icons.psychology_outlined),
+                    title: const Text('Use memories in chat'),
+                    value: settings.memoryContextEnabled,
+                    onChanged: notifier.updateMemoryContext,
+                  ),
+                  SwitchListTile(
+                    key: const Key('memory-semantic-search-switch'),
+                    secondary: const Icon(Icons.hub_outlined),
+                    title: const Text('Semantic reranking'),
+                    subtitle: const Text('Configured embedding provider'),
+                    value: settings.memorySemanticSearchEnabled,
+                    onChanged: settings.memoryContextEnabled
+                        ? notifier.updateMemorySemanticSearch
+                        : null,
+                  ),
+                  ListTile(
+                    key: const Key('memory-context-budget'),
+                    leading: const Icon(Icons.data_usage_outlined),
+                    title: const Text('Context budget'),
+                    trailing: DropdownButton<int>(
+                      key: const Key('memory-context-budget-menu'),
+                      value: settings.memoryContextTokenBudget,
+                      items: const [
+                        DropdownMenuItem(value: 256, child: Text('256 tokens')),
+                        DropdownMenuItem(value: 512, child: Text('512 tokens')),
+                        DropdownMenuItem(
+                          value: 1024,
+                          child: Text('1024 tokens'),
+                        ),
+                        DropdownMenuItem(
+                          value: 2048,
+                          child: Text('2048 tokens'),
+                        ),
+                      ],
+                      onChanged: settings.memoryContextEnabled
+                          ? (value) {
+                              if (value != null) {
+                                notifier.updateMemoryContextTokenBudget(value);
+                              }
+                            }
+                          : null,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
     );
   }
 

--- a/lib/presentation/widgets/chat/memory_context_usage_sheet.dart
+++ b/lib/presentation/widgets/chat/memory_context_usage_sheet.dart
@@ -1,0 +1,175 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:native_tavern/data/models/long_term_memory.dart';
+import 'package:native_tavern/domain/services/chat_generation_pipeline.dart';
+import 'package:native_tavern/domain/services/long_term_memory_context_service.dart';
+import 'package:native_tavern/presentation/providers/memory_context_providers.dart';
+
+class MemoryContextUsageSheet extends ConsumerWidget {
+  const MemoryContextUsageSheet({super.key, required this.chatId});
+
+  final String chatId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final usage = ref.watch(memoryContextUsageProvider(chatId));
+    final maximumHeight = MediaQuery.sizeOf(context).height * 0.72;
+    return SafeArea(
+      child: SizedBox(
+        key: const Key('memory-usage-sheet'),
+        height: maximumHeight,
+        child: usage.when(
+          loading: () => const Center(child: CircularProgressIndicator()),
+          error: (_, __) => const Center(child: Icon(Icons.error_outline)),
+          data: (value) {
+            if (value == null) {
+              return const Center(
+                child: Icon(Icons.psychology_outlined, size: 48),
+              );
+            }
+            return Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(20, 0, 20, 12),
+                  child: Row(
+                    children: [
+                      const Icon(Icons.psychology_outlined),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              'Memories used',
+                              style: Theme.of(context).textTheme.titleMedium,
+                            ),
+                            Text(
+                              '${_modeLabel(value.mode)} | '
+                              '${value.usedTokens}/${value.allocatedTokens} tokens',
+                              style: Theme.of(context).textTheme.bodySmall,
+                            ),
+                          ],
+                        ),
+                      ),
+                      Text('${value.includedCount}/${value.items.length}'),
+                    ],
+                  ),
+                ),
+                const Divider(height: 1),
+                if (value.items.isEmpty)
+                  Expanded(
+                    child: Center(
+                      child: Icon(
+                        value.status == ContextContributionStatus.disabled
+                            ? Icons.visibility_off_outlined
+                            : Icons.manage_search,
+                        size: 48,
+                      ),
+                    ),
+                  )
+                else
+                  Expanded(
+                    child: ListView.separated(
+                      itemCount: value.items.length,
+                      separatorBuilder: (_, __) => const Divider(height: 1),
+                      itemBuilder: (context, index) {
+                        final item = value.items[index];
+                        final memory = item.memory;
+                        final source = memory.source;
+                        final canOpenSource = source.sourceChatId != null &&
+                            source.sourceMessageIds.isNotEmpty;
+                        return Padding(
+                          key: Key('memory-usage-item-${memory.id}'),
+                          padding: const EdgeInsets.fromLTRB(16, 12, 8, 12),
+                          child: Row(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Padding(
+                                padding: const EdgeInsets.only(top: 2),
+                                child: Icon(_statusIcon(item.status), size: 20),
+                              ),
+                              const SizedBox(width: 12),
+                              Expanded(
+                                child: Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    Text(memory.content),
+                                    const SizedBox(height: 6),
+                                    Wrap(
+                                      spacing: 10,
+                                      runSpacing: 4,
+                                      children: [
+                                        Text(
+                                          '${(item.score * 100).round()}% relevance',
+                                          style: Theme.of(context)
+                                              .textTheme
+                                              .bodySmall,
+                                        ),
+                                        Text(
+                                          _statusLabel(item.status),
+                                          style: Theme.of(context)
+                                              .textTheme
+                                              .bodySmall,
+                                        ),
+                                        Text(
+                                          source.origin ==
+                                                  MemoryOrigin.generated
+                                              ? '${source.providerId} / ${source.modelId}'
+                                              : 'Manual',
+                                          style: Theme.of(context)
+                                              .textTheme
+                                              .bodySmall,
+                                        ),
+                                      ],
+                                    ),
+                                  ],
+                                ),
+                              ),
+                              if (canOpenSource)
+                                IconButton(
+                                  key: Key('memory-usage-source-${memory.id}'),
+                                  tooltip: 'Open source',
+                                  onPressed: () {
+                                    final router = GoRouter.of(context);
+                                    Navigator.of(context).pop();
+                                    router.push(
+                                      '/chat/${source.sourceChatId}'
+                                      '?message=${source.sourceMessageIds.first}',
+                                    );
+                                  },
+                                  icon: const Icon(Icons.open_in_new),
+                                ),
+                            ],
+                          ),
+                        );
+                      },
+                    ),
+                  ),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
+String _modeLabel(MemoryRetrievalMode mode) => switch (mode) {
+      MemoryRetrievalMode.fts => 'Local FTS',
+      MemoryRetrievalMode.hybrid => 'Hybrid',
+      MemoryRetrievalMode.ftsFallback => 'Local FTS fallback',
+    };
+
+IconData _statusIcon(ContextContributionItemStatus status) => switch (status) {
+      ContextContributionItemStatus.included => Icons.check_circle_outline,
+      ContextContributionItemStatus.truncated => Icons.content_cut,
+      ContextContributionItemStatus.dropped => Icons.block_outlined,
+    };
+
+String _statusLabel(ContextContributionItemStatus status) => switch (status) {
+      ContextContributionItemStatus.included => 'Included',
+      ContextContributionItemStatus.truncated => 'Trimmed',
+      ContextContributionItemStatus.dropped => 'Excluded',
+    };

--- a/test/chat_extension_end_to_end_test.dart
+++ b/test/chat_extension_end_to_end_test.dart
@@ -97,11 +97,12 @@ void main() {
 
     final assembly = container.read(lastContextAssemblyProvider);
     expect(assembly, isNotNull);
-    final memoryTrace = assembly!.traces.singleWhere(
+    final testTrace = assembly!.traces.singleWhere(
       (trace) => trace.contributorId == 'test.memory',
     );
+    expect(testTrace.contributorId, 'test.memory');
     expect(
-      memoryTrace.status,
+      testTrace.status,
       ContextContributionStatus.applied,
     );
     final generation = container.read(lastChatGenerationTraceProvider);
@@ -109,7 +110,7 @@ void main() {
     expect(generation?.middlewareTraces, hasLength(2));
   });
 
-  test('Data Bank with no matches sends the baseline without prompt changes',
+  test('built-in contributors with no matches preserve the baseline prompt',
       () async {
     final notifier = container.read(activeChatProvider.notifier);
     await notifier.createChat('character-1');
@@ -118,12 +119,15 @@ void main() {
 
     final assembly = container.read(lastContextAssemblyProvider);
     expect(assembly, isNotNull);
-    expect(assembly!.traces, hasLength(1));
+    expect(assembly!.traces, hasLength(2));
     expect(
-      assembly.traces.single.contributorId,
-      'data-bank.retrieval',
+      assembly.traces.map((trace) => trace.contributorId),
+      ['data-bank.retrieval', 'memory.long_term'],
     );
-    expect(assembly.traces.single.injectedMessages, isEmpty);
+    expect(
+      assembly.traces.every((trace) => trace.injectedMessages.isEmpty),
+      isTrue,
+    );
     expect(llmService.requests.single, assembly.messages);
     expect(
       llmService.requests.single

--- a/test/chat_generation_pipeline_test.dart
+++ b/test/chat_generation_pipeline_test.dart
@@ -154,10 +154,16 @@ void main() {
       final registry = ChatExtensionRegistry();
       registry.registerContributor(_Contributor(
         id: 'bounded',
-        maxTokens: 18,
-        onContribute: (_) async => ContextContribution(messages: [
-          {'role': 'system', 'content': 'x' * 500},
-        ]),
+        maxTokens: 30,
+        onContribute: (_) async => ContextContribution(
+          messages: [
+            {'role': 'system', 'content': 'short'},
+            {'role': 'system', 'content': 'x' * 500},
+            {'role': 'system', 'content': 'never reached'},
+          ],
+          itemIds: const ['short', 'long', 'dropped'],
+          metadata: const {'source': 'local'},
+        ),
       ));
       final session = ChatGenerationPipeline(registry: registry).startSession(
         chatId: 'chat-1',
@@ -170,15 +176,62 @@ void main() {
       ]);
       final trace = result.traces.single;
 
-      expect(trace.allocatedTokens, 18);
-      expect(trace.usedTokens, lessThanOrEqualTo(18));
+      expect(trace.allocatedTokens, 30);
+      expect(trace.usedTokens, lessThanOrEqualTo(30));
       expect(trace.originalTokens, greaterThan(trace.usedTokens));
       expect(trace.truncatedMessageCount, 1);
-      expect(trace.injectedMessages.single['content'], contains('[truncated]'));
+      expect(trace.droppedMessageCount, 1);
+      expect(trace.injectedMessages.last['content'], contains('[truncated]'));
+      expect(
+        trace.itemTraces.map((item) => item.status),
+        [
+          ContextContributionItemStatus.included,
+          ContextContributionItemStatus.truncated,
+          ContextContributionItemStatus.dropped,
+        ],
+      );
+      expect(trace.metadata, {'source': 'local'});
       expect(result.wasTrimmed, isTrue);
       expect(
         result.estimatedTokens,
-        lessThanOrEqualTo(result.baseEstimatedTokens + 18),
+        lessThanOrEqualTo(result.baseEstimatedTokens + 30),
+      );
+      session.close();
+    });
+
+    test('honors an explicit conversation boundary after summary and RAG',
+        () async {
+      final registry = ChatExtensionRegistry();
+      registry.registerContributor(
+        _Contributor(
+          id: 'memory',
+          onContribute: (request) async {
+            expect(request.conversationStartIndex, 3);
+            return ContextContribution(messages: const [
+              {'role': 'system', 'content': 'Memory'},
+            ]);
+          },
+        ),
+      );
+      final session = ChatGenerationPipeline(registry: registry).startSession(
+        chatId: 'chat-1',
+        mode: ChatGenerationMode.send,
+        config: _config,
+      );
+
+      final result = await session.assemble(
+        const [
+          {'role': 'system', 'content': 'World info'},
+          {'role': 'assistant', 'content': 'Summary'},
+          {'role': 'system', 'content': 'RAG'},
+          {'role': 'user', 'content': 'Current message'},
+        ],
+        conversationStartIndex: 3,
+      );
+
+      expect(
+        result.messages.map((message) => message['content']),
+        ['World info', 'Summary', 'RAG', 'Memory', 'Current message'],
       );
       session.close();
     });

--- a/test/data_bank_chat_end_to_end_test.dart
+++ b/test/data_bank_chat_end_to_end_test.dart
@@ -237,7 +237,11 @@ void main() {
     await notifier.sendMessage('navigation marker', _config);
 
     final assembly = container.read(lastContextAssemblyProvider);
-    expect(assembly?.traces.single.status, ContextContributionStatus.disabled);
+    expect(assembly, isNotNull);
+    final dataBankTrace = assembly!.traces.singleWhere(
+      (trace) => trace.contributorId == 'data-bank.retrieval',
+    );
+    expect(dataBankTrace.status, ContextContributionStatus.disabled);
     expect(
       _joinedPrompt(llmService.requests.last),
       isNot(contains('Relevant Data Bank sources')),

--- a/test/long_term_memory_context_service_test.dart
+++ b/test/long_term_memory_context_service_test.dart
@@ -1,0 +1,275 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:native_tavern/data/database/database.dart';
+import 'package:native_tavern/data/models/long_term_memory.dart';
+import 'package:native_tavern/data/repositories/drift_long_term_memory_repository.dart';
+import 'package:native_tavern/domain/services/chat_generation_pipeline.dart';
+import 'package:native_tavern/domain/services/long_term_memory_context_service.dart';
+
+void main() {
+  final now = DateTime.utc(2026, 8, 8, 12);
+  late AppDatabase database;
+  late DriftLongTermMemoryRepository repository;
+  late LongTermMemoryContextService service;
+
+  setUp(() async {
+    database = AppDatabase.forTesting(NativeDatabase.memory());
+    await database.customSelect('SELECT 1').get();
+    await _seedOwners(database);
+    repository = DriftLongTermMemoryRepository(database, now: () => now);
+    service = LongTermMemoryContextService(repository: repository);
+  });
+
+  tearDown(() => database.close());
+
+  test('aggregates allowed scopes and excludes other, inactive, and expired',
+      () async {
+    final scopes = [
+      MemoryScope.chat('chat-1'),
+      MemoryScope.group('group-1'),
+      MemoryScope.characterPersona(
+        characterId: 'character-1',
+        personaId: 'persona-1',
+      ),
+      MemoryScope.character('character-1'),
+    ];
+    await repository.createAll([
+      for (final (index, scope) in scopes.indexed)
+        _memory(
+          id: 'allowed-$index',
+          scope: scope,
+          content: 'Prefers jasmine tea.',
+        ),
+      _memory(
+        id: 'other-chat',
+        scope: MemoryScope.chat('chat-2'),
+        content: 'Prefers jasmine tea.',
+      ),
+      _memory(
+        id: 'candidate',
+        scope: MemoryScope.chat('chat-1'),
+        content: 'Prefers jasmine tea.',
+        state: MemoryState.candidate,
+      ),
+      _memory(
+        id: 'expired',
+        scope: MemoryScope.character('character-1'),
+        content: 'Prefers jasmine tea.',
+        createdAt: now.subtract(const Duration(days: 2)),
+        expiresAt: now.subtract(const Duration(hours: 1)),
+      ),
+    ]);
+
+    final first = await service.select(query: 'jasmine', scopes: scopes);
+    final second = await service.select(query: 'jasmine', scopes: scopes);
+
+    expect(first.mode, MemoryRetrievalMode.fts);
+    expect(
+      first.matches.map((match) => match.memory.id),
+      ['allowed-0', 'allowed-1', 'allowed-2', 'allowed-3'],
+    );
+    expect(
+      second.matches.map((match) => match.memory.id),
+      first.matches.map((match) => match.memory.id),
+    );
+    expect(
+      first.matches.map((match) => match.memory.id),
+      isNot(contains(anyOf('other-chat', 'candidate', 'expired'))),
+    );
+
+    final branch = await service.select(
+      query: 'jasmine',
+      scopes: [
+        MemoryScope.chat('chat-2'),
+        MemoryScope.character('character-1'),
+      ],
+    );
+    expect(
+      branch.matches.map((match) => match.memory.id),
+      ['other-chat', 'allowed-3'],
+    );
+  });
+
+  test('hybrid ranking can include a semantic-only memory', () async {
+    final scope = MemoryScope.character('character-1');
+    await repository.createAll([
+      _memory(
+        id: 'fts-match',
+        scope: scope,
+        content: 'Orchid details.',
+        importance: 0,
+      ),
+      _memory(
+        id: 'semantic-only',
+        scope: scope,
+        content: 'Favorite beverage is tea.',
+        importance: 1,
+      ),
+    ]);
+
+    final selection = await service.select(
+      query: 'orchid',
+      scopes: [scope],
+      semanticThreshold: 0.7,
+      semanticScorer: (_, candidates) async => {
+        for (final candidate in candidates)
+          candidate.id: candidate.id == 'semantic-only' ? 0.99 : 0.1,
+      },
+    );
+
+    expect(selection.mode, MemoryRetrievalMode.hybrid);
+    expect(
+      selection.matches.map((match) => match.memory.id),
+      ['semantic-only', 'fts-match'],
+    );
+    expect(selection.matches.first.ftsScore, isNull);
+    expect(selection.matches.first.semanticScore, 0.99);
+  });
+
+  test('semantic timeout, errors, and malformed scores fall back to FTS',
+      () async {
+    final scope = MemoryScope.character('character-1');
+    await repository.create(
+      _memory(id: 'local', scope: scope, content: 'Local orchid result.'),
+    );
+
+    Future<void> expectFallback(
+      LongTermMemoryContextService target,
+      MemorySemanticScorer scorer,
+      MemorySemanticFallbackReason reason,
+    ) async {
+      final selection = await target.select(
+        query: 'orchid',
+        scopes: [scope],
+        semanticScorer: scorer,
+      );
+      expect(selection.mode, MemoryRetrievalMode.ftsFallback);
+      expect(selection.fallbackReason, reason);
+      expect(selection.matches.single.memory.id, 'local');
+    }
+
+    await expectFallback(
+      service,
+      (_, __) async => throw StateError('not configured'),
+      MemorySemanticFallbackReason.unavailable,
+    );
+    await expectFallback(
+      service,
+      (_, __) async => const {},
+      MemorySemanticFallbackReason.invalidResponse,
+    );
+    await expectFallback(
+      LongTermMemoryContextService(
+        repository: repository,
+        semanticTimeout: const Duration(milliseconds: 1),
+      ),
+      (_, __) => Completer<Map<String, double>>().future,
+      MemorySemanticFallbackReason.timeout,
+    );
+  });
+
+  test('contributor uses current user text and keeps body out of metadata',
+      () async {
+    const body = 'Jasmine tea is the preferred drink.';
+    await repository.create(
+      _memory(
+        id: 'traceable',
+        scope: MemoryScope.chat('chat-1'),
+        content: body,
+      ),
+    );
+    ChatContextRequest? observedRequest;
+    final contributor = LongTermMemoryContextContributor(
+      service: service,
+      resolveScopes: (request) async {
+        observedRequest = request;
+        return [MemoryScope.chat(request.chatId)];
+      },
+      enabled: () => true,
+      tokenBudget: () => 512,
+      semanticEnabled: () => false,
+      semanticThreshold: () => 0.7,
+      semanticScorer: (_, __) async => const {},
+    );
+    final request = ChatContextRequest(
+      sessionId: 'session-1',
+      chatId: 'chat-1',
+      characterId: 'character-1',
+      mode: ChatGenerationMode.regenerate,
+      baseMessages: const [
+        {'role': 'user', 'content': 'old query'},
+        {'role': 'assistant', 'content': 'old answer'},
+        {
+          'role': 'user',
+          'content': [
+            {'type': 'text', 'text': 'jasmine'},
+            {
+              'type': 'image_url',
+              'image_url': {'url': 'data:image/png'}
+            },
+          ],
+        },
+      ],
+      inputTokenBudget: 4096,
+      availableContributionTokens: 512,
+      conversationStartIndex: 0,
+      cancellationToken: ChatCancellationToken(),
+    );
+
+    final contribution = await contributor.contribute(request);
+
+    expect(observedRequest, same(request));
+    expect(contribution.itemIds, ['traceable']);
+    expect(contribution.messages.single['content'], contains(body));
+    expect(contribution.placement,
+        ContextContributionPlacement.beforeConversation);
+    final encodedMetadata = jsonEncode(contribution.metadata);
+    expect(encodedMetadata, contains('traceable'));
+    expect(encodedMetadata, isNot(contains(body)));
+  });
+}
+
+LongTermMemory _memory({
+  required String id,
+  required MemoryScope scope,
+  required String content,
+  MemoryState state = MemoryState.active,
+  double importance = 0.5,
+  DateTime? createdAt,
+  DateTime? expiresAt,
+}) {
+  final effectiveCreatedAt = createdAt ?? DateTime.utc(2026, 8, 8, 12);
+  return LongTermMemory(
+    id: id,
+    kind: MemoryKind.preference,
+    scope: scope,
+    state: state,
+    content: content,
+    importance: importance,
+    confidence: 0.9,
+    createdAt: effectiveCreatedAt,
+    expiresAt: expiresAt,
+    normalizedIdentityKey: id,
+  );
+}
+
+Future<void> _seedOwners(AppDatabase database) async {
+  const statements = [
+    'INSERT INTO characters (id, name, created_at, modified_at) '
+        "VALUES ('character-1', 'Character', 1, 1)",
+    'INSERT INTO personas (id, name, created_at, updated_at) '
+        "VALUES ('persona-1', 'Persona', 1, 1)",
+    'INSERT INTO groups (id, name, created_at, modified_at) '
+        "VALUES ('group-1', 'Group', 1, 1)",
+    'INSERT INTO chats (id, character_id, created_at, updated_at) '
+        "VALUES ('chat-1', 'character-1', 1, 1)",
+    'INSERT INTO chats (id, character_id, created_at, updated_at) '
+        "VALUES ('chat-2', 'character-1', 1, 1)",
+  ];
+  for (final statement in statements) {
+    await database.customStatement(statement);
+  }
+}

--- a/test/memory_context_end_to_end_test.dart
+++ b/test/memory_context_end_to_end_test.dart
@@ -1,0 +1,474 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:native_tavern/core/services/initialization_service.dart';
+import 'package:native_tavern/data/database/database.dart';
+import 'package:native_tavern/data/models/character.dart' as models;
+import 'package:native_tavern/data/models/chat.dart';
+import 'package:native_tavern/data/models/long_term_memory.dart';
+import 'package:native_tavern/data/repositories/character_repository.dart';
+import 'package:native_tavern/data/repositories/chat_repository.dart';
+import 'package:native_tavern/data/repositories/group_repository.dart';
+import 'package:native_tavern/data/repositories/world_info_repository.dart';
+import 'package:native_tavern/domain/repositories/long_term_memory_repository.dart';
+import 'package:native_tavern/domain/services/chat_generation_pipeline.dart';
+import 'package:native_tavern/domain/services/llm_service.dart';
+import 'package:native_tavern/domain/services/long_term_memory_context_service.dart';
+import 'package:native_tavern/presentation/providers/chat_extension_providers.dart';
+import 'package:native_tavern/presentation/providers/chat_providers.dart';
+import 'package:native_tavern/presentation/providers/memory_context_providers.dart';
+import 'package:native_tavern/presentation/providers/memory_providers.dart';
+import 'package:native_tavern/presentation/providers/settings_providers.dart';
+import 'package:native_tavern/presentation/providers/vector_storage_providers.dart';
+import 'package:native_tavern/presentation/widgets/chat/memory_context_usage_sheet.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late AppDatabase database;
+  late Directory dataDirectory;
+  late ChatRepository chatRepository;
+  late CharacterRepository characterRepository;
+  late LongTermMemoryRepository memoryRepository;
+  late WorldInfoRepository worldInfoRepository;
+  late _RecordingLLMService llmService;
+  late ProviderContainer container;
+  late List<String> ragQueries;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    final preferences = await SharedPreferences.getInstance();
+    database = AppDatabase.forTesting(NativeDatabase.memory());
+    await database.customSelect('SELECT 1').get();
+    dataDirectory = Directory.systemTemp.createTempSync('nt_memory_context');
+    chatRepository = ChatRepository(database);
+    characterRepository = CharacterRepository(database, dataDirectory.path);
+    worldInfoRepository = WorldInfoRepository(database);
+    llmService = _RecordingLLMService();
+    ragQueries = [];
+    container = ProviderContainer(
+      overrides: [
+        databaseProvider.overrideWithValue(database),
+        dataPathProvider.overrideWithValue(dataDirectory.path),
+        characterRepositoryProvider.overrideWithValue(characterRepository),
+        chatRepositoryProvider.overrideWithValue(chatRepository),
+        llmServiceProvider.overrideWithValue(llmService),
+        sharedPreferencesProvider.overrideWithValue(preferences),
+        ragContextProvider.overrideWithValue((query) async {
+          ragQueries.add(query);
+          return 'RAG marker';
+        }),
+      ],
+    );
+    memoryRepository = container.read(longTermMemoryRepositoryProvider);
+
+    final now = DateTime.now();
+    await characterRepository.createCharacter(
+      models.Character(
+        id: 'character-1',
+        name: 'Context Tester',
+        description: 'Primary context test character.',
+        createdAt: now,
+        modifiedAt: now,
+      ),
+    );
+    await characterRepository.createCharacter(
+      models.Character(
+        id: 'character-2',
+        name: 'Other Character',
+        createdAt: now,
+        modifiedAt: now,
+      ),
+    );
+    container.read(appSettingsProvider);
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+  });
+
+  tearDown(() async {
+    container.dispose();
+    await database.close();
+    dataDirectory.deleteSync(recursive: true);
+  });
+
+  test('summary, lorebook, RAG, memory, and current chat keep their order',
+      () async {
+    final notifier = container.read(activeChatProvider.notifier);
+    final chatId = (await notifier.createChat('character-1'))!;
+    final chat = (await chatRepository.getChat(chatId))!;
+    await chatRepository.updateChat(
+      chat.copyWith(
+        summaries: [
+          ChatSummary(
+            id: 'summary-1',
+            content: 'Summary marker',
+            endMessageIndex: -1,
+            createdAt: DateTime.now(),
+          ),
+        ],
+      ),
+    );
+    final lorebook = await worldInfoRepository.createWorldInfo(
+      name: 'Test lorebook',
+      characterId: 'character-1',
+    );
+    await worldInfoRepository.addEntry(
+      worldInfoId: lorebook.id,
+      keys: const [],
+      content: 'Lorebook marker',
+      comment: 'Lore',
+      constant: true,
+    );
+    await memoryRepository.create(
+      _memory(
+        id: 'ordered-memory',
+        scope: MemoryScope.character('character-1'),
+        content: 'Orchid memory marker',
+      ),
+    );
+    await notifier.loadChat(chatId);
+
+    await notifier.sendMessage('orchid', _config);
+
+    final contents = llmService.requests.single
+        .map((message) => message['content'].toString())
+        .toList();
+    final loreIndex = _containingIndex(contents, 'Lorebook marker');
+    final summaryIndex = _containingIndex(contents, 'Summary marker');
+    final ragIndex = _containingIndex(contents, 'RAG marker');
+    final memoryIndex = _containingIndex(contents, 'Orchid memory marker');
+    final userIndex = contents.indexOf('orchid');
+    expect(loreIndex, lessThan(summaryIndex));
+    expect(summaryIndex, lessThan(ragIndex));
+    expect(ragIndex, lessThan(memoryIndex));
+    expect(memoryIndex, lessThan(userIndex));
+    expect(ragQueries.last, 'orchid');
+
+    final assembly = container.read(lastContextAssemblyProvider)!;
+    final trace = assembly.traces.singleWhere(
+      (candidate) =>
+          candidate.contributorId ==
+          LongTermMemoryContextContributor.contributorId,
+    );
+    expect(assembly.chatId, chatId);
+    expect(assembly.mode, ChatGenerationMode.send);
+    expect(trace.itemTraces.single.itemId, 'ordered-memory');
+    expect(
+      trace.itemTraces.single.status,
+      ContextContributionItemStatus.included,
+    );
+    expect(jsonEncode(trace.metadata), isNot(contains('Orchid memory marker')));
+
+    final usage =
+        await container.read(memoryContextUsageProvider(chatId).future);
+    expect(usage?.items.single.memory.content, 'Orchid memory marker');
+    expect(usage?.items.single.score, greaterThan(0));
+  });
+
+  test('disabled memory leaves the baseline prompt byte-for-byte unchanged',
+      () async {
+    const body = 'Violet memory marker';
+    await memoryRepository.create(
+      _memory(
+        id: 'switch-memory',
+        scope: MemoryScope.character('character-1'),
+        content: body,
+      ),
+    );
+    final settings = container.read(appSettingsProvider.notifier);
+    settings.updateMemoryContext(false);
+    expect(container.read(appSettingsProvider).memoryContextEnabled, isFalse);
+    final notifier = container.read(activeChatProvider.notifier);
+    final baselineChatId = (await notifier.createChat('character-1'))!;
+    await notifier.sendMessage('violet', _config);
+    final baseline = llmService.requests.last;
+    final disabledTrace =
+        container.read(lastContextAssemblyProvider)!.traces.singleWhere(
+              (trace) =>
+                  trace.contributorId ==
+                  LongTermMemoryContextContributor.contributorId,
+            );
+    expect(disabledTrace.status, ContextContributionStatus.disabled);
+    expect(
+      baseline.any((message) => message['content'].toString().contains(body)),
+      isFalse,
+    );
+    expect(
+      await container.read(memoryContextUsageProvider(baselineChatId).future),
+      isNotNull,
+    );
+
+    settings.updateMemoryContext(true);
+    final enabledChatId = (await notifier.createChat('character-1'))!;
+    await notifier.sendMessage('violet', _config);
+    final withMemory = llmService.requests.last;
+    final withoutMemory = withMemory
+        .where(
+          (message) => !message['content'].toString().contains(body),
+        )
+        .toList(growable: false);
+
+    expect(enabledChatId, isNot(baselineChatId));
+    expect(withoutMemory, baseline);
+  });
+
+  test('regeneration queries the selected user swipe', () async {
+    await memoryRepository.createAll([
+      _memory(
+        id: 'orchid-memory',
+        scope: MemoryScope.character('character-1'),
+        content: 'Orchid branch memory.',
+      ),
+      _memory(
+        id: 'jasmine-memory',
+        scope: MemoryScope.character('character-1'),
+        content: 'Jasmine branch memory.',
+      ),
+    ]);
+    final notifier = container.read(activeChatProvider.notifier);
+    final chatId = (await notifier.createChat('character-1'))!;
+    final now = DateTime.now();
+    await chatRepository.addMessage(
+      ChatMessage(
+        id: 'swipe-user',
+        chatId: chatId,
+        role: MessageRole.user,
+        content: 'orchid',
+        timestamp: now,
+        swipes: const ['orchid', 'jasmine'],
+      ),
+    );
+    await chatRepository.addMessage(
+      ChatMessage(
+        id: 'swipe-assistant',
+        chatId: chatId,
+        role: MessageRole.assistant,
+        content: 'Old answer',
+        timestamp: now.add(const Duration(seconds: 1)),
+        swipes: const ['Old answer'],
+      ),
+    );
+    await notifier.loadChat(chatId);
+
+    await notifier.swipeMessage('swipe-user', 1);
+    await notifier.regenerateLastMessage(_config);
+
+    final request = llmService.requests.single;
+    expect(
+      request.any(
+        (message) =>
+            message['content'].toString().contains('Jasmine branch memory.'),
+      ),
+      isTrue,
+    );
+    expect(
+      request.any(
+        (message) =>
+            message['content'].toString().contains('Orchid branch memory.'),
+      ),
+      isFalse,
+    );
+    expect(container.read(lastContextAssemblyProvider)?.mode,
+        ChatGenerationMode.regenerate);
+  });
+
+  test('group response includes group and current responder scopes only',
+      () async {
+    final group = await GroupRepository(database).createGroup(
+      name: 'Context group',
+      characterIds: const ['character-1'],
+    );
+    final notifier = container.read(activeChatProvider.notifier);
+    final chatId = (await notifier.createGroupChat(group))!;
+    await memoryRepository.createAll([
+      _memory(
+        id: 'group-memory',
+        scope: MemoryScope.group(group.id),
+        content: 'Group orchid memory.',
+      ),
+      _memory(
+        id: 'responder-memory',
+        scope: MemoryScope.character('character-1'),
+        content: 'Responder orchid memory.',
+      ),
+      _memory(
+        id: 'other-memory',
+        scope: MemoryScope.character('character-2'),
+        content: 'Other orchid memory.',
+      ),
+    ]);
+
+    await notifier.sendGroupMessage('orchid', _config);
+
+    final request = llmService.requests.single;
+    expect(_requestContains(request, 'Group orchid memory.'), isTrue);
+    expect(_requestContains(request, 'Responder orchid memory.'), isTrue);
+    expect(_requestContains(request, 'Other orchid memory.'), isFalse);
+    final assembly = container.read(lastContextAssemblyProvider)!;
+    expect(assembly.chatId, chatId);
+    expect(assembly.groupId, group.id);
+    expect(assembly.characterId, 'character-1');
+    expect(assembly.mode, ChatGenerationMode.groupResponse);
+  });
+
+  testWidgets('usage sheet explains trimming and routes to its source',
+      (tester) async {
+    tester.view.physicalSize = const Size(320, 640);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    final now = DateTime.now();
+    final usage = MemoryContextUsage(
+      chatId: 'chat-panel',
+      mode: MemoryRetrievalMode.hybrid,
+      status: ContextContributionStatus.applied,
+      allocatedTokens: 256,
+      usedTokens: 72,
+      items: [
+        MemoryContextUsageItem(
+          memory: LongTermMemory(
+            id: 'panel-memory',
+            kind: MemoryKind.preference,
+            scope: MemoryScope.chat('chat-panel'),
+            state: MemoryState.active,
+            content: 'A traceable memory shown in the usage panel.',
+            source: MemorySource.generated(
+              sourceChatId: 'source-chat',
+              sourceMessageIds: const ['source-message'],
+              extractedAt: now.subtract(const Duration(minutes: 1)),
+              providerId: 'provider-1',
+              modelId: 'model-1',
+            ),
+            importance: 0.8,
+            confidence: 0.9,
+            createdAt: now,
+            normalizedIdentityKey: 'panel-memory',
+          ),
+          status: ContextContributionItemStatus.truncated,
+          score: 0.86,
+          originalTokens: 120,
+          usedTokens: 72,
+        ),
+      ],
+    );
+    final router = GoRouter(
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (context, _) => Scaffold(
+            body: Center(
+              child: IconButton(
+                key: const Key('open-memory-usage'),
+                onPressed: () => showModalBottomSheet<void>(
+                  context: context,
+                  isScrollControlled: true,
+                  showDragHandle: true,
+                  builder: (_) => const MemoryContextUsageSheet(
+                    chatId: 'chat-panel',
+                  ),
+                ),
+                icon: const Icon(Icons.psychology_outlined),
+              ),
+            ),
+          ),
+        ),
+        GoRoute(
+          path: '/chat/:id',
+          builder: (_, state) => Scaffold(
+            body: Text(
+              '${state.pathParameters['id']}/'
+              '${state.uri.queryParameters['message']}',
+            ),
+          ),
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          memoryContextUsageProvider('chat-panel').overrideWith(
+            (ref) async => usage,
+          ),
+        ],
+        child: MaterialApp.router(routerConfig: router),
+      ),
+    );
+    await tester.tap(find.byKey(const Key('open-memory-usage')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Memories used'), findsOneWidget);
+    expect(find.text('Hybrid | 72/256 tokens'), findsOneWidget);
+    expect(find.text('86% relevance'), findsOneWidget);
+    expect(find.text('Trimmed'), findsOneWidget);
+    expect(find.text('provider-1 / model-1'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+
+    await tester.tap(
+      find.byKey(const Key('memory-usage-source-panel-memory')),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('source-chat/source-message'), findsOneWidget);
+  });
+}
+
+const _config = LLMConfig(
+  provider: LLMProvider.openAICompatible,
+  model: 'test-model',
+  apiKey: '',
+  apiUrl: 'http://localhost',
+  contextLength: 4096,
+  maxTokens: 256,
+  streamEnabled: false,
+  autoSummarizeEnabled: false,
+);
+
+final class _RecordingLLMService extends LLMService {
+  final List<List<ChatMessageMap>> requests = [];
+
+  @override
+  Future<LLMResponse> generateWithReasoning(
+    List<Map<String, dynamic>> messages,
+    LLMConfig config,
+  ) async {
+    requests.add([
+      for (final message in messages) Map<String, dynamic>.from(message),
+    ]);
+    return const LLMResponse(content: 'Recorded response.');
+  }
+}
+
+LongTermMemory _memory({
+  required String id,
+  required MemoryScope scope,
+  required String content,
+}) {
+  return LongTermMemory(
+    id: id,
+    kind: MemoryKind.preference,
+    scope: scope,
+    state: MemoryState.active,
+    content: content,
+    createdAt: DateTime.now(),
+    normalizedIdentityKey: id,
+  );
+}
+
+int _containingIndex(List<String> contents, String value) {
+  final index = contents.indexWhere((content) => content.contains(value));
+  expect(index, greaterThanOrEqualTo(0),
+      reason: 'Missing "$value" in $contents');
+  return index;
+}
+
+bool _requestContains(List<ChatMessageMap> request, String value) {
+  return request.any(
+    (message) => message['content'].toString().contains(value),
+  );
+}

--- a/test/memory_inbox_end_to_end_test.dart
+++ b/test/memory_inbox_end_to_end_test.dart
@@ -58,6 +58,28 @@ void main() {
 
     await _pumpInbox(tester, database, chatRepository, preferences, llmService);
 
+    await tester.tap(find.byKey(const Key('memory-context-settings')));
+    await tester.pumpAndSettle();
+    final contextSwitch = tester.widget<SwitchListTile>(
+      find.byKey(const Key('memory-context-switch')),
+    );
+    final semanticSwitch = tester.widget<SwitchListTile>(
+      find.byKey(const Key('memory-semantic-search-switch')),
+    );
+    expect(contextSwitch.value, isTrue);
+    expect(semanticSwitch.value, isFalse);
+    expect(
+      tester
+          .widget<DropdownButton<int>>(
+            find.byKey(const Key('memory-context-budget-menu')),
+          )
+          .value,
+      512,
+    );
+    expect(tester.takeException(), isNull);
+    await tester.tapAt(const Offset(8, 8));
+    await tester.pumpAndSettle();
+
     final autoSwitch = tester.widget<SwitchListTile>(
       find.byKey(const Key('memory-auto-extraction-switch')),
     );


### PR DESCRIPTION
## Summary
- B07: add a budgeted long-term-memory context contributor, deterministic relevance selection, per-memory inclusion/truncation traces, and a Memories used explanation sheet with source navigation.
- B08: add optional hybrid semantic reranking through the existing embedding configuration, with timeout, unavailable, and malformed-response fallback to local FTS.
- B09: cover summary, lorebook, RAG, branch/swipe regeneration, group responder scope, feature-off baseline parity, mobile layout, and Data Bank/MCP pipeline coexistence.

## Validation
- flutter test test/chat_generation_pipeline_test.dart test/chat_extension_end_to_end_test.dart test/data_bank_context_service_test.dart test/data_bank_chat_end_to_end_test.dart test/mcp_protocol_end_to_end_test.dart test/long_term_memory_context_service_test.dart test/memory_context_end_to_end_test.dart test/memory_inbox_end_to_end_test.dart (37 passed)
- flutter test (342 passed, 2 PDFium environment-gated tests skipped)
- changed-file flutter analyze: no compilation errors or new diagnostics; 63 existing diagnostics remain in chat/settings files
- git diff --check

Closes #25