### PR TITLE
[A05/A06] 稳定 Live2D 移动端渲染并加入发布许可门禁

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -2,9 +2,11 @@
 
 ## Live2D runtime
 
-NativeTavern currently integrates `flutter_live2d` 1.0.2 as a Flutter bridge
-to the Live2D Cubism Native SDK on Android and iOS. The bundled
-`native_tavern_live2d_macos` bridge uses Cubism SDK for Native 5-r.5 on macOS.
+NativeTavern currently integrates `flutter_live2d` 1.0.2 at upstream revision
+`378b5b977df47672c78e12723f93854300a87e40` as a Flutter bridge to the Live2D
+Cubism Native SDK on Android and iOS. The bundled
+`native_tavern_live2d_macos` bridge uses the same Framework source snapshot on
+macOS. The bundled Cubism Core reports runtime version 6.0.1.
 
 - `flutter_live2d` source: BSD 3-Clause License
 - Cubism Native Framework: Live2D Open Software License
@@ -48,6 +50,7 @@ The individual Sample Data Terms prohibit changes of any kind to Hiyori
 Momose's character design. Live2D sample data is licensed material, not public
 domain or CC0 content.
 
-Before a production release, NativeTavern should pin and audit the complete
-native runtime, record the Cubism SDK/Core versions, retain all required
-notices, and confirm the publisher's Release License obligations.
+Native runtime binaries, Framework sources, model assets, required notices,
+publisher Release License evidence, and mobile validation evidence are checked
+by `tool/live2d_release_gate.dart`. A distributable build must not proceed when
+that release gate fails.

--- a/config/live2d_release_manifest.json
+++ b/config/live2d_release_manifest.json
@@ -1,0 +1,117 @@
+{
+  "schemaVersion": 1,
+  "bridge": {
+    "package": "flutter_live2d",
+    "version": "1.0.2",
+    "source": "https://github.com/linh18nd/flutter_live2d",
+    "sourceRevision": "378b5b977df47672c78e12723f93854300a87e40",
+    "licenseFile": "packages/native_tavern_live2d_macos/macos/licenses/flutter_live2d-BSD-3-Clause.txt",
+    "artifactSets": [
+      {
+        "platform": "android",
+        "path": "package:flutter_live2d/android/src/main/assets/FrameworkShaders",
+        "fileCount": 36,
+        "sha256": "2130c2079aaade0352f3abb2fde51f864a32b01466ea47ee3a9f8fe859b69250"
+      }
+    ]
+  },
+  "framework": {
+    "version": "flutter_live2d-v1.0.2-snapshot",
+    "sourceRevision": "378b5b977df47672c78e12723f93854300a87e40",
+    "licenseFile": "packages/native_tavern_live2d_macos/macos/licenses/CubismFramework-LICENSE.md",
+    "artifacts": [
+      {
+        "platform": "android",
+        "path": "package:flutter_live2d/android/src/main/cpp/CubismFramework/CubismFramework.cpp",
+        "sha256": "2e4191bcbc84e8b3fc0836930d6524d0a8981e8c58f6383100e7713bc517327c"
+      },
+      {
+        "platform": "ios",
+        "path": "package:flutter_live2d/ios/CubismFramework/CubismFramework.cpp",
+        "sha256": "2e4191bcbc84e8b3fc0836930d6524d0a8981e8c58f6383100e7713bc517327c"
+      },
+      {
+        "platform": "macos",
+        "path": "packages/native_tavern_live2d_macos/macos/CubismFramework/CubismFramework.cpp",
+        "sha256": "2e4191bcbc84e8b3fc0836930d6524d0a8981e8c58f6383100e7713bc517327c"
+      }
+    ]
+  },
+  "core": {
+    "version": "6.0.1",
+    "licenseFile": "packages/native_tavern_live2d_macos/macos/licenses/CubismCore-LICENSE.md",
+    "redistributableFilesList": "packages/native_tavern_live2d_macos/macos/licenses/CubismCore-RedistributableFiles.txt",
+    "artifacts": [
+      {
+        "platform": "android-arm64-v8a",
+        "path": "package:flutter_live2d/android/libs/arm64-v8a/libLive2DCubismCore.a",
+        "sha256": "b301d59702f7ac341f6314368d406267d877da6f66458c6eb5b8337580c2742f"
+      },
+      {
+        "platform": "android-armeabi-v7a",
+        "path": "package:flutter_live2d/android/libs/armeabi-v7a/libLive2DCubismCore.a",
+        "sha256": "ae8c4526c1625893efaccb8a88e7828c480c9d499f6405a202a6a77227c7c7f1"
+      },
+      {
+        "platform": "android-x86_64",
+        "path": "package:flutter_live2d/android/libs/x86_64/libLive2DCubismCore.a",
+        "sha256": "501d28b56be1e28744d7bf697e60096e571da5d68ed867cda1bffa5f9944f707"
+      },
+      {
+        "platform": "ios-arm64",
+        "path": "package:flutter_live2d/ios/Libs/Live2DCubismCore.xcframework/ios-arm64/libLive2DCubismCore.a",
+        "sha256": "544ef4945c19d43919b861567328da6bfd95b99c2474114db403d24ed8292fcc"
+      },
+      {
+        "platform": "ios-simulator",
+        "path": "package:flutter_live2d/ios/Libs/Live2DCubismCore.xcframework/ios-arm64_x86_64-simulator/libLive2DCubismCore.a",
+        "sha256": "b4b82b2909500ec13038fb24e806ef92230e19fbf0cb05e4b2ad41d872be42ff"
+      },
+      {
+        "platform": "macos",
+        "path": "packages/native_tavern_live2d_macos/macos/Libs/libLive2DCubismCore.dylib",
+        "sha256": "d6b029354e47e81c1e063ad2de3cfc63bdd0b7bf3fe8dd079de17c2a4b43b27f"
+      }
+    ]
+  },
+  "models": [
+    {
+      "id": "hiyori_free",
+      "assetRoot": "assets/live2d/hiyori_free/",
+      "source": "https://www.live2d.com/en/learn/sample/momose-hiyori/",
+      "sourceArchiveSha256": "1e4254d561f2a151562aa67036d78e17e4ffee08869b8ce10ab6052a05e2b3a4",
+      "licenseFile": "assets/live2d/hiyori_free/SOURCE.md",
+      "releaseApproved": true,
+      "files": [
+        {"path": "ReadMe.txt", "sha256": "b0f5c39242cc257cbf53d1893d34c241ff221cb7304417910be50ba721fd909d"},
+        {"path": "SOURCE.md", "sha256": "1d19e89a7114e6997bc8966ee1c2722cd8208cd56a0417b5bf3c269d54a1d524"},
+        {"path": "hiyori_free_t08.2048/texture_00.png", "sha256": "5d4183d2f1eb1c4a08e45f91ea968b29694fb916945e75f9bc1099aaeabc1a4f"},
+        {"path": "hiyori_free_t08.cdi3.json", "sha256": "dcdad6a9b6cb91fda95f0418317495cdb47e4d704206a86a85d4d89957903a46"},
+        {"path": "hiyori_free_t08.moc3", "sha256": "86d4417140ef036b5ce155d99f938c49e1ed66ee398e52f6d87fd122770345f1"},
+        {"path": "hiyori_free_t08.model3.json", "sha256": "936ada713af7ac6842cd38f614a77ed0ae288e8ba1f31d1ffae4d745cdda6e38"},
+        {"path": "hiyori_free_t08.physics3.json", "sha256": "b94886e2a3b6868a11ee38b2c2ceabcce6864f14ea444b353a5a007f5d337bb6"},
+        {"path": "motion/hiyori_m01.motion3.json", "sha256": "c2a280a0fe30f82f0c4fcc8140bd674ba7d6627f479e3326dac7f1464fdc3b39"},
+        {"path": "motion/hiyori_m02.motion3.json", "sha256": "a8638ad57ff255b7a6f5baa81e937ea5c072fd0cf12b048df521dabb0353f0f1"},
+        {"path": "motion/hiyori_m03.motion3.json", "sha256": "0b418a08fd58ba6922563f7068eaf68dca1c3f16eda9a9c98c5b2cd8d21f3ee1"},
+        {"path": "motion/hiyori_m04.motion3.json", "sha256": "2f2a3c9a4a0b1bf7aba42f3dd0548c644db41f583c9f99f92e452953d9af67a0"},
+        {"path": "motion/hiyori_m05.motion3.json", "sha256": "8806e09de13a01b66d421dfdf9cbddb59360f6a28d64aa5c4d07b11bae2a4ef0"},
+        {"path": "motion/hiyori_m06.motion3.json", "sha256": "ddae4c8d820decb9abb41de85a3b7fb24ed57a57275222e4be8a940d4d4e72fb"},
+        {"path": "motion/hiyori_m07.motion3.json", "sha256": "1006ab62ef4ad8470a1d0fbd3d97fede62dd1bc2c426889a711b448be922acb2"},
+        {"path": "motion/hiyori_m08.motion3.json", "sha256": "a8618287946ba791300b6d6e002a7f81ed7b0734d725826abe2506472ea6fc00"}
+      ]
+    }
+  ],
+  "requiredNotices": [
+    "THIRD_PARTY_NOTICES.md",
+    "packages/native_tavern_live2d_macos/macos/licenses/CubismFramework-NOTICE.md"
+  ],
+  "releaseEvidence": {
+    "releaseLicenseDecision": "pending",
+    "releaseLicenseEvidence": null,
+    "mobileValidation": {
+      "minimumCharacterSwitches": 20,
+      "android": {"status": "pending", "evidence": null},
+      "ios": {"status": "pending", "evidence": null}
+    }
+  }
+}

