### PR TITLE
fix(chat): prevent lifecycle crash on navigation

### DIFF
--- a/lib/presentation/screens/chat/chat_screen.dart
+++ b/lib/presentation/screens/chat/chat_screen.dart
@@ -93,6 +93,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
   final ImagePicker _imagePicker = ImagePicker();
   final ChatTTSAutoPlayController _ttsAutoPlayController =
       ChatTTSAutoPlayController();
+  late final TTSStopAction _stopTts;
   final Map<String, GlobalKey<_MessageBubbleState>> _messageKeys = {};
   bool _initialMessageJumpScheduled = false;
   String? _highlightedMessageId;
@@ -100,8 +101,10 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
   @override
   void initState() {
     super.initState();
+    _stopTts = ref.read(ttsStopProvider);
     // Load chat and bookmarks when screen opens
     WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
       ref.read(activeChatProvider.notifier).loadChat(widget.chatId);
       ref.read(bookmarkNotifierProvider.notifier).loadBookmarks(widget.chatId);
       ref.read(rpgChatProvider(widget.chatId).notifier).load();
@@ -208,7 +211,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
 
   @override
   void dispose() {
-    unawaited(ref.read(ttsStopProvider)(ownerId: widget.chatId));
+    unawaited(_stopTts(ownerId: widget.chatId));
     _messageController.removeListener(_onTextChanged);
     _messageController.dispose();
     _scrollController.dispose();
@@ -986,6 +989,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
   }
 
   void _handleChatTTSChange(ActiveChatState? previous, ActiveChatState next) {
+    if (!mounted) return;
     final action = _ttsAutoPlayController.evaluate(
       previous: previous,
       next: next,
@@ -1017,6 +1021,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
 
     // Scroll to bottom when new messages arrive or when chat finishes loading
     ref.listen(activeChatProvider, (previous, next) {
+      if (!mounted) return;
       // Scroll to bottom when:
       // 1. New messages are added during conversation
       // 2. Chat finishes loading (transitions from loading to loaded with messages)

--- a/test/chat_screen_lifecycle_test.dart
+++ b/test/chat_screen_lifecycle_test.dart
@@ -1,0 +1,108 @@
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:native_tavern/core/services/initialization_service.dart';
+import 'package:native_tavern/data/database/database.dart';
+import 'package:native_tavern/data/models/character.dart' as models;
+import 'package:native_tavern/data/repositories/character_repository.dart';
+import 'package:native_tavern/data/repositories/chat_repository.dart';
+import 'package:native_tavern/domain/services/llm_service.dart';
+import 'package:native_tavern/l10n/generated/app_localizations.dart';
+import 'package:native_tavern/presentation/providers/chat_providers.dart';
+import 'package:native_tavern/presentation/providers/settings_providers.dart';
+import 'package:native_tavern/presentation/providers/tts_providers.dart';
+import 'package:native_tavern/presentation/screens/chat/chat_screen.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late AppDatabase database;
+  late Directory dataDirectory;
+  late ProviderContainer container;
+  late String chatId;
+  String? stoppedOwnerId;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    final preferences = await SharedPreferences.getInstance();
+    database = AppDatabase.forTesting(NativeDatabase.memory());
+    dataDirectory = await Directory.systemTemp.createTemp(
+      'chat-screen-lifecycle-',
+    );
+    final characterRepository = CharacterRepository(
+      database,
+      dataDirectory.path,
+    );
+    final chatRepository = ChatRepository(database);
+    container = ProviderContainer(
+      overrides: [
+        databaseProvider.overrideWithValue(database),
+        dataPathProvider.overrideWithValue(dataDirectory.path),
+        characterRepositoryProvider.overrideWithValue(characterRepository),
+        chatRepositoryProvider.overrideWithValue(chatRepository),
+        sharedPreferencesProvider.overrideWithValue(preferences),
+        llmServiceProvider.overrideWithValue(LLMService()),
+        ttsStopProvider.overrideWithValue(({String? ownerId}) async {
+          stoppedOwnerId = ownerId;
+        }),
+      ],
+    );
+
+    final now = DateTime.utc(2026, 8, 8);
+    await characterRepository.createCharacter(
+      models.Character(
+        id: 'lifecycle-character',
+        name: 'Lifecycle Tester',
+        description: 'Exercises chat navigation disposal.',
+        createdAt: now,
+        modifiedAt: now,
+      ),
+    );
+    chatId = (await container
+        .read(activeChatProvider.notifier)
+        .createChat('lifecycle-character'))!;
+  });
+
+  tearDown(() async {
+    container.dispose();
+    await database.close();
+    await dataDirectory.delete(recursive: true);
+  });
+
+  testWidgets('leaving chat stops TTS without using a disposed ref', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          localizationsDelegates: const [
+            AppLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: ChatScreen(chatId: chatId),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(home: SizedBox.shrink()),
+      ),
+    );
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+    expect(stoppedOwnerId, chatId);
+  });
+}


### PR DESCRIPTION
Closes #58

## Summary
- cache the scoped TTS stop action while ChatScreen is mounted instead of reading Riverpod ref during disposal
- guard deferred first-frame loading and active-chat listeners after unmount
- add a real ChatScreen navigation lifecycle regression test

## Verification
- chat lifecycle regression test passed
- RPG editor, settings navigation, TTS autoplay, and TTS/Live2D end-to-end tests passed (11 tests)
- new regression test static analysis: 0 diagnostics
- full suite: 380 passed, 2 environment skips; one pre-existing failure because test/android_release_builder_test.dart imports the missing ignored file tool/build_android_release.dart