### PR TITLE
feat: add Imagine entry and AI-filled image prompts

### DIFF
--- a/lib/domain/services/image_prompt_composer.dart
+++ b/lib/domain/services/image_prompt_composer.dart
@@ -1,0 +1,62 @@
+/// Builds a short image-generation prompt from a chat scene.
+class ImagePromptComposer {
+  static const _maxFallbackLength = 400;
+
+  const ImagePromptComposer();
+
+  String fallbackPrompt({
+    required String sceneText,
+    String? characterName,
+  }) {
+    final cleaned = _cleanScene(sceneText);
+    final subject = characterName?.trim();
+    if (cleaned.isEmpty) {
+      return subject == null || subject.isEmpty
+          ? ''
+          : 'portrait of $subject, detailed, cinematic lighting';
+    }
+    if (subject == null || subject.isEmpty) return cleaned;
+    return '$subject, $cleaned';
+  }
+
+  List<Map<String, dynamic>> composeMessages({
+    required String sceneText,
+    String? characterName,
+  }) {
+    final scene = _cleanScene(sceneText);
+    final subject = characterName?.trim();
+    final subjectLine = subject == null || subject.isEmpty
+        ? 'No named subject.'
+        : 'Subject: $subject';
+    return [
+      {
+        'role': 'system',
+        'content':
+            'Write one concise image-generation prompt. Output only the prompt. '
+            'No quotes, no explanation, no markdown.',
+      },
+      {
+        'role': 'user',
+        'content':
+            '$subjectLine\nScene:\n${scene.isEmpty ? '(empty)' : scene}',
+      },
+    ];
+  }
+
+  String normalizeModelOutput(String raw) {
+    var text = raw.trim();
+    if (text.startsWith('```')) {
+      text = text.replaceFirst(RegExp(r'^```[a-zA-Z]*\n?'), '');
+      text = text.replaceFirst(RegExp(r'\n?```$'), '');
+    }
+    return text.replaceAll('"', '').trim();
+  }
+
+  String _cleanScene(String sceneText) {
+    var text = sceneText.trim();
+    text = text.replaceAll(RegExp(r'<[^>]+>'), ' ');
+    text = text.replaceAll(RegExp(r'\s+'), ' ').trim();
+    if (text.length <= _maxFallbackLength) return text;
+    return text.substring(0, _maxFallbackLength).trim();
+  }
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2532,6 +2532,14 @@
   "@aboutImageGenerationDescription": {
     "description": "About image generation description"
   },
+  "imagine": "Imagine",
+  "@imagine": {
+    "description": "Chat input action that opens image generation"
+  },
+  "fillImagePromptWithAi": "Fill with AI",
+  "@fillImagePromptWithAi": {
+    "description": "Ask the chat model to write an image prompt"
+  },
   "imagineCommand": "/imagine Command",
   "@imagineCommand": {
     "description": "Imagine command label"

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1831,5 +1831,7 @@
   "useLocalAiOnly": "仅使用本地 AI",
   "aiDataSharingSettingsTitle": "远程 AI 数据共享",
   "aiDataSharingAllowedDescription": "已允许向你配置的服务商和端点发送数据",
-  "aiDataSharingLocalOnlyDescription": "已阻止；本地 AI 端点仍可使用"
+  "aiDataSharingLocalOnlyDescription": "已阻止；本地 AI 端点仍可使用",
+  "imagine": "生图",
+  "fillImagePromptWithAi": "AI 填写提示词"
 }

--- a/lib/l10n/app_zh_TW.arb
+++ b/lib/l10n/app_zh_TW.arb
@@ -1831,5 +1831,7 @@
   "useLocalAiOnly": "僅使用本機 AI",
   "aiDataSharingSettingsTitle": "遠端 AI 資料共享",
   "aiDataSharingAllowedDescription": "已允許向你設定的服務商和端點傳送資料",
-  "aiDataSharingLocalOnlyDescription": "已封鎖；本機 AI 端點仍可使用"
+  "aiDataSharingLocalOnlyDescription": "已封鎖；本機 AI 端點仍可使用",
+  "imagine": "生圖",
+  "fillImagePromptWithAi": "AI 填寫提示詞"
 }

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -3373,6 +3373,18 @@ abstract class AppLocalizations {
   /// **'Generate images using AI models. Use the /imagine command in chat or generate character portraits from the character editor.'**
   String get aboutImageGenerationDescription;
 
+  /// Chat input action that opens image generation
+  ///
+  /// In en, this message translates to:
+  /// **'Imagine'**
+  String get imagine;
+
+  /// Ask the chat model to write an image prompt
+  ///
+  /// In en, this message translates to:
+  /// **'Fill with AI'**
+  String get fillImagePromptWithAi;
+
   /// Imagine command label
   ///
   /// In en, this message translates to:

--- a/lib/l10n/generated/app_localizations_ar.dart
+++ b/lib/l10n/generated/app_localizations_ar.dart
@@ -1785,6 +1785,12 @@ class AppLocalizationsAr extends AppLocalizations {
       'Generate images using AI models. Use the /imagine command in chat or generate character portraits from the character editor.';
 
   @override
+  String get imagine => 'Imagine';
+
+  @override
+  String get fillImagePromptWithAi => 'Fill with AI';
+
+  @override
   String get imagineCommand => '/imagine Command';
 
   @override

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -1790,6 +1790,12 @@ class AppLocalizationsDe extends AppLocalizations {
       'Generate images using AI models. Use the /imagine command in chat or generate character portraits from the character editor.';
 
   @override
+  String get imagine => 'Imagine';
+
+  @override
+  String get fillImagePromptWithAi => 'Fill with AI';
+
+  @override
   String get imagineCommand => '/imagine Command';
 
   @override

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -1790,6 +1790,12 @@ class AppLocalizationsEn extends AppLocalizations {
       'Generate images using AI models. Use the /imagine command in chat or generate character portraits from the character editor.';
 
   @override
+  String get imagine => 'Imagine';
+
+  @override
+  String get fillImagePromptWithAi => 'Fill with AI';
+
+  @override
   String get imagineCommand => '/imagine Command';
 
   @override

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -1791,6 +1791,12 @@ class AppLocalizationsEs extends AppLocalizations {
       'Generate images using AI models. Use the /imagine command in chat or generate character portraits from the character editor.';
 
   @override
+  String get imagine => 'Imagine';
+
+  @override
+  String get fillImagePromptWithAi => 'Fill with AI';
+
+  @override
   String get imagineCommand => '/imagine Command';
 
   @override

--- a/lib/l10n/generated/app_localizations_fr.dart
+++ b/lib/l10n/generated/app_localizations_fr.dart
@@ -1793,6 +1793,12 @@ class AppLocalizationsFr extends AppLocalizations {
       'Generate images using AI models. Use the /imagine command in chat or generate character portraits from the character editor.';
 
   @override
+  String get imagine => 'Imagine';
+
+  @override
+  String get fillImagePromptWithAi => 'Fill with AI';
+
+  @override
   String get imagineCommand => '/imagine Command';
 
   @override

--- a/lib/l10n/generated/app_localizations_hi.dart
+++ b/lib/l10n/generated/app_localizations_hi.dart
@@ -1788,6 +1788,12 @@ class AppLocalizationsHi extends AppLocalizations {
       'Generate images using AI models. Use the /imagine command in chat or generate character portraits from the character editor.';
 
   @override
+  String get imagine => 'Imagine';
+
+  @override
+  String get fillImagePromptWithAi => 'Fill with AI';
+
+  @override
   String get imagineCommand => '/imagine Command';
 
   @override

--- a/lib/l10n/generated/app_localizations_id.dart
+++ b/lib/l10n/generated/app_localizations_id.dart
@@ -1790,6 +1790,12 @@ class AppLocalizationsId extends AppLocalizations {
       'Generate images using AI models. Use the /imagine command in chat or generate character portraits from the character editor.';
 
   @override
+  String get imagine => 'Imagine';
+
+  @override
+  String get fillImagePromptWithAi => 'Fill with AI';
+
+  @override
   String get imagineCommand => '/imagine Command';
 
   @override

--- a/lib/l10n/generated/app_localizations_it.dart
+++ b/lib/l10n/generated/app_localizations_it.dart
@@ -1790,6 +1790,12 @@ class AppLocalizationsIt extends AppLocalizations {
       'Generate images using AI models. Use the /imagine command in chat or generate character portraits from the character editor.';
 
   @override
+  String get imagine => 'Imagine';
+
+  @override
+  String get fillImagePromptWithAi => 'Fill with AI';
+
+  @override
   String get imagineCommand => '/imagine Command';
 
   @override

--- a/lib/l10n/generated/app_localizations_ja.dart
+++ b/lib/l10n/generated/app_localizations_ja.dart
@@ -1779,6 +1779,12 @@ class AppLocalizationsJa extends AppLocalizations {
       'Generate images using AI models. Use the /imagine command in chat or generate character portraits from the character editor.';
 
   @override
+  String get imagine => 'Imagine';
+
+  @override
+  String get fillImagePromptWithAi => 'Fill with AI';
+
+  @override
   String get imagineCommand => '/imagine Command';
 
   @override

--- a/lib/l10n/generated/app_localizations_ko.dart
+++ b/lib/l10n/generated/app_localizations_ko.dart
@@ -1777,6 +1777,12 @@ class AppLocalizationsKo extends AppLocalizations {
       'Generate images using AI models. Use the /imagine command in chat or generate character portraits from the character editor.';
 
   @override
+  String get imagine => 'Imagine';
+
+  @override
+  String get fillImagePromptWithAi => 'Fill with AI';
+
+  @override
   String get imagineCommand => '/imagine Command';
 
   @override

--- a/lib/l10n/generated/app_localizations_ms.dart
+++ b/lib/l10n/generated/app_localizations_ms.dart
@@ -1789,6 +1789,12 @@ class AppLocalizationsMs extends AppLocalizations {
       'Generate images using AI models. Use the /imagine command in chat or generate character portraits from the character editor.';
 
   @override
+  String get imagine => 'Imagine';
+
+  @override
+  String get fillImagePromptWithAi => 'Fill with AI';
+
+  @override
   String get imagineCommand => '/imagine Command';
 
   @override

--- a/lib/l10n/generated/app_localizations_nl.dart
+++ b/lib/l10n/generated/app_localizations_nl.dart
@@ -1790,6 +1790,12 @@ class AppLocalizationsNl extends AppLocalizations {
       'Generate images using AI models. Use the /imagine command in chat or generate character portraits from the character editor.';
 
   @override
+  String get imagine => 'Imagine';
+
+  @override
+  String get fillImagePromptWithAi => 'Fill with AI';
+
+  @override
   String get imagineCommand => '/imagine Command';
 
   @override

--- a/lib/l10n/generated/app_localizations_pl.dart
+++ b/lib/l10n/generated/app_localizations_pl.dart
@@ -1789,6 +1789,12 @@ class AppLocalizationsPl extends AppLocalizations {
       'Generate images using AI models. Use the /imagine command in chat or generate character portraits from the character editor.';
 
   @override
+  String get imagine => 'Imagine';
+
+  @override
+  String get fillImagePromptWithAi => 'Fill with AI';
+
+  @override
   String get imagineCommand => '/imagine Command';
 
   @override

--- a/lib/l10n/generated/app_localizations_pt.dart
+++ b/lib/l10n/generated/app_localizations_pt.dart
@@ -1790,6 +1790,12 @@ class AppLocalizationsPt extends AppLocalizations {
       'Generate images using AI models. Use the /imagine command in chat or generate character portraits from the character editor.';
 
   @override
+  String get imagine => 'Imagine';
+
+  @override
+  String get fillImagePromptWithAi => 'Fill with AI';
+
+  @override
   String get imagineCommand => '/imagine Command';
 
   @override

--- a/lib/l10n/generated/app_localizations_ru.dart
+++ b/lib/l10n/generated/app_localizations_ru.dart
@@ -1789,6 +1789,12 @@ class AppLocalizationsRu extends AppLocalizations {
       'Generate images using AI models. Use the /imagine command in chat or generate character portraits from the character editor.';
 
   @override
+  String get imagine => 'Imagine';
+
+  @override
+  String get fillImagePromptWithAi => 'Fill with AI';
+
+  @override
   String get imagineCommand => '/imagine Command';
 
   @override

--- a/lib/l10n/generated/app_localizations_th.dart
+++ b/lib/l10n/generated/app_localizations_th.dart
@@ -1786,6 +1786,12 @@ class AppLocalizationsTh extends AppLocalizations {
       'Generate images using AI models. Use the /imagine command in chat or generate character portraits from the character editor.';
 
   @override
+  String get imagine => 'Imagine';
+
+  @override
+  String get fillImagePromptWithAi => 'Fill with AI';
+
+  @override
   String get imagineCommand => '/imagine Command';
 
   @override

--- a/lib/l10n/generated/app_localizations_tr.dart
+++ b/lib/l10n/generated/app_localizations_tr.dart
@@ -1789,6 +1789,12 @@ class AppLocalizationsTr extends AppLocalizations {
       'Generate images using AI models. Use the /imagine command in chat or generate character portraits from the character editor.';
 
   @override
+  String get imagine => 'Imagine';
+
+  @override
+  String get fillImagePromptWithAi => 'Fill with AI';
+
+  @override
   String get imagineCommand => '/imagine Command';
 
   @override

--- a/lib/l10n/generated/app_localizations_vi.dart
+++ b/lib/l10n/generated/app_localizations_vi.dart
@@ -1788,6 +1788,12 @@ class AppLocalizationsVi extends AppLocalizations {
       'Generate images using AI models. Use the /imagine command in chat or generate character portraits from the character editor.';
 
   @override
+  String get imagine => 'Imagine';
+
+  @override
+  String get fillImagePromptWithAi => 'Fill with AI';
+
+  @override
   String get imagineCommand => '/imagine Command';
 
   @override

--- a/lib/l10n/generated/app_localizations_zh.dart
+++ b/lib/l10n/generated/app_localizations_zh.dart
@@ -1753,6 +1753,12 @@ class AppLocalizationsZh extends AppLocalizations {
       '使用 AI 模型生成图片。可在聊天中使用 /imagine 命令，或在角色编辑器中生成角色肖像。';
 
   @override
+  String get imagine => '生图';
+
+  @override
+  String get fillImagePromptWithAi => 'AI 填写提示词';
+
+  @override
   String get imagineCommand => '/imagine 命令';
 
   @override
@@ -7786,6 +7792,12 @@ class AppLocalizationsZhTw extends AppLocalizationsZh {
   @override
   String get aboutImageGenerationDescription =>
       '使用 AI 模型產生圖片。可在聊天中使用 /imagine 命令，或在角色編輯器中產生角色肖像。';
+
+  @override
+  String get imagine => '生圖';
+
+  @override
+  String get fillImagePromptWithAi => 'AI 填寫提示詞';
 
   @override
   String get imagineCommand => '/imagine 命令';

--- a/lib/presentation/screens/chat/chat_screen.dart
+++ b/lib/presentation/screens/chat/chat_screen.dart
@@ -1951,6 +1951,42 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     );
   }
 
+  Future<void> _openImagineFromInput(ActiveChatState chatState) async {
+    final typed = _messageController.text.trim();
+    final lastAssistant = chatState.messages.reversed
+        .cast<ChatMessage?>()
+        .firstWhere(
+          (message) => message?.role == MessageRole.assistant,
+          orElse: () => null,
+        );
+    final result = await ImageGenerationDialog.show(
+      context,
+      basePrompt: typed.isNotEmpty ? typed : (lastAssistant?.content ?? ''),
+      characterName: chatState.character?.name,
+      mode: ImageGenMode.free,
+      autoCompose: typed.isEmpty,
+    );
+    if (result != null && result.images.isNotEmpty && mounted) {
+      await _attachGeneratedImagesToNewMessage(result);
+    }
+  }
+
+  Future<void> _attachGeneratedImagesToNewMessage(ImageGenResult result) async {
+    final l10n = AppLocalizations.of(context);
+    try {
+      final attachments = await _saveGeneratedImages(result);
+      await ref.read(activeChatProvider.notifier).addLocalMessage(
+            role: MessageRole.user,
+            content: result.prompt,
+            attachments: attachments,
+          );
+      _showSnackBar('${l10n.generationComplete} (${attachments.length})');
+      _scrollToBottom();
+    } catch (error) {
+      _showCommandError(l10n.failedToSaveImage('$error'));
+    }
+  }
+
   void _showImageGenerationDialog(
     ChatMessage message,
     Character? character,
@@ -1962,6 +1998,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
       mode: message.role == MessageRole.assistant
           ? ImageGenMode.lastMessage
           : ImageGenMode.free,
+      autoCompose: message.role == MessageRole.assistant,
     );
 
     if (result != null && result.images.isNotEmpty && mounted) {
@@ -2288,6 +2325,18 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
                 onTap: () => _showFormattingMenu(),
               ),
               const SizedBox(width: 8),
+              if (ref.watch(imageGenSettingsProvider).enabled)
+                _InputMenuButton(
+                  key: const Key('chat-input-imagine'),
+                  icon: Icons.auto_awesome,
+                  label: AppLocalizations.of(context).imagine,
+                  onTap: () {
+                    _setInputMenuVisible(false);
+                    _openImagineFromInput(chatState);
+                  },
+                ),
+              if (ref.watch(imageGenSettingsProvider).enabled)
+                const SizedBox(width: 8),
               // Context usage indicator
               Expanded(
                 child: Container(
@@ -3853,6 +3902,7 @@ class _InputMenuButton extends StatelessWidget {
   final VoidCallback onTap;
 
   const _InputMenuButton({
+    super.key,
     required this.icon,
     required this.label,
     required this.onTap,

--- a/lib/presentation/widgets/chat/image_generation_dialog.dart
+++ b/lib/presentation/widgets/chat/image_generation_dialog.dart
@@ -2,8 +2,10 @@ import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:native_tavern/domain/services/image_generation_service.dart';
+import 'package:native_tavern/domain/services/image_prompt_composer.dart';
 import 'package:native_tavern/l10n/generated/app_localizations.dart';
 import 'package:native_tavern/presentation/providers/image_gen_providers.dart';
+import 'package:native_tavern/presentation/providers/settings_providers.dart';
 import 'package:native_tavern/presentation/theme/app_theme.dart';
 
 /// Dialog for generating images from message content
@@ -17,11 +19,15 @@ class ImageGenerationDialog extends ConsumerStatefulWidget {
   /// The generation mode
   final ImageGenMode mode;
 
+  /// When true, ask the chat model to fill the prompt after the dialog opens.
+  final bool autoCompose;
+
   const ImageGenerationDialog({
     super.key,
     required this.basePrompt,
     this.characterName,
     this.mode = ImageGenMode.free,
+    this.autoCompose = false,
   });
 
   @override
@@ -33,6 +39,7 @@ class ImageGenerationDialog extends ConsumerStatefulWidget {
     required String basePrompt,
     String? characterName,
     ImageGenMode mode = ImageGenMode.free,
+    bool autoCompose = false,
   }) {
     return showDialog<ImageGenResult>(
       context: context,
@@ -41,6 +48,7 @@ class ImageGenerationDialog extends ConsumerStatefulWidget {
         basePrompt: basePrompt,
         characterName: characterName,
         mode: mode,
+        autoCompose: autoCompose,
       ),
     );
   }
@@ -50,9 +58,11 @@ class _ImageGenerationDialogState extends ConsumerState<ImageGenerationDialog> {
   late TextEditingController _promptController;
   late TextEditingController _negativePromptController;
   bool _isGenerating = false;
+  bool _isComposingPrompt = false;
   double _progress = 0.0;
   String? _error;
   Uint8List? _generatedImage;
+  final _composer = const ImagePromptComposer();
 
   @override
   void initState() {
@@ -61,6 +71,11 @@ class _ImageGenerationDialogState extends ConsumerState<ImageGenerationDialog> {
     _negativePromptController = TextEditingController(
       text: ref.read(imageGenSettingsProvider).defaultNegativePrompt ?? '',
     );
+    if (widget.autoCompose) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) _fillPromptWithAi();
+      });
+    }
   }
 
   @override
@@ -155,12 +170,31 @@ class _ImageGenerationDialogState extends ConsumerState<ImageGenerationDialog> {
               const SizedBox(height: 16),
 
               // Prompt
-              Text(
-                l10n.prompt,
-                style: const TextStyle(
-                  color: AppTheme.textSecondary,
-                  fontWeight: FontWeight.bold,
-                ),
+              Row(
+                children: [
+                  Text(
+                    l10n.prompt,
+                    style: const TextStyle(
+                      color: AppTheme.textSecondary,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  const Spacer(),
+                  TextButton.icon(
+                    key: const Key('image-gen-fill-prompt'),
+                    onPressed: _isGenerating || _isComposingPrompt
+                        ? null
+                        : _fillPromptWithAi,
+                    icon: _isComposingPrompt
+                        ? const SizedBox(
+                            width: 14,
+                            height: 14,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Icon(Icons.auto_fix_high, size: 16),
+                    label: Text(l10n.fillImagePromptWithAi),
+                  ),
+                ],
               ),
               const SizedBox(height: 8),
               TextField(
@@ -177,7 +211,7 @@ class _ImageGenerationDialogState extends ConsumerState<ImageGenerationDialog> {
                     borderSide: BorderSide.none,
                   ),
                 ),
-                enabled: !_isGenerating,
+                enabled: !_isGenerating && !_isComposingPrompt,
               ),
               const SizedBox(height: 16),
 
@@ -312,6 +346,52 @@ class _ImageGenerationDialogState extends ConsumerState<ImageGenerationDialog> {
           ),
       ],
     );
+  }
+
+  Future<void> _fillPromptWithAi() async {
+    final l10n = AppLocalizations.of(context);
+    final config = ref.read(llmConfigProvider);
+    if (config.apiKey.isEmpty && config.apiUrl.isEmpty) {
+      setState(() => _error = l10n.configureNow);
+      return;
+    }
+
+    setState(() {
+      _isComposingPrompt = true;
+      _error = null;
+    });
+
+    try {
+      final sceneText = widget.basePrompt.trim().isEmpty
+          ? _promptController.text
+          : widget.basePrompt;
+      final generated = await ref.read(llmServiceProvider).generate(
+            _composer.composeMessages(
+              sceneText: sceneText,
+              characterName: widget.characterName,
+            ),
+            config,
+          );
+      final prompt = _composer.normalizeModelOutput(generated);
+      if (!mounted) return;
+      _promptController.text = prompt.isEmpty
+          ? _composer.fallbackPrompt(
+              sceneText: sceneText,
+              characterName: widget.characterName,
+            )
+          : prompt;
+    } catch (error) {
+      if (!mounted) return;
+      _promptController.text = _composer.fallbackPrompt(
+        sceneText: widget.basePrompt,
+        characterName: widget.characterName,
+      );
+      setState(() => _error = error.toString());
+    } finally {
+      if (mounted) {
+        setState(() => _isComposingPrompt = false);
+      }
+    }
   }
 
   Future<void> _generate() async {

--- a/test/image_prompt_composer_test.dart
+++ b/test/image_prompt_composer_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:native_tavern/domain/services/image_prompt_composer.dart';
+import 'package:native_tavern/domain/services/image_generation_service.dart';
+import 'package:native_tavern/domain/services/slash_command_service.dart';
+
+void main() {
+  const composer = ImagePromptComposer();
+
+  test('fallback prompt keeps the character and cleaned scene', () {
+    expect(
+      composer.fallbackPrompt(
+        sceneText: '<p>She  opens the lantern.</p>',
+        characterName: 'Mira',
+      ),
+      'Mira, She opens the lantern.',
+    );
+  });
+
+  test('compose messages ask the model for a single prompt', () {
+    final messages = composer.composeMessages(
+      sceneText: 'A rainy harbor at dusk',
+      characterName: 'Mira',
+    );
+
+    expect(messages, hasLength(2));
+    expect(messages.first['role'], 'system');
+    expect(messages.first['content'], contains('Output only the prompt'));
+    expect(messages.last['content'], contains('Subject: Mira'));
+    expect(messages.last['content'], contains('A rainy harbor at dusk'));
+  });
+
+  test('normalizeModelOutput strips fences and quotes', () {
+    expect(
+      composer.normalizeModelOutput('```text\n"cinematic portrait of Mira"\n```'),
+      'cinematic portrait of Mira',
+    );
+  });
+
+  test('/imagine still parses prompt options for the existing chat handler', () {
+    final parsed = SlashCommandService().parse(
+      '/imagine rainy harbor --width 768 --height 1024',
+    );
+    expect(parsed.command, SlashCommands.imagine);
+    expect(parsed.argument, 'rainy harbor --width 768 --height 1024');
+
+    final request = ImageGenerationService().parseImagineCommand(
+      '/imagine rainy harbor --width 768 --height 1024',
+    );
+    expect(request, isNotNull);
+    expect(request!.prompt, 'rainy harbor');
+    expect(request.width, 768);
+    expect(request.height, 1024);
+  });
+}

--- a/test/recent_feature_localization_test.dart
+++ b/test/recent_feature_localization_test.dart
@@ -34,6 +34,8 @@ void main() {
     expect(l10n.storyEmptyHint, '聊一段时间才会有故事。');
     expect(l10n.storyGoToChat, '去聊天');
     expect(l10n.storyJotNote, '记一笔');
+    expect(l10n.imagine, '生图');
+    expect(l10n.fillImagePromptWithAi, 'AI 填写提示词');
     expect(l10n.moments, '动态');
     expect(l10n.openDataBank, '打开资料');
     expect(l10n.dataBank, '资料库');


### PR DESCRIPTION
Closes #62

## Summary
- `/imagine` already parsed and executed in chat; this keeps that path
- Chat input menu now has an Imagine button when image generation is enabled
- Image dialog can ask the chat model to fill a prompt from the current scene
- Opening Imagine from an assistant message or empty input auto-composes

## Verification
- `flutter test test/image_prompt_composer_test.dart test/slash_command_service_test.dart test/recent_feature_localization_test.dart`