--- a/docs/live2d-release-gate.md
+++ b/docs/live2d-release-gate.md
@@ -1,0 +1,63 @@
+# Live2D release gate
+
+NativeTavern treats Live2D runtime code, proprietary binaries, and model data
+as separately licensed inputs. A development build may use audited inputs while
+a distributable build also requires publisher and physical-device evidence.
+
+## Pinned inputs
+
+- Mobile bridge: `flutter_live2d` 1.0.2 from an immutable upstream Git
+  revision. The pub.dev 1.0.2 archive is not used because it omits the Android
+  Framework shaders; the complete 36-file shader set is pinned by a tree
+  SHA-256 in `config/live2d_release_manifest.json`.
+- Cubism Core: runtime version 6.0.1. Every Android, iOS, simulator, and macOS
+  binary is pinned separately by SHA-256.
+- Cubism Framework: the source snapshot shipped by `flutter_live2d` v1.0.2.
+  Android, iOS, and macOS sentinel files must remain byte-identical.
+- Hiyori Momose FREE: only the runtime subset is bundled. Every file is listed
+  and hashed; an unlisted file under the asset root fails the gate.
+
+Run the provenance and integrity audit during development:
+
+```sh
+dart run tool/live2d_release_gate.dart --development
+```
+
+Run the stricter gate before producing a distributable build:
+
+```sh
+dart run tool/live2d_release_gate.dart
+```
+
+The release command fails until both of these requirements are recorded in the
+manifest:
+
+1. The publisher records `not_required` or `obtained` for the Cubism SDK
+   Release License decision and links the internal legal evidence.
+2. Android and iOS physical-device runs are marked `verified` and link their
+   captured test reports.
+
+Imported user models remain application data and are never copied into a
+release bundle. Any new bundled model directory must be added to the manifest
+with its source, license, release decision, complete file inventory, and
+SHA-256 values. Merely adding a directory to `pubspec.yaml` fails the gate.
+
+## Mobile evidence protocol
+
+Use a release-mode build on at least one supported physical Android device and
+one supported physical iPhone or iPad. Record device, OS, build commit, start
+and end measurements, and attach profiler exports. Each report must cover:
+
+- transparent compositing over light and dark chat backgrounds;
+- stage clipping at all edges and the supported scale range;
+- one-finger chat scrolling, two-finger model transform, tap, and double-tap;
+- at least 20 character transitions, followed by a second 20-transition pass;
+- background rendering stopping and resuming without a blank or frozen view;
+- 30 minutes of idle animation plus 10 minutes of repeated interactions;
+- frame timing, resident memory, CPU, energy/battery, and thermal state;
+- final memory returning within 25 MiB or 10 percent of the post-warmup value,
+  whichever is larger, with no growth between the two transition passes.
+
+Do not mark a platform `verified` from an emulator or simulator run. Those runs
+are functional regression evidence only and cannot establish power, thermal,
+or physical GPU baselines.

