### PR TITLE
fix(rpg): isolate editor scroll state

### DIFF
--- a/lib/presentation/screens/rpg/rpg_scenario_editor_screen.dart
+++ b/lib/presentation/screens/rpg/rpg_scenario_editor_screen.dart
@@ -624,6 +624,7 @@ class _ScalarEditor extends StatefulWidget {
 class _ScalarEditorState extends State<_ScalarEditor> {
   late final TextEditingController _text;
   late final FocusNode _focus;
+  final ScrollController _scroll = ScrollController(keepScrollOffset: false);
   String? _localError;
 
   @override
@@ -644,6 +645,7 @@ class _ScalarEditorState extends State<_ScalarEditor> {
   void dispose() {
     _text.dispose();
     _focus.dispose();
+    _scroll.dispose();
     super.dispose();
   }
 
@@ -685,6 +687,7 @@ class _ScalarEditorState extends State<_ScalarEditor> {
         key: Key('rpg-field-${widget.path.key}'),
         controller: _text,
         focusNode: _focus,
+        scrollController: _scroll,
         maxLines: _isLongText(widget.path) ? 3 : 1,
         keyboardType: widget.value is num
             ? const TextInputType.numberWithOptions(

--- a/test/rpg_scenario_editor_screen_test.dart
+++ b/test/rpg_scenario_editor_screen_test.dart
@@ -28,6 +28,44 @@ void main() {
     });
   }
 
+  testWidgets('top-level scalar sections expand without PageStorage errors', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(1280, 900);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      const MaterialApp(home: RpgScenarioEditorScreen()),
+    );
+    await tester.pumpAndSettle();
+
+    const sections = {
+      'Compatibility': 'rpg-field-/compatibility/minimumEngineVersion',
+      'Initial State': 'rpg-field-/initialState/scenarioId',
+    };
+    final editorScroll = find
+        .descendant(
+          of: find.byKey(const PageStorageKey('rpg-document-editor')),
+          matching: find.byType(Scrollable),
+        )
+        .first;
+    for (final entry in sections.entries) {
+      final header = find.text(entry.key);
+      await tester.scrollUntilVisible(
+        header,
+        300,
+        scrollable: editorScroll,
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(header);
+      await tester.pumpAndSettle();
+      expect(tester.takeException(), isNull);
+      expect(find.byKey(Key(entry.value)), findsOneWidget);
+    }
+  });
+
   testWidgets('imports, edits, drafts, previews, exports, and reimports',
       (tester) async {
     tester.view.physicalSize = const Size(1200, 1000);


### PR DESCRIPTION
Closes #58

## Summary
- give every scalar RPG editor TextField an independent ScrollController with PageStorage persistence disabled
- prevent ExpansionTile bool state from being restored as a TextField double scroll offset
- cover Compatibility and Initial State expansion with a regression test matching the macOS failure

## Verification
- RPG editor, chat lifecycle, and settings navigation tests: 9 passed
- focused static analysis: 0 diagnostics
- reproduced the original bool/double failure before applying the fix