--- a/integration_test/live2d_mobile_stability_test.dart
+++ b/integration_test/live2d_mobile_stability_test.dart
@@ -1,0 +1,147 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:native_tavern/data/models/live2d.dart';
+import 'package:native_tavern/presentation/widgets/live2d/live2d_character_view.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'Live2D survives lifecycle changes and 20 character switches',
+    (tester) async {
+      final harnessKey = GlobalKey<_Live2DStabilityHarnessState>();
+      await tester.pumpWidget(_Live2DStabilityHarness(key: harnessKey));
+      await _waitUntil(
+          tester, () => harnessKey.currentState!.controller.isReady);
+
+      expect(find.byType(ClipRect), findsOneWidget);
+      expect(
+        find.byWidgetPredicate(
+          (widget) => widget is Opacity && widget.opacity == 0.72,
+        ),
+        findsOneWidget,
+      );
+
+      final stage = find.byType(Live2DCharacterView);
+      final center = tester.getCenter(stage);
+      await tester.tapAt(center);
+      await tester.pump();
+      await tester.tapAt(center);
+      await tester.pump(const Duration(milliseconds: 40));
+      await tester.tapAt(center);
+      await tester.pump();
+      expect(tester.takeException(), isNull);
+
+      tester.binding.handleAppLifecycleStateChanged(
+        AppLifecycleState.paused,
+      );
+      await tester.pump();
+      await _waitUntil(
+        tester,
+        () => harnessKey.currentState!.controller.isRenderingPaused,
+      );
+      tester.binding.handleAppLifecycleStateChanged(
+        AppLifecycleState.resumed,
+      );
+      await tester.pump();
+      await _waitUntil(
+        tester,
+        () => !harnessKey.currentState!.controller.isRenderingPaused,
+      );
+      expect(harnessKey.currentState!.controller.isReady, isTrue);
+
+      for (var index = 0; index < 20; index++) {
+        final modelId = harnessKey.currentState!.switchCharacter();
+        await tester.pump();
+        await _waitUntil(
+          tester,
+          () =>
+              harnessKey.currentState!.controller.isReady &&
+              harnessKey.currentState!.controller.loadedModelId == modelId,
+        );
+        expect(tester.takeException(), isNull);
+      }
+
+      final finalController = harnessKey.currentState!.controller;
+      harnessKey.currentState!.showTextOnly();
+      await tester.pumpAndSettle();
+      expect(find.text('Text-only chat remains available'), findsOneWidget);
+      expect(finalController.isAttached, isFalse);
+      expect(tester.takeException(), isNull);
+    },
+    timeout: const Timeout(Duration(minutes: 5)),
+  );
+}
+
+Future<void> _waitUntil(
+  WidgetTester tester,
+  bool Function() predicate,
+) async {
+  final deadline = DateTime.now().add(const Duration(seconds: 20));
+  while (!predicate()) {
+    if (DateTime.now().isAfter(deadline)) {
+      fail('Timed out waiting for the Live2D native view state.');
+    }
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+    await tester.pump();
+  }
+}
+
+class _Live2DStabilityHarness extends StatefulWidget {
+  const _Live2DStabilityHarness({super.key});
+
+  @override
+  State<_Live2DStabilityHarness> createState() =>
+      _Live2DStabilityHarnessState();
+}
+
+class _Live2DStabilityHarnessState extends State<_Live2DStabilityHarness> {
+  final Live2DCharacterController controller = Live2DCharacterController();
+  var generation = 0;
+  var textOnly = false;
+
+  String switchCharacter() {
+    setState(() {
+      generation++;
+    });
+    return 'hiyori_free_$generation';
+  }
+
+  void showTextOnly() {
+    setState(() {
+      textOnly = true;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        body: ColoredBox(
+          color: const Color(0xfff4f0e8),
+          child: textOnly
+              ? const Center(child: Text('Text-only chat remains available'))
+              : Stack(
+                  fit: StackFit.expand,
+                  children: [
+                    const Center(child: Text('Transparent chat background')),
+                    Live2DCharacterView(
+                      config: Live2DConfig(
+                        modelId: 'hiyori_free_$generation',
+                        displayName: 'Hiyori Momose (Official Sample)',
+                        modelDirectory: 'assets/live2d/hiyori_free/',
+                        modelFileName: 'hiyori_free_t08.model3.json',
+                        opacity: 0.72,
+                      ),
+                      controller: controller,
+                      interactive: true,
+                      showStatus: true,
+                    ),
+                  ],
+                ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/domain/services/live2d_render_lifecycle.dart
+++ b/lib/domain/services/live2d_render_lifecycle.dart
@@ -1,0 +1,80 @@
+typedef Live2DRenderingPauseApplier = Future<void> Function(bool paused);
+
+/// Serializes app lifecycle changes before they reach a native render loop.
+///
+/// A platform view can attach after the app has already entered the
+/// background, and pause/resume platform calls can complete out of order.
+/// This coordinator preserves the latest requested state across both cases.
+class Live2DRenderingLifecycle {
+  final Live2DRenderingPauseApplier _applyPaused;
+
+  Future<void> _tail = Future<void>.value();
+  bool _attached = false;
+  bool _disposed = false;
+  bool _desiredPaused;
+  bool? _appliedPaused;
+  int _attachmentGeneration = 0;
+  Object? _lastError;
+
+  Live2DRenderingLifecycle({
+    required Live2DRenderingPauseApplier applyPaused,
+    bool initialPaused = false,
+  })  : _applyPaused = applyPaused,
+        _desiredPaused = initialPaused;
+
+  bool get isAttached => _attached;
+  bool get desiredPaused => _desiredPaused;
+  bool? get appliedPaused => _appliedPaused;
+  Object? get lastError => _lastError;
+
+  Future<void> setAttached(bool attached) {
+    if (_disposed || _attached == attached) return _tail;
+    _attached = attached;
+    _appliedPaused = null;
+    _attachmentGeneration++;
+    return attached ? _scheduleSynchronization() : Future<void>.value();
+  }
+
+  Future<void> setAppActive(bool active) {
+    if (_disposed) return Future<void>.value();
+    _desiredPaused = !active;
+    return _scheduleSynchronization();
+  }
+
+  Future<void> _scheduleSynchronization() {
+    final operation = _tail.then<void>(
+      (_) => _synchronize(),
+      onError: (_, __) => _synchronize(),
+    );
+    _tail = operation;
+    return operation;
+  }
+
+  Future<void> _synchronize() async {
+    if (_disposed || !_attached || _appliedPaused == _desiredPaused) return;
+
+    final target = _desiredPaused;
+    final attachmentGeneration = _attachmentGeneration;
+    try {
+      await _applyPaused(target);
+    } catch (error, stackTrace) {
+      _lastError = error;
+      Error.throwWithStackTrace(error, stackTrace);
+    }
+
+    if (_disposed ||
+        !_attached ||
+        attachmentGeneration != _attachmentGeneration) {
+      return;
+    }
+    _appliedPaused = target;
+    _lastError = null;
+  }
+
+  void dispose() {
+    _disposed = true;
+    _attached = false;
+    _appliedPaused = null;
+    _attachmentGeneration++;
+  }
+}

--- a/lib/presentation/widgets/live2d/live2d_character_view.dart
+++ b/lib/presentation/widgets/live2d/live2d_character_view.dart
@@ -11,6 +11,7 @@ import 'package:native_tavern/data/models/live2d.dart';
 import 'package:native_tavern/domain/services/emotion_detection_service.dart';
 import 'package:native_tavern/domain/services/live2d_action_orchestrator.dart';
 import 'package:native_tavern/domain/services/live2d_hit_test_service.dart';
+import 'package:native_tavern/domain/services/live2d_render_lifecycle.dart';
 import 'package:native_tavern/domain/services/live2d_service.dart';
 import 'package:native_tavern/domain/services/live2d_tts_playback_coordinator.dart';
 import 'package:native_tavern/domain/services/tts_service.dart';
@@ -150,16 +151,23 @@ class _MacOSLive2DController implements _NativeLive2DController {
 class Live2DCharacterController {
   _NativeLive2DController? _nativeController;
   Live2DActionOrchestrator? _orchestrator;
+  String? _loadedModelId;
   String _lipSyncParameter = 'ParamMouthOpenY';
 
+  bool get isAttached => _nativeController?.value.isAttached ?? false;
   bool get isReady => _nativeController?.value.isLoaded ?? false;
+  bool get isRenderingPaused =>
+      _nativeController?.value.isRenderingPaused ?? false;
+  String? get loadedModelId => _loadedModelId;
 
   void _attach(
     _NativeLive2DController controller,
+    String modelId,
     String lipSyncParameter,
     Live2DActionOrchestrator orchestrator,
   ) {
     _nativeController = controller;
+    _loadedModelId = modelId;
     _lipSyncParameter = lipSyncParameter;
     _orchestrator = orchestrator;
   }
@@ -167,6 +175,7 @@ class Live2DCharacterController {
   void _detach(_NativeLive2DController controller) {
     if (identical(_nativeController, controller)) {
       _nativeController = null;
+      _loadedModelId = null;
       _orchestrator = null;
     }
   }
@@ -245,6 +254,7 @@ class Live2DCharacterView extends StatefulWidget {
 class _Live2DCharacterViewState extends State<Live2DCharacterView>
     with WidgetsBindingObserver {
   late final _NativeLive2DController _nativeController;
+  late final Live2DRenderingLifecycle _renderingLifecycle;
   late Live2DActionOrchestrator _orchestrator;
   late Live2DConfig _actionConfig;
   final Live2DHitTestService _hitTestService = const Live2DHitTestService();
@@ -271,6 +281,12 @@ class _Live2DCharacterViewState extends State<Live2DCharacterView>
     super.initState();
     _nativeController =
         Platform.isMacOS ? _MacOSLive2DController() : _MobileLive2DController();
+    final appLifecycleState = WidgetsBinding.instance.lifecycleState;
+    _renderingLifecycle = Live2DRenderingLifecycle(
+      applyPaused: _nativeController.setRenderingPaused,
+      initialPaused: appLifecycleState != null &&
+          appLifecycleState != AppLifecycleState.resumed,
+    );
     _actionConfig = widget.config;
     _orchestrator = _createOrchestrator(_actionConfig);
     _applyConfigTransform(widget.config);
@@ -316,9 +332,11 @@ class _Live2DCharacterViewState extends State<Live2DCharacterView>
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
-    if (!_nativeController.value.isAttached) return;
-    final paused = state != AppLifecycleState.resumed;
-    unawaited(_nativeController.setRenderingPaused(paused).catchError((_) {}));
+    unawaited(
+      _renderingLifecycle
+          .setAppActive(state == AppLifecycleState.resumed)
+          .catchError((_) {}),
+    );
   }
 
   @override
@@ -340,6 +358,20 @@ class _Live2DCharacterViewState extends State<Live2DCharacterView>
     try {
       await _nativeController.whenAttached;
       if (!mounted || generation != _loadGeneration) return;
+      if (Platform.isAndroid && !_renderingLifecycle.isAttached) {
+        // flutter_live2d reports its platform-view id before Android attaches
+        // the TextureView surface. Commands sent in that gap are discarded by
+        // the render hub, so let the platform view composite before loading.
+        await WidgetsBinding.instance.endOfFrame;
+        await WidgetsBinding.instance.endOfFrame;
+      }
+      if (!mounted || generation != _loadGeneration) return;
+      try {
+        await _renderingLifecycle.setAttached(true);
+      } catch (_) {
+        // A lifecycle command can be retried on the next app state change.
+      }
+      if (!mounted || generation != _loadGeneration) return;
       final actionConfig = await _discoverActionConfig();
       if (!mounted || generation != _loadGeneration) return;
       final modelDirectory = await _resolveModelDirectory();
@@ -359,6 +391,7 @@ class _Live2DCharacterViewState extends State<Live2DCharacterView>
       _replaceOrchestrator(actionConfig);
       widget.controller?._attach(
         _nativeController,
+        widget.config.modelId,
         actionConfig.lipSyncParameter,
         _orchestrator,
       );
@@ -646,6 +679,7 @@ class _Live2DCharacterViewState extends State<Live2DCharacterView>
     WidgetsBinding.instance.removeObserver(this);
     widget.controller?._detach(_nativeController);
     _orchestrator.dispose();
+    _renderingLifecycle.dispose();
     unawaited(
       _setMouthOpen(0).whenComplete(_nativeController.dispose),
     );

--- a/packages/native_tavern_live2d_macos/README.md
+++ b/packages/native_tavern_live2d_macos/README.md
@@ -16,6 +16,7 @@ tracked by this repository. Before building the macOS app:
 
 The bundled `macos/Libs/libLive2DCubismCore.dylib` is listed by Live2D as a
 redistributable file. Applicable licenses and notices are retained under
-`macos/licenses/`.
+`macos/licenses/`. It reports Cubism Core runtime version 6.0.1 and its digest
+is pinned by the repository Live2D release manifest.
 
 Official download: https://www.live2d.com/en/sdk/download/native/

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -422,6 +422,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.4.1"
+  flutter_driver:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_inappwebview:
     dependency: "direct main"
     description:
@@ -505,10 +510,11 @@ packages:
   flutter_live2d:
     dependency: "direct main"
     description:
-      name: flutter_live2d
-      sha256: "0de86420758951c3be961ea05b0ec8e96f9e267355008ef0f7985ddc5fcd5d6d"
-      url: "https://pub.dev"
-    source: hosted
+      path: "."
+      ref: "378b5b977df47672c78e12723f93854300a87e40"
+      resolved-ref: "378b5b977df47672c78e12723f93854300a87e40"
+      url: "https://github.com/linh18nd/flutter_live2d.git"
+    source: git
     version: "1.0.2"
   flutter_localizations:
     dependency: "direct main"
@@ -629,6 +635,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
+  fuchsia_remote_debug_protocol:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   glob:
     dependency: transitive
     description:
@@ -829,6 +840,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.2"
+  integration_test:
+    dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   intl:
     dependency: "direct main"
     description:
@@ -1164,6 +1180,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.2"
+  process:
+    dependency: transitive
+    description:
+      name: process
+      sha256: c6248e4526673988586e8c00bb22a49210c258dc91df5227d5da9748ecf79744
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.5"
   pub_semver:
     dependency: transitive
     description:
@@ -1545,6 +1569,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  sync_http:
+    dependency: transitive
+    description:
+      name: sync_http
+      sha256: "7f0cd72eca000d2e026bcd6f990b81d0ca06022ef4e32fb257b30d3d1014a961"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1"
   synchronized:
     dependency: transitive
     description:
@@ -1705,6 +1737,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  webdriver:
+    dependency: transitive
+    description:
+      name: webdriver
+      sha256: "2f3a14ca026957870cfd9c635b83507e0e51d8091568e90129fbf805aba7cade"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   win32:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -68,8 +68,11 @@ dependencies:
   flutter_markdown: ^0.6.18
   flutter_inappwebview: ^6.0.0
   shimmer: ^3.0.0
-  # Community bridge to the official Cubism Native SDK; pin until vendored.
-  flutter_live2d: 1.0.2
+  # Pin the upstream tree: the pub.dev 1.0.2 archive omits Android shaders.
+  flutter_live2d:
+    git:
+      url: https://github.com/linh18nd/flutter_live2d.git
+      ref: 378b5b977df47672c78e12723f93854300a87e40
   native_tavern_live2d_macos:
     path: packages/native_tavern_live2d_macos
   share_plus: ^12.0.1
@@ -90,6 +93,8 @@ dependencies:
 
 dev_dependencies:
   flutter_test:
+    sdk: flutter
+  integration_test:
     sdk: flutter
   flutter_lints: ^3.0.1
   sqlite3: ^2.9.4

--- a/test/live2d_release_gate_test.dart
+++ b/test/live2d_release_gate_test.dart
@@ -1,0 +1,103 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+
+import '../tool/live2d_release_gate.dart';
+
+void main() {
+  final repositoryRoot = Directory.current;
+
+  test('development audit verifies every pinned runtime and model artifact',
+      () async {
+    final report = await auditLive2DRelease(
+      repositoryRoot: repositoryRoot,
+      mode: Live2DGateMode.development,
+    );
+
+    expect(report.errors, isEmpty);
+    expect(report.checkedArtifacts, 61);
+  });
+
+  test('release is blocked until legal and physical-device evidence exists',
+      () async {
+    final report = await auditLive2DRelease(
+      repositoryRoot: repositoryRoot,
+      mode: Live2DGateMode.release,
+    );
+
+    expect(
+      report.errors,
+      contains(
+        'Cubism SDK Release License decision is pending; release is blocked.',
+      ),
+    );
+    expect(
+      report.errors,
+      contains('android physical-device validation is not verified.'),
+    );
+    expect(
+      report.errors,
+      contains('ios physical-device validation is not verified.'),
+    );
+  });
+
+  test('development audit rejects a modified tracked artifact', () async {
+    final manifest = jsonDecode(
+      File('config/live2d_release_manifest.json').readAsStringSync(),
+    ) as Map<String, dynamic>;
+    final core = manifest['core'] as Map<String, dynamic>;
+    final artifacts = core['artifacts'] as List<dynamic>;
+    final macOSCore = artifacts.last as Map<String, dynamic>;
+    macOSCore['sha256'] = List.filled(64, '0').join();
+
+    final tempDirectory = Directory.systemTemp.createTempSync('live2d_gate');
+    addTearDown(() => tempDirectory.deleteSync(recursive: true));
+    final manifestFile = File(p.join(tempDirectory.path, 'manifest.json'))
+      ..writeAsStringSync(jsonEncode(manifest));
+
+    final report = await auditLive2DRelease(
+      repositoryRoot: repositoryRoot,
+      mode: Live2DGateMode.development,
+      manifestFile: manifestFile,
+    );
+
+    expect(
+      report.errors,
+      contains(
+        'Live2D artifact SHA-256 mismatch: '
+        'packages/native_tavern_live2d_macos/macos/Libs/'
+        'libLive2DCubismCore.dylib',
+      ),
+    );
+  });
+
+  test('development audit rejects an unpinned bridge revision', () async {
+    final manifest = jsonDecode(
+      File('config/live2d_release_manifest.json').readAsStringSync(),
+    ) as Map<String, dynamic>;
+    final bridge = manifest['bridge'] as Map<String, dynamic>;
+    bridge['sourceRevision'] = List.filled(40, '0').join();
+
+    final tempDirectory = Directory.systemTemp.createTempSync('live2d_gate');
+    addTearDown(() => tempDirectory.deleteSync(recursive: true));
+    final manifestFile = File(p.join(tempDirectory.path, 'manifest.json'))
+      ..writeAsStringSync(jsonEncode(manifest));
+
+    final report = await auditLive2DRelease(
+      repositoryRoot: repositoryRoot,
+      mode: Live2DGateMode.development,
+      manifestFile: manifestFile,
+    );
+
+    expect(
+      report.errors,
+      contains(
+        'Live2D bridge revision mismatch: manifest '
+        '${List.filled(40, '0').join()}, lock '
+        '378b5b977df47672c78e12723f93854300a87e40.',
+      ),
+    );
+  });
+}

--- a/test/live2d_render_lifecycle_test.dart
+++ b/test/live2d_render_lifecycle_test.dart
@@ -1,0 +1,76 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:native_tavern/domain/services/live2d_render_lifecycle.dart';
+
+void main() {
+  test('applies a background state that arrived before native attachment',
+      () async {
+    final applied = <bool>[];
+    final lifecycle = Live2DRenderingLifecycle(
+      initialPaused: true,
+      applyPaused: (paused) async => applied.add(paused),
+    );
+
+    expect(applied, isEmpty);
+    await lifecycle.setAttached(true);
+
+    expect(applied, [true]);
+    expect(lifecycle.appliedPaused, isTrue);
+  });
+
+  test('serializes rapid lifecycle changes and preserves the latest state',
+      () async {
+    final firstCall = Completer<void>();
+    final applied = <bool>[];
+    final lifecycle = Live2DRenderingLifecycle(
+      applyPaused: (paused) async {
+        applied.add(paused);
+        if (applied.length == 1) await firstCall.future;
+      },
+    );
+
+    final attach = lifecycle.setAttached(true);
+    final pause = lifecycle.setAppActive(false);
+    final resume = lifecycle.setAppActive(true);
+    firstCall.complete();
+    await Future.wait([attach, pause, resume]);
+
+    expect(applied.last, isFalse);
+    expect(lifecycle.desiredPaused, isFalse);
+    expect(lifecycle.appliedPaused, isFalse);
+  });
+
+  test('detachment invalidates an in-flight native result', () async {
+    final call = Completer<void>();
+    final lifecycle = Live2DRenderingLifecycle(
+      applyPaused: (_) => call.future,
+    );
+
+    final attach = lifecycle.setAttached(true);
+    await lifecycle.setAttached(false);
+    call.complete();
+    await attach;
+
+    expect(lifecycle.isAttached, isFalse);
+    expect(lifecycle.appliedPaused, isNull);
+  });
+
+  test('a failed native call can be retried', () async {
+    var attempts = 0;
+    final lifecycle = Live2DRenderingLifecycle(
+      applyPaused: (_) async {
+        attempts++;
+        if (attempts == 1) throw StateError('native view unavailable');
+      },
+    );
+
+    await expectLater(lifecycle.setAttached(true), throwsStateError);
+    expect(lifecycle.lastError, isA<StateError>());
+
+    await lifecycle.setAppActive(false);
+    expect(attempts, 2);
+    expect(lifecycle.appliedPaused, isTrue);
+    expect(lifecycle.lastError, isNull);
+  });
+}

--- a/tool/live2d_release_gate.dart
+++ b/tool/live2d_release_gate.dart
@@ -1,0 +1,472 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:path/path.dart' as p;
+import 'package:yaml/yaml.dart';
+
+enum Live2DGateMode { development, release }
+
+class Live2DGateReport {
+  final List<String> errors;
+  final int checkedArtifacts;
+
+  const Live2DGateReport({
+    required this.errors,
+    required this.checkedArtifacts,
+  });
+
+  bool get passed => errors.isEmpty;
+}
+
+Future<Live2DGateReport> auditLive2DRelease({
+  required Directory repositoryRoot,
+  Live2DGateMode mode = Live2DGateMode.release,
+  File? manifestFile,
+}) async {
+  final errors = <String>[];
+  var checkedArtifacts = 0;
+  final root = repositoryRoot.absolute;
+  final manifest = await _readJsonMap(
+    manifestFile ??
+        File(p.join(root.path, 'config/live2d_release_manifest.json')),
+    errors,
+  );
+  if (manifest == null) {
+    return Live2DGateReport(errors: errors, checkedArtifacts: 0);
+  }
+  if (manifest['schemaVersion'] != 1) {
+    errors.add('Unsupported Live2D manifest schemaVersion.');
+  }
+
+  final packageRoot = await _resolvePackageRoot(root, 'flutter_live2d', errors);
+  final bridge = _map(manifest['bridge'], 'bridge', errors);
+  if (bridge != null) {
+    await _verifyBridge(root, packageRoot, bridge, errors);
+    checkedArtifacts++;
+    for (final value
+        in _list(bridge['artifactSets'], 'bridge.artifactSets', errors)) {
+      final artifactSet = _map(value, 'bridge artifact set', errors);
+      if (artifactSet == null) continue;
+      checkedArtifacts += await _verifyArtifactSet(
+        root,
+        packageRoot,
+        artifactSet,
+        errors,
+      );
+    }
+  }
+
+  for (final sectionName in ['framework', 'core']) {
+    final section = _map(manifest[sectionName], sectionName, errors);
+    if (section == null) continue;
+    _requireExistingFile(
+        root, section['licenseFile'], '$sectionName license', errors);
+    if (sectionName == 'core') {
+      _requireExistingFile(
+        root,
+        section['redistributableFilesList'],
+        'Cubism Core redistributable files list',
+        errors,
+      );
+    }
+    final artifacts =
+        _list(section['artifacts'], '$sectionName.artifacts', errors);
+    for (final value in artifacts) {
+      final artifact = _map(value, '$sectionName artifact', errors);
+      if (artifact == null) continue;
+      await _verifyArtifact(root, packageRoot, artifact, errors);
+      checkedArtifacts++;
+    }
+  }
+
+  final reviewedAssetRoots = <String>{};
+  final models = _list(manifest['models'], 'models', errors);
+  for (final value in models) {
+    final model = _map(value, 'model', errors);
+    if (model == null) continue;
+    final assetRoot = model['assetRoot'];
+    if (assetRoot is! String || assetRoot.isEmpty) {
+      errors.add('A Live2D model is missing assetRoot.');
+      continue;
+    }
+    reviewedAssetRoots.add(_withTrailingSlash(assetRoot));
+    _requireExistingFile(root, model['licenseFile'], 'model license', errors);
+    final declaredFiles = <String>{};
+    final files = _list(model['files'], 'model.files', errors);
+    for (final value in files) {
+      final artifact = _map(value, 'model artifact', errors);
+      if (artifact == null) continue;
+      final relativePath = artifact['path'];
+      if (relativePath is String) {
+        declaredFiles.add(p.posix.normalize(relativePath));
+      }
+      await _verifyArtifact(
+        root,
+        packageRoot,
+        {
+          ...artifact,
+          'path': p.posix.join(assetRoot, relativePath?.toString() ?? ''),
+        },
+        errors,
+      );
+      checkedArtifacts++;
+    }
+    _verifyModelInventory(root, assetRoot, declaredFiles, errors);
+    if (mode == Live2DGateMode.release && model['releaseApproved'] != true) {
+      errors.add('Live2D model ${model['id']} is not approved for release.');
+    }
+  }
+
+  await _verifyPubspecAssets(root, reviewedAssetRoots, errors);
+  for (final notice in _list(
+    manifest['requiredNotices'],
+    'requiredNotices',
+    errors,
+  )) {
+    _requireExistingFile(root, notice, 'required notice', errors);
+  }
+
+  if (mode == Live2DGateMode.release) {
+    _verifyReleaseEvidence(manifest['releaseEvidence'], errors);
+  }
+  return Live2DGateReport(
+    errors: List.unmodifiable(errors),
+    checkedArtifacts: checkedArtifacts,
+  );
+}
+
+Future<void> _verifyBridge(
+  Directory root,
+  Directory? packageRoot,
+  Map<String, dynamic> bridge,
+  List<String> errors,
+) async {
+  final lockFile = File(p.join(root.path, 'pubspec.lock'));
+  if (!lockFile.existsSync()) {
+    errors.add('pubspec.lock is missing.');
+    return;
+  }
+  final lock = loadYaml(lockFile.readAsStringSync());
+  final packageName = bridge['package'];
+  final locked = lock is YamlMap && lock['packages'] is YamlMap
+      ? (lock['packages'] as YamlMap)[packageName]
+      : null;
+  if (locked is! YamlMap) {
+    errors.add('Live2D bridge $packageName is not present in pubspec.lock.');
+    return;
+  }
+  if (locked['version'] != bridge['version']) {
+    errors.add(
+      'Live2D bridge version mismatch: manifest ${bridge['version']}, '
+      'lock ${locked['version']}.',
+    );
+  }
+  final description = locked['description'];
+  if (locked['source'] != 'git' || description is! YamlMap) {
+    errors.add('Live2D bridge must resolve from the pinned Git source.');
+  } else {
+    final lockedRevision = description['resolved-ref'];
+    if (lockedRevision != bridge['sourceRevision']) {
+      errors.add(
+        'Live2D bridge revision mismatch: manifest '
+        '${bridge['sourceRevision']}, lock $lockedRevision.',
+      );
+    }
+    final lockedUrl = description['url'];
+    if (lockedUrl is! String ||
+        _normalizeGitUrl(lockedUrl) != _normalizeGitUrl(bridge['source'])) {
+      errors.add('Live2D bridge Git source does not match the manifest.');
+    }
+  }
+  _requireExistingFile(root, bridge['licenseFile'], 'bridge license', errors);
+
+  if (packageRoot != null) {
+    final packagePubspec = File(p.join(packageRoot.path, 'pubspec.yaml'));
+    if (!packagePubspec.existsSync()) {
+      errors.add('Resolved flutter_live2d package has no pubspec.yaml.');
+    } else {
+      final yaml = loadYaml(packagePubspec.readAsStringSync());
+      if (yaml is! YamlMap || yaml['version'] != bridge['version']) {
+        errors.add('Resolved flutter_live2d package version is not pinned.');
+      }
+    }
+  }
+}
+
+Future<int> _verifyArtifactSet(
+  Directory root,
+  Directory? packageRoot,
+  Map<String, dynamic> artifactSet,
+  List<String> errors,
+) async {
+  final pathValue = artifactSet['path'];
+  final expectedCount = artifactSet['fileCount'];
+  final expectedSha = artifactSet['sha256'];
+  if (pathValue is! String ||
+      expectedCount is! int ||
+      expectedCount < 1 ||
+      expectedSha is! String) {
+    errors.add('A Live2D artifact set is missing path, fileCount, or sha256.');
+    return 0;
+  }
+
+  final resolved = _resolveArtifact(root, packageRoot, pathValue, errors);
+  if (resolved == null) return 0;
+  final directory = Directory(resolved.path);
+  if (!directory.existsSync()) {
+    errors.add('Live2D artifact set is missing: $pathValue');
+    return 0;
+  }
+
+  final files = directory
+      .listSync(recursive: true, followLinks: false)
+      .whereType<File>()
+      .toList()
+    ..sort((a, b) {
+      final aPath = p.posix.normalize(p.relative(a.path, from: directory.path));
+      final bPath = p.posix.normalize(p.relative(b.path, from: directory.path));
+      return aPath.compareTo(bPath);
+    });
+  if (files.length != expectedCount) {
+    errors.add(
+      'Live2D artifact set file count mismatch: $pathValue '
+      '(manifest $expectedCount, actual ${files.length})',
+    );
+  }
+
+  final inventory = StringBuffer();
+  for (final file in files) {
+    final relativePath =
+        p.posix.normalize(p.relative(file.path, from: directory.path));
+    final fileSha = sha256.convert(file.readAsBytesSync());
+    inventory.writeln('$relativePath:$fileSha');
+  }
+  final actualSha =
+      sha256.convert(utf8.encode(inventory.toString())).toString();
+  if (actualSha != expectedSha) {
+    errors.add('Live2D artifact set SHA-256 mismatch: $pathValue');
+  }
+  return files.length;
+}
+
+Future<void> _verifyArtifact(
+  Directory root,
+  Directory? packageRoot,
+  Map<String, dynamic> artifact,
+  List<String> errors,
+) async {
+  final pathValue = artifact['path'];
+  final expectedSha = artifact['sha256'];
+  if (pathValue is! String || expectedSha is! String) {
+    errors.add('A Live2D artifact is missing path or sha256.');
+    return;
+  }
+  final file = _resolveArtifact(root, packageRoot, pathValue, errors);
+  if (file == null || !file.existsSync()) {
+    errors.add('Live2D artifact is missing: $pathValue');
+    return;
+  }
+  final actualSha = sha256.convert(file.readAsBytesSync()).toString();
+  if (actualSha != expectedSha) {
+    errors.add('Live2D artifact SHA-256 mismatch: $pathValue');
+  }
+}
+
+File? _resolveArtifact(
+  Directory root,
+  Directory? packageRoot,
+  String pathValue,
+  List<String> errors,
+) {
+  const prefix = 'package:flutter_live2d/';
+  if (pathValue.startsWith(prefix)) {
+    if (packageRoot == null) return null;
+    return File(p.join(packageRoot.path, pathValue.substring(prefix.length)));
+  }
+  final normalized = p.normalize(p.join(root.path, pathValue));
+  if (!p.isWithin(root.path, normalized)) {
+    errors.add('Live2D artifact escapes the repository: $pathValue');
+    return null;
+  }
+  return File(normalized);
+}
+
+void _verifyModelInventory(
+  Directory root,
+  String assetRoot,
+  Set<String> declaredFiles,
+  List<String> errors,
+) {
+  final directory = Directory(p.join(root.path, assetRoot));
+  if (!directory.existsSync()) {
+    errors.add('Live2D model directory is missing: $assetRoot');
+    return;
+  }
+  final actualFiles = directory
+      .listSync(recursive: true, followLinks: false)
+      .whereType<File>()
+      .map((file) =>
+          p.posix.normalize(p.relative(file.path, from: directory.path)))
+      .toSet();
+  for (final pathValue in actualFiles.difference(declaredFiles)) {
+    errors.add('Unreviewed Live2D model file: $assetRoot$pathValue');
+  }
+  for (final pathValue in declaredFiles.difference(actualFiles)) {
+    errors.add('Declared Live2D model file is missing: $assetRoot$pathValue');
+  }
+}
+
+Future<void> _verifyPubspecAssets(
+  Directory root,
+  Set<String> reviewedRoots,
+  List<String> errors,
+) async {
+  final pubspec = loadYaml(
+    File(p.join(root.path, 'pubspec.yaml')).readAsStringSync(),
+  );
+  final flutter = pubspec is YamlMap ? pubspec['flutter'] : null;
+  final assets = flutter is YamlMap ? flutter['assets'] : null;
+  if (assets is! YamlList) {
+    errors.add('pubspec.yaml has no Flutter asset list.');
+    return;
+  }
+  for (final value in assets.whereType<String>()) {
+    if (!value.startsWith('assets/live2d/')) continue;
+    final covered = reviewedRoots.any((root) => value.startsWith(root));
+    if (!covered) {
+      errors.add('Unreviewed Live2D asset root in pubspec.yaml: $value');
+    }
+  }
+}
+
+void _verifyReleaseEvidence(Object? value, List<String> errors) {
+  final evidence = _map(value, 'releaseEvidence', errors);
+  if (evidence == null) return;
+  final decision = evidence['releaseLicenseDecision'];
+  if (decision != 'not_required' && decision != 'obtained') {
+    errors.add(
+      'Cubism SDK Release License decision is pending; release is blocked.',
+    );
+  } else if (evidence['releaseLicenseEvidence'] is! String) {
+    errors
+        .add('Cubism SDK Release License decision has no evidence reference.');
+  }
+
+  final validation = _map(
+    evidence['mobileValidation'],
+    'releaseEvidence.mobileValidation',
+    errors,
+  );
+  if (validation == null) return;
+  if (validation['minimumCharacterSwitches'] is! int ||
+      (validation['minimumCharacterSwitches'] as int) < 20) {
+    errors.add('Mobile validation must cover at least 20 character switches.');
+  }
+  for (final platform in ['android', 'ios']) {
+    final result = _map(validation[platform], '$platform validation', errors);
+    if (result == null) continue;
+    if (result['status'] != 'verified' || result['evidence'] is! String) {
+      errors.add('$platform physical-device validation is not verified.');
+    }
+  }
+}
+
+Future<Directory?> _resolvePackageRoot(
+  Directory root,
+  String packageName,
+  List<String> errors,
+) async {
+  final configFile = File(p.join(root.path, '.dart_tool/package_config.json'));
+  if (!configFile.existsSync()) {
+    errors.add('Run flutter pub get before the Live2D release gate.');
+    return null;
+  }
+  final config = jsonDecode(configFile.readAsStringSync());
+  final packages = config is Map<String, dynamic> ? config['packages'] : null;
+  if (packages is! List) {
+    errors.add('Invalid .dart_tool/package_config.json.');
+    return null;
+  }
+  for (final value in packages) {
+    if (value is Map && value['name'] == packageName) {
+      final rootUri = value['rootUri'];
+      if (rootUri is! String) break;
+      return Directory.fromUri(configFile.uri.resolve(rootUri));
+    }
+  }
+  errors.add('Unable to resolve package:$packageName.');
+  return null;
+}
+
+Future<Map<String, dynamic>?> _readJsonMap(
+  File file,
+  List<String> errors,
+) async {
+  try {
+    final value = jsonDecode(file.readAsStringSync());
+    if (value is Map<String, dynamic>) return value;
+    errors.add('Live2D release manifest must be a JSON object.');
+  } catch (error) {
+    errors.add('Unable to read Live2D release manifest: $error');
+  }
+  return null;
+}
+
+Map<String, dynamic>? _map(
+  Object? value,
+  String name,
+  List<String> errors,
+) {
+  if (value is Map<String, dynamic>) return value;
+  errors.add('$name must be an object.');
+  return null;
+}
+
+List<dynamic> _list(Object? value, String name, List<String> errors) {
+  if (value is List<dynamic>) return value;
+  errors.add('$name must be a list.');
+  return const [];
+}
+
+void _requireExistingFile(
+  Directory root,
+  Object? pathValue,
+  String description,
+  List<String> errors,
+) {
+  if (pathValue is! String ||
+      !File(p.join(root.path, pathValue)).existsSync()) {
+    errors.add('Missing $description: $pathValue');
+  }
+}
+
+String _withTrailingSlash(String value) =>
+    value.endsWith('/') ? value : '$value/';
+
+String _normalizeGitUrl(Object? value) {
+  if (value is! String) return '';
+  return value.endsWith('.git') ? value.substring(0, value.length - 4) : value;
+}
+
+Future<void> main(List<String> arguments) async {
+  final mode = arguments.contains('--development')
+      ? Live2DGateMode.development
+      : Live2DGateMode.release;
+  final report = await auditLive2DRelease(
+    repositoryRoot: Directory.current,
+    mode: mode,
+  );
+  if (report.passed) {
+    stdout.writeln(
+      'Live2D ${mode.name} gate passed '
+      '(${report.checkedArtifacts} artifacts checked).',
+    );
+    return;
+  }
+  stderr.writeln('Live2D ${mode.name} gate failed:');
+  for (final error in report.errors) {
+    stderr.writeln('- $error');
+  }
+  exitCode = 1;
+}


### PR DESCRIPTION
## 完成情况

### A05 移动端稳定性

- 串行化前后台暂停/恢复命令，覆盖平台视图尚未附着、快速状态切换、失败重试和销毁时的竞态。
- Android 首次原生命令前等待平台视图完成合成，修复已加载但画面空白的问题。
- 为控制器补充附着、加载、暂停和当前模型诊断状态。
- 新增端到端集成测试，覆盖透明合成、裁切/手势、前后台恢复、连续 20 次角色切换和 Live2D 视图销毁后的文本聊天回退。

### A06 SDK 与许可门禁

- 将 `flutter_live2d` 固定到不可变上游 commit `378b5b977df47672c78e12723f93854300a87e40`；pub.dev 1.0.2 缺少 Android Framework 的全部 36 个 shader。
- 对桥接层、Framework、Cubism Core 和 Hiyori 模型建立可追溯清单与 SHA-256 校验，共检查 61 个制品。
- 更新第三方声明和发布验证协议。
- 发布门禁在 Cubism Release License 结论、Android 真机证据或 iOS 真机证据缺失时明确失败，避免不合规资源进入发行包。

## Android E2E

使用正式 Git 固定依赖运行，不包含诊断桥接补丁：

- 初始模型和第 20 次切换后的模型均正常可见，透明合成正常。
- 前后台暂停/恢复、手势和 20 次模型切换通过。
- APK 包含 36 个 shader；日志无 shader 加载、`glUniform` 或相关 GL 错误。
- PSS 约从 311.7 MiB 到 320.3 MiB，增量约 8.6 MiB。

模拟器结果只作为功能回归证据；门禁仍要求发布前补充 Android/iOS 真机的性能、功耗和热状态报告。

## 验证

- `flutter test test/live2d_render_lifecycle_test.dart test/live2d_release_gate_test.dart`：8 项通过
- `flutter test`：350 项通过，2 项跳过
- 本次 6 个 Dart 变更文件静态分析：零问题
- 全仓分析：分支 1110 条存量 warning/info，少于当前主干的 1148 条，无新增静态分析问题
- `dart run tool/live2d_release_gate.dart --development`：通过，61 个制品
- 正式发布门禁：按预期因许可结论及两端真机证据待补而失败
- `git diff --check`：通过

Closes #20